### PR TITLE
v2.8: Severity calibration, coverage check, verify-before-claim, precise/exhaustive mode

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -24,7 +24,7 @@ description: >
   launching reviewers.
 ---
 
-# Agent Review Panel v2.7
+# Agent Review Panel v2.8
 
 A multi-agent adversarial review system based on nine research foundations:
 ChatEval (ICLR 2024), AutoGen, Du et al. (ICML 2024), MachineSoM (ACL 2024),
@@ -84,6 +84,7 @@ Phase 3: Debate             → Reviewers engage with each other + find new issu
 Phase 3.5: Summarize        → Distill resolved/unresolved points between rounds
 Phase 4: Blind Final        → Each reviewer gives final score independently
 Phase 4.5: Completeness Audit → Dedicated agent scans for what the panel missed
+Phase 4.55: Verify Commands  → Run up to 5 reviewer verification commands (advisory)
 Phase 4.6: Claim Verification → Verify all line-number citations against source
 Phase 4.7: Severity Verification → Read actual code for every P0/P1, downgrade if overstated
 Phase 5: Supreme Judge      → Opus arbitrates everything including verification results
@@ -104,6 +105,20 @@ Collect full content, then run Context Gathering (below).
 - **Pure plan/design** — architecture docs, proposals, RFCs
 - **Mixed** — plans with code snippets, SQL, or config
 - **Documentation** — READMEs, guides, API docs
+
+### Review Mode Detection (v2.8)
+
+Auto-detect review mode from content type. No user toggle.
+
+| Content Type | Review Mode | Behavior |
+|---|---|---|
+| Pure code | **Precise** | Every finding MUST cite a specific file, line number, or code snippet. Findings without concrete evidence are demoted to [UNVERIFIED]. |
+| Pure plan/design | **Exhaustive** | Broader risk identification allowed. Findings may reference design sections or architectural patterns without line-number evidence. |
+| Mixed | **Precise** for code, **Exhaustive** for prose | Reviewers label each finding with its mode. Code findings without line citations are demoted. |
+| Documentation | **Exhaustive** | Same as plan/design. |
+
+The detected mode is injected into Phase 2 reviewer prompts and the judge prompt.
+Report header states the detected mode.
 
 ### Detect Content Signals
 
@@ -280,6 +295,29 @@ See `references/prompt-templates.md` for full prompt.
 
 ---
 
+## Phase 4.55: Verification Command Execution (v2.8)
+
+Collect all `verification_command` entries from Phase 2 reviewer outputs for
+P0/P1 findings. Select up to 5 commands, prioritized by: P0 before P1, then
+by number of reviewers citing the same finding.
+
+**For each command:**
+1. Validate it is read-only (grep, cat, head, tail, wc — reject write/install/network commands)
+2. Execute via Bash tool
+3. Record: command, exit code, first 50 lines of output, match against reviewer's expectation
+
+**Annotate results:**
+- `[CMD_CONFIRMED]` — output matches expectation
+- `[CMD_CONTRADICTED]` — output contradicts claim (demote finding by 1 severity level)
+- `[CMD_INCONCLUSIVE]` — command ran but output is ambiguous
+- `[CMD_FAILED]` — command errored (file not found, etc.)
+
+**Advisory, not gating:** Failed verification demotes severity and annotates
+the finding — it does NOT delete findings. The judge sees both the original
+severity and the verification result.
+
+---
+
 ## Phase 4.6: Claim Verification
 
 Single agent (`model: "opus"`) checks all reviewer citations against source.
@@ -331,7 +369,9 @@ verification table when ruling on disagreements.
 ## Phase 5: Supreme Judge
 
 Single agent (`model: "opus"`). Receives everything. Steps:
-0. Review claim verification AND severity verification — disregard overstated findings
+0. Review claim verification, severity verification, AND verification command results
+0.5c. Severity dampening — "What is the MINIMUM severity justified by concrete evidence?" In Precise mode, findings without code citations cannot exceed P2.
+0.5d. Coverage check — flag unexamined risk categories, scan source for gaps
 1. Verify audit findings, anti-rhetoric assessment
 2. Evaluate debate quality, rule on disagreements
 3. Check consensus correctness, absent-safeguard check
@@ -356,6 +396,7 @@ Write structured markdown report to `review_panel_report.md` (or user-specified 
 **Panel:** {N} reviewers + Auditor + Judge
 **Verdict:** {recommendation}  |  **Confidence:** {High|Medium|Low}
 **Auto-detected signals:** {list or "None — base set used"}
+**Review mode:** {Precise|Exhaustive|Mixed} (auto-detected from content type)
 
 ## Executive Summary
 {Judge's verdict, 3-5 sentences. Score X/10.}
@@ -377,6 +418,8 @@ Defect type labels: [EXISTING_DEFECT] (bug in current code) [PLAN_RISK] (risk if
 {Each disagreement: Side A, Side B, Judge's ruling with reasoning}
 ## Completeness Audit Findings
 {New issues found by auditor, verified by judge}
+## Coverage Gaps (if any)
+{Risk categories no reviewer examined, with judge's independent assessment}
 ## Action Items (with severity AND epistemic labels)
 
 ## Detailed Reviews (collapsible sections)
@@ -385,6 +428,7 @@ Defect type labels: [EXISTING_DEFECT] (bug in current code) [PLAN_RISK] (risk if
 - Debate Rounds + Summaries
 - Final Blind Assessments
 - Completeness Audit
+- Verification Command Execution Results
 - Claim Verification Report
 - Severity Verification Table
 - Supreme Judge Full Analysis
@@ -398,7 +442,8 @@ disagreements count, audit findings count, top action item.
 ## Implementation Notes
 
 - **Parallel execution:** Phases 2, 2.5, 3, 4 use single message with multiple
-  Agent tool calls. Phases 4.5, 4.6, 5 are sequential single agents.
+  Agent tool calls. Phases 4.5, 4.55, 4.6, 4.7, 5 are sequential (4.55 is
+  orchestrator-driven via Bash, not a subagent).
 - **Context management:** Full content in Phases 2, 4.5, 5. Phase 3.5 summaries
   with source excerpts in debate rounds for long works (>500 lines).
 - **Error handling:** Retry failed agents once. Proceed with minimum 2 reviewers.

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v2.8 (2026-03-26) — Severity Calibration, Coverage Check, Verify-Before-Claim, Precise/Exhaustive Mode
+
+Motivated by panel review of 6 proposed changes (see `docs/archive/review_panel_report.md`).
+Critical panel finding: all original proposals pushed findings downward with zero upward pressure.
+
+- **Severity-dampening judge prompt** — Judge Step 0.5c: "What is the MINIMUM severity justified by concrete evidence?" Prompt edit, zero latency. (Datadog FP filtering)
+- **Coverage check** (NEW — surfaced by panel) — Judge Step 0.5d: "Are there unexamined risk categories?" Flags [COVERAGE_GAP] areas. Counterbalances downward pressure.
+- **Verify-before-claim (advisory mode)** — Phase 2 reviewers include `verification_command` for P0/P1. New Phase 4.55 runs up to 5 commands, annotates [CMD_CONFIRMED]/[CMD_CONTRADICTED]/[CMD_INCONCLUSIVE]/[CMD_FAILED]. Advisory, not gating. (Tool-MAD, CodeRabbit, Nexus)
+- **Auto-detected Precise/Exhaustive mode** — Code → Precise (require line citations). Plans → Exhaustive (allow broader risk). Auto-detected, no toggle. Report header shows mode. (Qodo 2.0)
+
+New research foundations: Tool-MAD (Jan 2026), Nexus (Oct 2025), CORE (Microsoft FSE 2024), SGCR (ASE 2025), Qodo 2.0.
+
+---
+
 ## v2.7 (2026-03-26) — Severity Verification & Defect Classification
 
 Motivated by S57 benchmark: 2/3 P0 findings were overstated after code investigation.

--- a/references/prompt-templates.md
+++ b/references/prompt-templates.md
@@ -27,6 +27,22 @@ Your reasoning strategy is: {reasoning_strategy_description}
 Apply this strategy throughout your review — it shapes HOW you evaluate,
 not just what you look for.
 
+## Review Mode: {Precise|Exhaustive|Mixed}
+
+{If Precise:}
+PRECISE mode. Every finding MUST include a specific file path and line number,
+OR a quoted code snippet. Findings lacking concrete code evidence will be
+labeled [UNVERIFIED] and carry reduced weight in the judge's assessment.
+
+{If Exhaustive:}
+EXHAUSTIVE mode. You may identify broader risks, architectural concerns, and
+missing considerations without line-number evidence. When concrete evidence IS
+available, always cite it. Label each finding [CODE_GROUNDED] or [RISK_IDENTIFIED].
+
+{If Mixed:}
+MIXED mode. For code sections, apply Precise rules (require line citations).
+For design/prose, apply Exhaustive rules. Label each finding [PRECISE] or [EXHAUSTIVE].
+
 ## Your Task
 
 Review the following work carefully through your specific lens.
@@ -81,6 +97,17 @@ For each suggestion that recommends a code change or new safeguard:
 
 #### Key Concern
 The single most important thing the author should address.
+
+#### Verification Commands (P0/P1 findings only)
+For each finding you rated P0 or P1, provide a shell command that would verify
+your claim against the actual codebase. Use ONLY: grep -rn, cat, head, tail,
+wc -l. No write operations, no installs, no network commands.
+
+Format:
+- [Finding]: `grep -rn "pattern" path/to/file` — Expected: {what output should show if claim is correct}
+
+If you cannot construct a verification command, state why — this itself is a
+signal about the finding's specificity.
 ```
 
 ## Phase 2.5: Private Reflection Prompt
@@ -220,11 +247,23 @@ For each claim:
 You are the Supreme Judge. You receive:
 1. Original work  2. Independent reviews  3. Debate transcript
 4. Blind finals  5. Completeness audit  6. Claim verification report
+7. Verification command execution results
+
+## Review Mode: {Precise|Exhaustive|Mixed}
 
 ## Steps (in order):
-0. Review Claim Verification — disregard [INACCURATE]/[HALLUCINATED] claims
+0. Review Claim Verification, Severity Verification, AND Verification Command
+   Results — disregard [INACCURATE]/[HALLUCINATED] claims. For [CMD_CONTRADICTED]
+   findings, use demoted severity unless you find independent reason to restore.
 0.5a. Verify Audit Findings against source
 0.5b. Anti-Rhetoric Assessment — flag position changes lacking source citations
+0.5c. Severity Dampening — For every P0/P1: "What is the MINIMUM severity
+      justified by concrete, verified evidence?" Findings without specific code
+      location or reproducible scenario cannot exceed P2. In Precise mode,
+      findings lacking line citations cannot exceed P2.
+0.5d. Coverage Check — "Are there unexamined risk categories (security, error
+      handling, race conditions, API contracts, data integrity) given these
+      changes?" Flag [COVERAGE_GAP] areas. Scan source independently for gaps.
 1. Evaluate Debate Quality — engagement, strength, missing perspectives
 2. Rule on Each Disagreement — state, summarize sides, rule with reasoning
 3. Identify Consensus Points — check if unanimous agreement is correct

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -24,7 +24,7 @@ description: >
   launching reviewers.
 ---
 
-# Agent Review Panel v2.7
+# Agent Review Panel v2.8
 
 A multi-agent adversarial review system based on nine research foundations:
 ChatEval (ICLR 2024), AutoGen, Du et al. (ICML 2024), MachineSoM (ACL 2024),
@@ -84,6 +84,7 @@ Phase 3: Debate             → Reviewers engage with each other + find new issu
 Phase 3.5: Summarize        → Distill resolved/unresolved points between rounds
 Phase 4: Blind Final        → Each reviewer gives final score independently
 Phase 4.5: Completeness Audit → Dedicated agent scans for what the panel missed
+Phase 4.55: Verify Commands  → Run up to 5 reviewer verification commands (advisory)
 Phase 4.6: Claim Verification → Verify all line-number citations against source
 Phase 4.7: Severity Verification → Read actual code for every P0/P1, downgrade if overstated
 Phase 5: Supreme Judge      → Opus arbitrates everything including verification results
@@ -104,6 +105,20 @@ Collect full content, then run Context Gathering (below).
 - **Pure plan/design** — architecture docs, proposals, RFCs
 - **Mixed** — plans with code snippets, SQL, or config
 - **Documentation** — READMEs, guides, API docs
+
+### Review Mode Detection (v2.8)
+
+Auto-detect review mode from content type. No user toggle.
+
+| Content Type | Review Mode | Behavior |
+|---|---|---|
+| Pure code | **Precise** | Every finding MUST cite a specific file, line number, or code snippet. Findings without concrete evidence are demoted to [UNVERIFIED]. |
+| Pure plan/design | **Exhaustive** | Broader risk identification allowed. Findings may reference design sections or architectural patterns without line-number evidence. |
+| Mixed | **Precise** for code, **Exhaustive** for prose | Reviewers label each finding with its mode. Code findings without line citations are demoted. |
+| Documentation | **Exhaustive** | Same as plan/design. |
+
+The detected mode is injected into Phase 2 reviewer prompts and the judge prompt.
+Report header states the detected mode.
 
 ### Detect Content Signals
 
@@ -280,6 +295,29 @@ See `references/prompt-templates.md` for full prompt.
 
 ---
 
+## Phase 4.55: Verification Command Execution (v2.8)
+
+Collect all `verification_command` entries from Phase 2 reviewer outputs for
+P0/P1 findings. Select up to 5 commands, prioritized by: P0 before P1, then
+by number of reviewers citing the same finding.
+
+**For each command:**
+1. Validate it is read-only (grep, cat, head, tail, wc — reject write/install/network commands)
+2. Execute via Bash tool
+3. Record: command, exit code, first 50 lines of output, match against reviewer's expectation
+
+**Annotate results:**
+- `[CMD_CONFIRMED]` — output matches expectation
+- `[CMD_CONTRADICTED]` — output contradicts claim (demote finding by 1 severity level)
+- `[CMD_INCONCLUSIVE]` — command ran but output is ambiguous
+- `[CMD_FAILED]` — command errored (file not found, etc.)
+
+**Advisory, not gating:** Failed verification demotes severity and annotates
+the finding — it does NOT delete findings. The judge sees both the original
+severity and the verification result.
+
+---
+
 ## Phase 4.6: Claim Verification
 
 Single agent (`model: "opus"`) checks all reviewer citations against source.
@@ -331,7 +369,9 @@ verification table when ruling on disagreements.
 ## Phase 5: Supreme Judge
 
 Single agent (`model: "opus"`). Receives everything. Steps:
-0. Review claim verification AND severity verification — disregard overstated findings
+0. Review claim verification, severity verification, AND verification command results
+0.5c. Severity dampening — "What is the MINIMUM severity justified by concrete evidence?" In Precise mode, findings without code citations cannot exceed P2.
+0.5d. Coverage check — flag unexamined risk categories, scan source for gaps
 1. Verify audit findings, anti-rhetoric assessment
 2. Evaluate debate quality, rule on disagreements
 3. Check consensus correctness, absent-safeguard check
@@ -356,6 +396,7 @@ Write structured markdown report to `review_panel_report.md` (or user-specified 
 **Panel:** {N} reviewers + Auditor + Judge
 **Verdict:** {recommendation}  |  **Confidence:** {High|Medium|Low}
 **Auto-detected signals:** {list or "None — base set used"}
+**Review mode:** {Precise|Exhaustive|Mixed} (auto-detected from content type)
 
 ## Executive Summary
 {Judge's verdict, 3-5 sentences. Score X/10.}
@@ -377,6 +418,8 @@ Defect type labels: [EXISTING_DEFECT] (bug in current code) [PLAN_RISK] (risk if
 {Each disagreement: Side A, Side B, Judge's ruling with reasoning}
 ## Completeness Audit Findings
 {New issues found by auditor, verified by judge}
+## Coverage Gaps (if any)
+{Risk categories no reviewer examined, with judge's independent assessment}
 ## Action Items (with severity AND epistemic labels)
 
 ## Detailed Reviews (collapsible sections)
@@ -385,6 +428,7 @@ Defect type labels: [EXISTING_DEFECT] (bug in current code) [PLAN_RISK] (risk if
 - Debate Rounds + Summaries
 - Final Blind Assessments
 - Completeness Audit
+- Verification Command Execution Results
 - Claim Verification Report
 - Severity Verification Table
 - Supreme Judge Full Analysis
@@ -398,7 +442,8 @@ disagreements count, audit findings count, top action item.
 ## Implementation Notes
 
 - **Parallel execution:** Phases 2, 2.5, 3, 4 use single message with multiple
-  Agent tool calls. Phases 4.5, 4.6, 5 are sequential single agents.
+  Agent tool calls. Phases 4.5, 4.55, 4.6, 4.7, 5 are sequential (4.55 is
+  orchestrator-driven via Bash, not a subagent).
 - **Context management:** Full content in Phases 2, 4.5, 5. Phase 3.5 summaries
   with source excerpts in debate rounds for long works (>500 lines).
 - **Error handling:** Retry failed agents once. Proceed with minimum 2 reviewers.


### PR DESCRIPTION
## Summary
- **Severity-dampening judge prompt** — reframes severity assessment from "what severity?" to "minimum severity justified by concrete evidence"
- **Coverage check** (NEW, panel-surfaced) — judge flags unexamined risk categories to counterbalance the downward pressure of all severity-reduction mechanisms
- **Verify-before-claim (advisory mode)** — reviewers provide verification commands for P0/P1; orchestrator runs up to 5 read-only commands and annotates results. Failed verification demotes, does not delete
- **Auto-detected Precise/Exhaustive mode** — code reviews require line citations (Precise), plan reviews allow broader risk identification (Exhaustive). Auto-detected from input type

Research: Tool-MAD (2026), Nexus (2025), CORE (FSE 2024), SGCR (ASE 2025), Qodo 2.0.
Panel-reviewed: 6 proposed → 3 shipped + 1 new (coverage check). 3 deferred to v2.9.

## Test plan
- [ ] Run panel on a code file — verify Precise mode auto-detected, verification commands generated
- [ ] Run panel on a plan document — verify Exhaustive mode auto-detected
- [ ] Check severity dampening reduces P0 overstatement vs v2.7 baseline
- [ ] Verify coverage check flags at least one [COVERAGE_GAP] area
- [ ] Confirm Phase 4.55 commands are read-only validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)