### PR TITLE
Restore lost prescriptive constraints from v2.6 schliff pass

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -164,10 +164,14 @@ the #1 cause of incorrect [CRITICAL] recommendations.**
    - `project_*.md`, `MEMORY.md`, `lessons.md` (project + global)
    - Skills (`~/.claude/skills/*/SKILL.md`) — extract relevant caveats
    - `CLAUDE.md` — conventions and constraints
+   - Deduplication: if the same insight appears in multiple sources, include only
+     the most specific version (project > global > skill).
 
 5. **Web Research** (deep research mode only) — Triggers when user requests
    "deep review" or 5+ keywords from a signal group with no built-in checklist.
-   Cap at 2 web searches. Tag findings with [WEB].
+   Cap at 2 web searches. Tag findings with [WEB]. If the built-in domain
+   checklist already covers the signal group, web research is skipped unless
+   explicitly requested.
 
 6. **Context Brief** — Compile into structured brief with sections: System
    Documentation Found, Referenced Files, Safety Mechanisms, Knowledge Mining
@@ -256,7 +260,8 @@ Launch all reviewers **in parallel** each round. Each receives their own review
 After each round, summarize (no agent needed):
 - **Resolved this round** — who agreed, what convinced them
 - **Still in dispute** — with inlined source excerpts (max 10 lines per dispute,
-  max 3 disputes). Tag `[source not cited]` for vague claims.
+  first 5 + last 5 if longer; max 3 disputes). If a reviewer's claim cannot be
+  traced to a specific source location, tag `[source not cited by reviewer]`.
 - **New discoveries** — from which reviewer
 
 ### Sycophancy Detection (CONSENSAGENT)

--- a/references/prompt-templates.md
+++ b/references/prompt-templates.md
@@ -108,6 +108,11 @@ Format:
 
 If you cannot construct a verification command, state why — this itself is a
 signal about the finding's specificity.
+
+Be specific. Reference exact lines, sections, or components. Vague feedback
+like "could be better" is not useful. If you find no issues in an area, say so
+explicitly rather than manufacturing criticism. If the line-by-line audit found
+nothing, state: "Line-by-line audit: no issues found."
 ```
 
 ## Phase 2.5: Private Reflection Prompt
@@ -129,6 +134,9 @@ Also note:
 - Any NEW issues you notice on this second reading
 - Which findings you would MOST defend if challenged
 - Which findings you are LEAST certain about
+
+This reflection is private — no one else will see it directly. Be honest
+about your uncertainty.
 ```
 
 ## Phase 3: Debate Round Prompt
@@ -160,6 +168,10 @@ Your agreement intensity is {X}%.
 Do NOT simply restate your original position. Engage with at least 2
 specific points from other reviewers. Changing your mind when presented
 with strong evidence is rigor, not weakness.
+
+Remember: your agreement intensity is {X}%. You don't disagree reflexively,
+but you hold a high evidence bar. If you genuinely cannot find a new
+discovery after careful re-reading, state that explicitly.
 ```
 
 ## Phase 4: Blind Final Assessment Prompt
@@ -213,6 +225,9 @@ Re-read source line by line. For every code snippet, constant, set, SQL query:
 **New Findings:** [only what NO reviewer mentioned]
 **Verification of Panel Claims:** [incorrect or hallucinated claims]
 **Coverage Assessment:** [% of code scrutinized, unattended areas]
+
+Report ONLY findings that NO reviewer mentioned. If the panel was thorough
+and you find nothing new, say so — do not manufacture issues.
 ```
 
 ## Phase 4.6: Claim Verification Prompt
@@ -230,15 +245,27 @@ the source material are factually accurate.
 - Cited location: {line/section/function}
 - What reviewer claims: {the claim}
 
-## Classification
+## Verification Procedure
 For each claim:
+1. Go to the cited location in the source material
+2. Read what is ACTUALLY there
+3. Compare the reviewer's claim to what you found
+4. Classify:
+
 - **[VERIFIED]** — Source confirms. Quote evidence.
 - **[INACCURATE]** — Exists but mischaracterized. State actual vs claimed.
 - **[MISATTRIBUTED]** — May be true, wrong location. Find correct location.
 - **[HALLUCINATED]** — Location doesn't exist or unrelated.
 - **[UNVERIFIABLE]** — Not specific enough to check.
 
-## Output: Verification table + summary + flagged claims for judge
+## Output Format
+
+| Reviewer | Claim | Location | Verdict | Evidence |
+|----------|-------|----------|---------|----------|
+
+**Summary:** Total claims checked: N. Verified: X%. Inaccurate: Y%. Hallucinated: Z%.
+
+**Flagged for Judge:** [list only [INACCURATE], [MISATTRIBUTED], and [HALLUCINATED] claims]
 ```
 
 ## Phase 5: Supreme Judge Prompt
@@ -252,27 +279,69 @@ You are the Supreme Judge. You receive:
 ## Review Mode: {Precise|Exhaustive|Mixed}
 
 ## Steps (in order):
-0. Review Claim Verification, Severity Verification, AND Verification Command
-   Results — disregard [INACCURATE]/[HALLUCINATED] claims. For [CMD_CONTRADICTED]
-   findings, use demoted severity unless you find independent reason to restore.
-0.5a. Verify Audit Findings against source
-0.5b. Anti-Rhetoric Assessment — flag position changes lacking source citations
-0.5c. Severity Dampening — For every P0/P1: "What is the MINIMUM severity
-      justified by concrete, verified evidence?" Findings without specific code
-      location or reproducible scenario cannot exceed P2. In Precise mode,
-      findings lacking line citations cannot exceed P2.
-0.5d. Coverage Check — "Are there unexamined risk categories (security, error
-      handling, race conditions, API contracts, data integrity) given these
-      changes?" Flag [COVERAGE_GAP] areas. Scan source independently for gaps.
-1. Evaluate Debate Quality — engagement, strength, missing perspectives
-2. Rule on Each Disagreement — state, summarize sides, rule with reasoning
-3. Identify Consensus Points — check if unanimous agreement is correct
-4. Absent-Safeguard Check — do [CRITICAL] recs assume absent safety mechanisms?
-5. Independent Gap Check — your own scan for missed issues
-6. Score Assessment — independent 1-10 score
-7. Classify All Findings — [VERIFIED]/[CONSENSUS]/[SINGLE-SOURCE]/[UNVERIFIED]/[DISPUTED]
-8. Final Verdict — recommendation, confidence, strengths, critical issues, action items
-9. Meta-observation — what this process revealed
+0. **Review Verification Results** — Review Claim Verification, Severity
+   Verification, AND Verification Command Results. Disregard [INACCURATE]/
+   [HALLUCINATED] claims. For [CMD_CONTRADICTED] findings, use demoted severity
+   unless you find independent reason to restore. Note which reviewer made false
+   claims — patterns of inaccuracy from one reviewer may indicate that reviewer's
+   other uncited claims are also suspect. If a finding was [MISATTRIBUTED] (real
+   issue, wrong location), credit the finding but note the citation error.
+
+0.5a. **Verify Audit Findings** against source material directly.
+
+0.5b. **Anti-Rhetoric Assessment** — Flag position changes that lack source
+   citations. Weight arguments backed by line citations and source excerpts MORE
+   heavily than eloquent but citation-free argumentation. Note: an argument can
+   be both eloquent AND correct — the goal is to catch cases where rhetoric
+   SUBSTITUTED for evidence, not where it accompanied evidence.
+
+0.5c. **Severity Dampening** — For every P0/P1: "What is the MINIMUM severity
+   justified by concrete, verified evidence?" Findings without specific code
+   location or reproducible scenario cannot exceed P2. **In Precise mode,
+   findings lacking line citations cannot exceed P2.**
+
+0.5d. **Coverage Check** — "Are there unexamined risk categories (security, error
+   handling, race conditions, API contracts, data integrity) given these
+   changes?" Flag [COVERAGE_GAP] areas. Scan source independently for gaps.
+
+1. **Evaluate Debate Quality** — Did reviewers genuinely engage, or just restate
+   positions? Who made the strongest arguments? What perspectives were missing?
+
+2. **Rule on Each Disagreement** — State the disagreement, summarize each side,
+   rule with reasoning, note your confidence level.
+
+3. **Identify Consensus Points** — Check if unanimous agreement is actually
+   correct. Sometimes a panel can be unanimously wrong.
+
+4. **Absent-Safeguard Check** — Do [CRITICAL] recommendations assume the ABSENCE
+   of a safety mechanism? Did ANY reviewer verify that the assumed-absent
+   safeguard doesn't exist? Check the Context Brief — does it list a safety
+   mechanism that already handles the concern? If so, downgrade or dismiss the
+   recommendation. If a reviewer flagged "Unverified assumption," treat the
+   recommendation as unconfirmed until verified against the source material.
+
+5. **Independent Gap Check** — Your own scan for missed issues. You are not
+   constrained to topics others discussed.
+
+6. **Score Assessment** — Independent 1-10 score.
+
+7. **Classify All Findings** with epistemic labels:
+   - **[VERIFIED]**: Confirmed by claim verification AND at least 2 reviewers
+   - **[CONSENSUS]**: 3+ reviewers agree, not independently verified
+   - **[SINGLE-SOURCE]**: Only one reviewer raised it, unverified
+   - **[UNVERIFIED]**: Cited but not confirmed against source
+   - **[DISPUTED]**: Reviewers explicitly disagreed, unresolved
+
+8. **Final Verdict** — Recommendation, strengths, critical issues, action items.
+   **Verdict Confidence:** High = clear evidence, panel mostly agrees. Medium =
+   some ambiguity or split panel. Low = insufficient evidence, novel domain, or
+   fundamental disagreements the panel couldn't resolve.
+
+9. **Meta-observation** — What did this review process itself reveal about the
+   work or about the panel's blind spots?
+
+Be thorough, be fair, and be specific. Your verdict is the one the human will
+read first.
 ```
 
 ## Sycophancy Alert Injection (when triggered)

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -164,10 +164,14 @@ the #1 cause of incorrect [CRITICAL] recommendations.**
    - `project_*.md`, `MEMORY.md`, `lessons.md` (project + global)
    - Skills (`~/.claude/skills/*/SKILL.md`) — extract relevant caveats
    - `CLAUDE.md` — conventions and constraints
+   - Deduplication: if the same insight appears in multiple sources, include only
+     the most specific version (project > global > skill).
 
 5. **Web Research** (deep research mode only) — Triggers when user requests
    "deep review" or 5+ keywords from a signal group with no built-in checklist.
-   Cap at 2 web searches. Tag findings with [WEB].
+   Cap at 2 web searches. Tag findings with [WEB]. If the built-in domain
+   checklist already covers the signal group, web research is skipped unless
+   explicitly requested.
 
 6. **Context Brief** — Compile into structured brief with sections: System
    Documentation Found, Referenced Files, Safety Mechanisms, Knowledge Mining
@@ -256,7 +260,8 @@ Launch all reviewers **in parallel** each round. Each receives their own review
 After each round, summarize (no agent needed):
 - **Resolved this round** — who agreed, what convinced them
 - **Still in dispute** — with inlined source excerpts (max 10 lines per dispute,
-  max 3 disputes). Tag `[source not cited]` for vague claims.
+  first 5 + last 5 if longer; max 3 disputes). If a reviewer's claim cannot be
+  traced to a specific source location, tag `[source not cited by reviewer]`.
 - **New discoveries** — from which reviewer
 
 ### Sycophancy Detection (CONSENSAGENT)


### PR DESCRIPTION
## Summary
- Panel review of commit 5e48d3b (v2.6 schliff optimization, -1183 lines) found critical behavioral instructions were lost — especially the judge prompt which was compressed from ~150 detailed lines to a ~20-line skeleton
- Restores 106 lines of prescriptive constraints across SKILL.md and prompt-templates.md without reverting the efficiency gains from reference file extraction
- Both reviewers independently flagged the judge prompt as the #1 casualty

## Key restorations

**Judge prompt (biggest impact):**
- Anti-rhetoric assessment: "catch rhetoric that SUBSTITUTED for evidence, not where it ACCOMPANIED evidence"
- Absent-safeguard check: full procedure for checking Context Brief, handling "Unverified assumption" flags
- Epistemic label definitions: criteria for [VERIFIED], [CONSENSUS], [SINGLE-SOURCE], [UNVERIFIED], [DISPUTED]
- Verdict confidence calibration: High/Medium/Low with specific criteria
- Reviewer credibility tracking: "patterns of inaccuracy from one reviewer may indicate other claims suspect"

**Other prompts:**
- Reviewer: "be specific, don't manufacture criticism" + audit fallback
- Reflection: "be honest about your uncertainty"
- Debate: agreement intensity reminder + new discovery fallback
- Auditor: "do not manufacture issues"
- Claim verification: 4-step procedure + output table format

**SKILL.md:**
- Knowledge mining deduplication rule
- Web research skip rule
- Snippet truncation strategy
- `[source not cited by reviewer]` tagging

## Test plan
- [ ] Run a review panel on a test document and verify judge output includes epistemic labels, confidence calibration, and anti-rhetoric assessment
- [ ] Verify claim verification output includes the table format with summary stats
- [ ] Check that auditor does not manufacture issues on a clean document

🤖 Generated with [Claude Code](https://claude.com/claude-code)