### PR TITLE
feat: VoltAgent integration (v2.9) — 127+ specialist agent mapping

### DIFF
--- a/HOW_WE_BUILT_THIS.md
+++ b/HOW_WE_BUILT_THIS.md
@@ -476,16 +476,53 @@ Both fixed in follow-up commit. Estimated schliff score: 84 → 90.
 
 ---
 
+## Step 15: VoltAgent Specialist Agent Integration (v2.9, 2026-03-29)
+
+### Motivation
+
+During a test plan review for a causal impact analysis webapp, we bypassed the full review panel ceremony and instead launched 4 VoltAgent specialist agents directly (`voltagent-qa-sec:qa-expert`, `voltagent-data-ai:data-scientist`, `voltagent-infra:devops-engineer`, `voltagent-qa-sec:code-reviewer`). The result was striking: 38 findings with <10% cross-reviewer overlap. Each specialist caught blind spots the others missed — QA found error path gaps, DataSci found statistical fixture contamination, DevOps found hardcoded paths and state isolation issues, and the code reviewer challenged scope achievability.
+
+The VoltAgent agents have built-in domain expertise via their system prompts, making them genuinely stronger reviewers than generic agents prompted as "you are the Security Auditor." The question was: could we integrate this into the review panel skill while keeping it portable?
+
+### Implementation
+
+Added a "VoltAgent Integration (v2.9)" section to SKILL.md with:
+
+1. **Availability check** — scan system-reminder for `voltagent-*` agents during Phase 1
+2. **3-tier mapping tables:**
+   - Core persona mapping (16 rows) — every built-in persona → VoltAgent primary + alt
+   - Signal-detected specialist mapping (35 rows) — content signals → language/domain agents
+   - Orchestration mapping (4 rows) — completeness audit, claim/severity verification
+3. **Smart installation prompts** — suggest only relevant families, once per session, non-blocking
+4. **Graceful fallback** — everything works without VoltAgent; it's a transparent upgrade
+
+Full catalog sourced from [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) (127+ agents across 10 families).
+
+### Key Design Decisions
+
+- **Devil's Advocate stays generic** — the contrarian role benefits from having no domain bias
+- **Supreme Judge stays generic** — must be domain-neutral to arbitrate
+- **Persona prompts still included** — VoltAgent agents get the review-specific context (agreement intensity, reasoning strategy, evaluation criteria) that their built-in system prompts don't cover
+- **Installation suggestion is non-blocking** — "Continue without them? They're optional"
+
+### Lessons
+
+24. **Domain-specific system prompts beat persona prompts for specialist reviews.** A `voltagent-qa-sec:code-reviewer` has built-in code review heuristics that a generic agent prompted as "Correctness Hawk" cannot match. The difference is most visible in edge case detection and error path coverage.
+
+25. **VoltAgent integration must be a transparent upgrade, not a requirement.** The skill has users who don't have VoltAgent installed. Making it required would break portability. The graceful-fallback + smart-suggestion pattern preserves the skill's universality while rewarding users who have specialist agents available.
+
+---
+
 ## File Inventory
 
 ```
-├── SKILL.md                           # The skill itself (v2.7, ~340 lines)
+├── SKILL.md                           # The skill itself (v2.9, ~460 lines)
 ├── skills/agent-review-panel/
 │   └── SKILL.md                       # Plugin copy (synced with root)
 ├── references/
 │   ├── signals-and-checklists.md      # 9 signal groups + domain checklists
 │   ├── prompt-templates.md            # All phase prompt templates
-│   ├── changelog.md                   # Version history (v2–v2.8 plan)
+│   ├── changelog.md                   # Version history (v2–v2.9)
 │   └── research-v28.md               # 19-source v2.8 research compilation
 ├── docs/
 │   ├── demo-flow.png                  # Architecture diagram (referenced by README)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ v2.8 adds 4 new mechanisms + tiered knowledge mining:
 v2.9 adds VoltAgent specialist agent integration:
 - **VoltAgent integration** — when [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) are installed, the panel upgrades generic persona-prompted reviewers to domain-specific agents (127+ available across 10 families). A `voltagent-qa-sec:code-reviewer` has deeper built-in code review heuristics than a generic agent prompted as "Correctness Hawk."
 - **3-tier mapping** — core personas (16), signal-detected specialists (35 content signals), and orchestration phases (completeness audit, verification) all map to VoltAgent agents with graceful fallback.
-- **Smart installation prompts** — when VoltAgent agents would help but aren't installed, suggests the relevant `claude install-skill` commands (only once per session, non-blocking).
+- **Smart installation prompts** — when VoltAgent agents would help but aren't installed, suggests the relevant `claude plugin install` commands (only once per session, non-blocking).
 - **Devil's Advocate stays generic** — the contrarian role intentionally avoids domain specialization to maintain unbiased skepticism.
 - Born from real production use: a 4-VoltAgent-specialist panel (QA Expert, Data Scientist, DevOps Engineer, Code Reviewer) reviewing a test plan produced 38 findings with <10% cross-reviewer overlap — each specialist caught blind spots the others missed.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ v2.8 adds 4 new mechanisms + tiered knowledge mining:
 - **Lost constraint restoration** — panel self-review of the v2.6 schliff pass caught 15+ prescriptive constraints lost during optimization. Judge prompt restored from skeleton (~20 lines) to full behavioral detail (~80 lines) including anti-rhetoric nuance, absent-safeguard procedures, epistemic label definitions, and verdict confidence calibration.
 - See `references/research-v28.md` for the 19-source research backing and `docs/archive/review_panel_report.md` for the full panel deliberation.
 
+v2.9 adds VoltAgent specialist agent integration:
+- **VoltAgent integration** — when [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) are installed, the panel upgrades generic persona-prompted reviewers to domain-specific agents (127+ available across 10 families). A `voltagent-qa-sec:code-reviewer` has deeper built-in code review heuristics than a generic agent prompted as "Correctness Hawk."
+- **3-tier mapping** — core personas (16), signal-detected specialists (35 content signals), and orchestration phases (completeness audit, verification) all map to VoltAgent agents with graceful fallback.
+- **Smart installation prompts** — when VoltAgent agents would help but aren't installed, suggests the relevant `claude install-skill` commands (only once per session, non-blocking).
+- **Devil's Advocate stays generic** — the contrarian role intentionally avoids domain specialization to maintain unbiased skepticism.
+- Born from real production use: a 4-VoltAgent-specialist panel (QA Expert, Data Scientist, DevOps Engineer, Code Reviewer) reviewing a test plan produced 38 findings with <10% cross-reviewer overlap — each specialist caught blind spots the others missed.
+
 ### 3. Anti-Groupthink Mechanisms
 
 Research shows multi-agent systems are prone to conformity — agents abandon correct findings under social pressure. We counter this with:
@@ -189,6 +196,7 @@ The skill auto-detects content type (pure code, pure plan, mixed, documentation)
 | [CONSENSAGENT](https://aclanthology.org/2025.findings-acl.1141/) (ACL 2025) | Dynamic sycophancy intervention |
 | [Trust or Escalate](https://arxiv.org/abs/2407.18370) (ICLR 2025) | Judge confidence gating |
 | [AI Trust Evaluation Framework](https://github.com/wan-huiyan/ai-trust-evaluation) | Claim verification, epistemic labels, scope disclosure, correlated-bias detection |
+| [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | 127+ specialist agents across 10 families; persona-to-agent mapping for domain-specific reviews |
 
 See `ROADMAP.md` for the full research roadmap (includes trust & verification items, merged from former TRUST_ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,6 +244,7 @@ Techniques evaluated and rejected for our use case.
 | LLM-Judge-Trajectories | — | Trajectory scoring (deferred) |
 | Multi-Agent-Review-Bench | — | Benchmark suite for review panels |
 | AgentReview | — | Survey of agent-based review systems |
+| [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | 127+ agents | Specialist agent catalog for persona-to-agent mapping (v2.9) |
 
 ---
 
@@ -260,7 +261,8 @@ Techniques evaluated and rejected for our use case.
 | v2.5 | 2026-03-20 | Trust & verification layer (claim verification, epistemic labels) |
 | v2.6 | 2026-03-25 | Schliff optimisation (75→86), reference extraction, A/B validated |
 | v2.7 | 2026-03-26 | Severity verification, temporal scope, defect classification |
-| v2.8 | planned | Panel-reviewed: severity dampening, coverage check, verify-before-claim, auto mode |
+| v2.8 | 2026-03-26 | Panel-reviewed: severity dampening, coverage check, verify-before-claim, auto mode |
+| v2.9 | 2026-03-29 | VoltAgent specialist agent integration (127+ agents, 10 families) |
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -346,13 +346,13 @@ installation to the user:
 > "This review would benefit from VoltAgent specialist agents for deeper
 > domain-specific analysis. You can install the relevant families with:
 >
-> `claude install-skill voltagent-qa-sec`  — security, code review, testing, compliance
-> `claude install-skill voltagent-data-ai` — data science, ML, databases, NLP
-> `claude install-skill voltagent-infra`   — DevOps, cloud, Docker, Kubernetes, Terraform
-> `claude install-skill voltagent-lang`    — language-specific reviewers (TS, Python, Go, Rust, etc.)
-> `claude install-skill voltagent-core-dev` — API design, microservices, frontend, backend
-> `claude install-skill voltagent-biz`     — product, business analysis, risk management
-> `claude install-skill voltagent-domains` — fintech, blockchain, IoT, embedded systems
+> `claude plugin install voltagent-qa-sec`  — security, code review, testing, compliance
+> `claude plugin install voltagent-data-ai` — data science, ML, databases, NLP
+> `claude plugin install voltagent-infra`   — DevOps, cloud, Docker, Kubernetes, Terraform
+> `claude plugin install voltagent-lang`    — language-specific reviewers (TS, Python, Go, Rust, etc.)
+> `claude plugin install voltagent-core-dev` — API design, microservices, frontend, backend
+> `claude plugin install voltagent-biz`     — product, business analysis, risk management
+> `claude plugin install voltagent-domains` — fintech, blockchain, IoT, embedded systems
 >
 > Continue without them? They're optional — the review will still work
 > with generic persona-prompted agents."

--- a/SKILL.md
+++ b/SKILL.md
@@ -346,13 +346,16 @@ installation to the user:
 > "This review would benefit from VoltAgent specialist agents for deeper
 > domain-specific analysis. You can install the relevant families with:
 >
-> `claude plugin install voltagent-qa-sec`  — security, code review, testing, compliance
-> `claude plugin install voltagent-data-ai` — data science, ML, databases, NLP
-> `claude plugin install voltagent-infra`   — DevOps, cloud, Docker, Kubernetes, Terraform
-> `claude plugin install voltagent-lang`    — language-specific reviewers (TS, Python, Go, Rust, etc.)
-> `claude plugin install voltagent-core-dev` — API design, microservices, frontend, backend
-> `claude plugin install voltagent-biz`     — product, business analysis, risk management
-> `claude plugin install voltagent-domains` — fintech, blockchain, IoT, embedded systems
+> ```
+> /plugin marketplace add VoltAgent/awesome-claude-code-subagents
+> /plugin install voltagent-qa-sec@voltagent-subagents
+> /plugin install voltagent-data-ai@voltagent-subagents
+> /plugin install voltagent-infra@voltagent-subagents
+> /plugin install voltagent-lang@voltagent-subagents
+> /plugin install voltagent-core-dev@voltagent-subagents
+> /plugin install voltagent-biz@voltagent-subagents
+> /plugin install voltagent-domains@voltagent-subagents
+> ```
 >
 > Continue without them? They're optional — the review will still work
 > with generic persona-prompted agents."

--- a/SKILL.md
+++ b/SKILL.md
@@ -346,16 +346,17 @@ installation to the user:
 > "This review would benefit from VoltAgent specialist agents for deeper
 > domain-specific analysis. You can install the relevant families with:
 >
-> ```
-> /plugin marketplace add VoltAgent/awesome-claude-code-subagents
-> /plugin install voltagent-qa-sec@voltagent-subagents
-> /plugin install voltagent-data-ai@voltagent-subagents
-> /plugin install voltagent-infra@voltagent-subagents
-> /plugin install voltagent-lang@voltagent-subagents
-> /plugin install voltagent-core-dev@voltagent-subagents
-> /plugin install voltagent-biz@voltagent-subagents
-> /plugin install voltagent-domains@voltagent-subagents
-> ```
+> **Quick install (CLI):**
+> `claude plugin install voltagent-qa-sec`  — security, code review, testing
+> `claude plugin install voltagent-data-ai` — data science, ML, databases
+> `claude plugin install voltagent-infra`   — DevOps, cloud, Terraform
+> `claude plugin install voltagent-lang`    — language specialists (TS, Python, Go, Rust)
+> `claude plugin install voltagent-biz`     — product, business analysis
+> `claude plugin install voltagent-domains` — fintech, blockchain, IoT
+>
+> **Or browse via marketplace:**
+> `/plugin marketplace add VoltAgent/awesome-claude-code-subagents`
+> then `/plugin install <name>@voltagent-subagents`
 >
 > Continue without them? They're optional — the review will still work
 > with generic persona-prompted agents."

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,6 +60,10 @@ requires bash for context gathering (grep, file reads). All agents use
 `model: "opus"`. Knowledge mining reads from memory paths if they exist; if
 not available, it degrades gracefully — no hard dependency.
 
+**Optional enhancement:** When VoltAgent specialist agents are installed, the
+panel can use them instead of generic persona-prompted agents for stronger
+domain-specific reviews. See "VoltAgent Integration" section below.
+
 This skill is scoped to multi-perspective adversarial review. For skill
 improvement requests, use schliff instead. For post-review plan updates,
 use plan-review-integrator. Supported versions: Claude Code v1.0+.
@@ -247,11 +251,130 @@ Code Quality Auditor — the #1 cause of missed details in v1.**
 
 Correctness, Completeness, Quality, Edge Cases (override if user specifies).
 
+### VoltAgent Integration (v2.9)
+
+VoltAgent specialist agents (127+ across 10 families) have built-in domain
+expertise via their system prompts, making them stronger reviewers than generic
+persona-prompted agents. When available, the panel should **upgrade** personas
+to VoltAgent agents. Full catalog: github.com/VoltAgent/awesome-claude-code-subagents
+
+**Step 1: Check availability.** During Phase 1 setup, check whether VoltAgent
+agents are available by scanning the system-reminder agent list for any
+`voltagent-*` prefixed agents. Note which families are installed.
+
+**Step 2: Map personas to specialists.** Use this mapping table:
+
+#### Core Persona Mapping (review panel built-in personas)
+
+| Persona | Primary VoltAgent | Alt VoltAgent | Fallback |
+|---|---|---|---|
+| Correctness Hawk | `voltagent-qa-sec:code-reviewer` | `voltagent-qa-sec:debugger` | Generic + prompt |
+| Architecture Critic | `voltagent-qa-sec:architect-reviewer` | `voltagent-infra:cloud-architect` | Generic + prompt |
+| Security Auditor | `voltagent-qa-sec:security-auditor` | `voltagent-qa-sec:penetration-tester` | Generic + prompt |
+| Code Quality Auditor | `voltagent-qa-sec:code-reviewer` | | Generic + prompt |
+| Feasibility Analyst | `voltagent-data-ai:data-scientist` | `voltagent-biz:business-analyst` | Generic + prompt |
+| Risk Assessor | `voltagent-qa-sec:chaos-engineer` | `voltagent-biz:risk-manager` | Generic + prompt |
+| Performance Specialist | `voltagent-qa-sec:performance-engineer` | `voltagent-infra:sre-engineer` | Generic + prompt |
+| Stakeholder Advocate | `voltagent-biz:product-manager` | `voltagent-biz:business-analyst` | Generic + prompt |
+| Devil's Advocate | Generic + prompt | | (intentionally generic) |
+| Data Quality Auditor | `voltagent-data-ai:data-analyst` | `voltagent-data-ai:data-engineer` | Generic + prompt |
+| Reliability/SRE | `voltagent-infra:sre-engineer` | `voltagent-infra:devops-incident-responder` | Generic + prompt |
+| DevOps/Infra | `voltagent-infra:devops-engineer` | `voltagent-infra:platform-engineer` | Generic + prompt |
+| Database Specialist | `voltagent-data-ai:database-optimizer` | `voltagent-data-ai:postgres-pro` | Generic + prompt |
+| Clarity Editor | `voltagent-dev-exp:documentation-engineer` | `voltagent-biz:technical-writer` | Generic + prompt |
+| Technical Accuracy | `voltagent-qa-sec:code-reviewer` | | Generic + prompt |
+| Completeness Checker | `voltagent-qa-sec:qa-expert` | | Generic + prompt |
+
+#### Signal-Detected Specialist Mapping (auto-added by content signals)
+
+When content signals trigger auto-addition of specialist reviewers, use these
+VoltAgent agents instead of generic personas:
+
+| Content Signal | Auto-Add Persona | VoltAgent `subagent_type` |
+|---|---|---|
+| SQL / database queries | Data Quality Auditor | `voltagent-data-ai:database-optimizer` |
+| Terraform / IaC | Infrastructure Reviewer | `voltagent-infra:terraform-engineer` |
+| Terragrunt | Infrastructure Reviewer | `voltagent-infra:terragrunt-expert` |
+| Docker / containers | Container Reviewer | `voltagent-infra:docker-expert` |
+| Kubernetes / k8s | K8s Reviewer | `voltagent-infra:kubernetes-specialist` |
+| CI/CD / pipelines | Pipeline Reviewer | `voltagent-infra:deployment-engineer` |
+| ML / model training | ML Reviewer | `voltagent-data-ai:ml-engineer` |
+| LLM / prompts | LLM Reviewer | `voltagent-data-ai:llm-architect` |
+| NLP / text processing | NLP Reviewer | `voltagent-data-ai:nlp-engineer` |
+| React / frontend | Frontend Reviewer | `voltagent-lang:react-specialist` |
+| TypeScript | TS Reviewer | `voltagent-lang:typescript-pro` |
+| Python | Python Reviewer | `voltagent-lang:python-pro` |
+| Go / Golang | Go Reviewer | `voltagent-lang:golang-pro` |
+| Rust | Rust Reviewer | `voltagent-lang:rust-engineer` |
+| Java / Spring | Java Reviewer | `voltagent-lang:java-architect` |
+| .NET / C# | .NET Reviewer | `voltagent-lang:csharp-developer` |
+| Ruby / Rails | Rails Reviewer | `voltagent-lang:rails-expert` |
+| PHP / Laravel | PHP Reviewer | `voltagent-lang:laravel-specialist` |
+| Swift / iOS | iOS Reviewer | `voltagent-lang:swift-expert` |
+| Flutter / Dart | Flutter Reviewer | `voltagent-lang:flutter-expert` |
+| GraphQL | GraphQL Reviewer | `voltagent-core-dev:graphql-architect` |
+| WebSocket / real-time | Real-time Reviewer | `voltagent-core-dev:websocket-engineer` |
+| Microservices | Architecture Reviewer | `voltagent-core-dev:microservices-architect` |
+| API design | API Reviewer | `voltagent-core-dev:api-designer` |
+| Network / DNS / routing | Network Reviewer | `voltagent-infra:network-engineer` |
+| Azure | Azure Reviewer | `voltagent-infra:azure-infra-engineer` |
+| Active Directory | AD Security Reviewer | `voltagent-qa-sec:ad-security-reviewer` |
+| PowerShell | PowerShell Reviewer | `voltagent-qa-sec:powershell-security-hardening` |
+| Compliance / GDPR / SOC2 | Compliance Reviewer | `voltagent-qa-sec:compliance-auditor` |
+| Accessibility / a11y | Accessibility Reviewer | `voltagent-qa-sec:accessibility-tester` |
+| Error handling / logging | Error Reviewer | `voltagent-qa-sec:error-detective` |
+| Test automation | Test Reviewer | `voltagent-qa-sec:test-automator` |
+| Blockchain / Web3 | Blockchain Reviewer | `voltagent-domains:blockchain-developer` |
+| Payment / fintech | Fintech Reviewer | `voltagent-domains:fintech-engineer` |
+| IoT / embedded | Embedded Reviewer | `voltagent-domains:embedded-systems` |
+| SEO | SEO Reviewer | `voltagent-domains:seo-specialist` |
+| Quant / financial models | Quant Reviewer | `voltagent-domains:quant-analyst` |
+
+#### Multi-Agent Orchestration Mapping (for completeness audit & judge)
+
+| Review Phase | VoltAgent `subagent_type` | Use When |
+|---|---|---|
+| Completeness Audit (4.5) | `voltagent-meta:knowledge-synthesizer` | Synthesize what the panel missed |
+| Claim Verification (4.6) | `voltagent-qa-sec:code-reviewer` | Verify line-number citations |
+| Severity Verification (4.7) | `voltagent-qa-sec:debugger` | Read actual code for P0/P1 findings |
+| Supreme Judge (5) | Generic + opus | (judge must be domain-neutral) |
+
+**Step 3: Suggest installation when beneficial.** If a selected persona would
+benefit from a VoltAgent agent but the agent family is not available, suggest
+installation to the user:
+
+> "This review would benefit from VoltAgent specialist agents for deeper
+> domain-specific analysis. You can install the relevant families with:
+>
+> `claude install-skill voltagent-qa-sec`  — security, code review, testing, compliance
+> `claude install-skill voltagent-data-ai` — data science, ML, databases, NLP
+> `claude install-skill voltagent-infra`   — DevOps, cloud, Docker, Kubernetes, Terraform
+> `claude install-skill voltagent-lang`    — language-specific reviewers (TS, Python, Go, Rust, etc.)
+> `claude install-skill voltagent-core-dev` — API design, microservices, frontend, backend
+> `claude install-skill voltagent-biz`     — product, business analysis, risk management
+> `claude install-skill voltagent-domains` — fintech, blockchain, IoT, embedded systems
+>
+> Continue without them? They're optional — the review will still work
+> with generic persona-prompted agents."
+
+Only suggest installation **once per session**. List only the families relevant
+to the detected content signals, not all 10. If the user declines or the agents
+aren't available, proceed with the generic fallback silently.
+
+**Step 4: Launch with `subagent_type`.** When launching Phase 2 agents, use:
+- `subagent_type: "voltagent-qa-sec:code-reviewer"` (when available)
+- Omit `subagent_type` (generic agent with persona prompt as fallback)
+
+The persona prompt is STILL included even when using VoltAgent agents — it
+provides the review-panel-specific context (agreement intensity, reasoning
+strategy, evaluation criteria) that the VoltAgent agent doesn't have natively.
+
 ---
 
 ## Phase 2: Independent Review (Round 0)
 
 Launch ALL reviewer agents **in parallel** using Agent tool with `model: "opus"`.
+When VoltAgent integration is active, use `subagent_type` from the mapping table.
 Each gets the structured prompt from `references/prompt-templates.md` (Phase 2
 template) with their persona, agreement intensity, reasoning strategy, context
 brief, and the full work content inside injection boundaries.

--- a/eval-suite.json
+++ b/eval-suite.json
@@ -1,7 +1,8 @@
 {
   "skill_name": "agent-review-panel",
-  "version": "2.0.0",
+  "version": "2.9.0",
   "created_by": "manual",
+  "updated": "2026-03-29",
   "triggers": [
     {
       "id": "pos-1",
@@ -296,6 +297,55 @@
       "should_trigger": false,
       "category": "edge",
       "notes": "'Peer review' typically means single-reviewer feedback, not a panel"
+    },
+    {
+      "id": "v29-pos-1",
+      "prompt": "Review panel this test plan — use voltagent specialist agents if available for deeper domain coverage",
+      "should_trigger": true,
+      "category": "positive-v29",
+      "notes": "v2.9: Explicit request for VoltAgent specialist agents in review panel"
+    },
+    {
+      "id": "v29-pos-2",
+      "prompt": "Run a panel review on this Terraform config with infrastructure specialists",
+      "should_trigger": true,
+      "category": "positive-v29",
+      "notes": "v2.9: Infrastructure signal should map to voltagent-infra:terraform-engineer"
+    },
+    {
+      "id": "v29-pos-3",
+      "prompt": "I want a review panel on this ML pipeline — make sure the data science reviewers really know their stuff",
+      "should_trigger": true,
+      "category": "positive-v29",
+      "notes": "v2.9: ML signal should map to voltagent-data-ai:data-scientist"
+    },
+    {
+      "id": "v29-neg-1",
+      "prompt": "Install voltagent-qa-sec for me",
+      "should_trigger": false,
+      "category": "negative-v29",
+      "notes": "v2.9: Installation request is not a review — VoltAgent keyword is a red herring"
+    },
+    {
+      "id": "v29-neg-2",
+      "prompt": "Use the voltagent-data-ai:data-scientist agent to analyze my dataset",
+      "should_trigger": false,
+      "category": "negative-v29",
+      "notes": "v2.9: Direct agent invocation, not a review panel request"
+    },
+    {
+      "id": "v29-edge-1",
+      "prompt": "Can I get QA, data science, and DevOps perspectives on this deployment plan?",
+      "should_trigger": true,
+      "category": "edge-v29",
+      "notes": "v2.9: Requesting 3 domain perspectives without saying 'panel' — should trigger and use VoltAgent mapping"
+    },
+    {
+      "id": "v29-edge-2",
+      "prompt": "Review this with specialist subagents — I want real domain expertise, not generic personas",
+      "should_trigger": true,
+      "category": "edge-v29",
+      "notes": "v2.9: Explicit preference for specialist agents over generic personas"
     }
   ],
   "test_cases": [
@@ -457,6 +507,77 @@
           "description": "Creates panel despite specific focus"
         }
       ]
+    },
+    {
+      "id": "tc-v29-1",
+      "prompt": "Review panel this Flask webapp test plan — I have voltagent-qa-sec and voltagent-data-ai installed. Use specialist agents.",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(voltagent|specialist|subagent_type|domain.specific)",
+          "description": "v2.9: Acknowledges VoltAgent availability and uses specialist agents"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(qa.expert|code.reviewer|data.scientist|security)",
+          "description": "v2.9: Maps personas to specific VoltAgent agent types"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(reviewer|persona|panelist|agent)",
+          "description": "v2.9: Still creates a proper review panel (not just standalone agents)"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(verdict|judge|consensus|disagree)",
+          "description": "v2.9: Full panel ceremony still runs (debate, judge, report)"
+        }
+      ]
+    },
+    {
+      "id": "tc-v29-2",
+      "prompt": "Do a panel review on this Terraform module. Note: I don't have any voltagent agents installed.",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(install|voltagent|specialist|recommend|benefit)",
+          "description": "v2.9: Suggests installing VoltAgent agents when they would help"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(optional|continue|without|fallback)",
+          "description": "v2.9: Makes clear VoltAgent is optional, not required"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(reviewer|persona|panelist|agent)",
+          "description": "v2.9: Proceeds with generic agents (graceful fallback)"
+        }
+      ]
+    },
+    {
+      "id": "tc-v29-3",
+      "prompt": "Review this Python data science code. Use VoltAgent specialist agents — I want a data scientist reviewer, a code quality reviewer, and a DevOps reviewer.",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(voltagent-data-ai|data.scientist)",
+          "description": "v2.9: Maps data scientist to voltagent-data-ai:data-scientist"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(voltagent-qa-sec|code.reviewer)",
+          "description": "v2.9: Maps code quality to voltagent-qa-sec:code-reviewer"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(voltagent-infra|devops)",
+          "description": "v2.9: Maps DevOps to voltagent-infra:devops-engineer"
+        }
+      ]
     }
   ],
   "edge_cases": [
@@ -561,6 +682,60 @@
           "type": "pattern",
           "value": "(?i)(review|panel|fresh|new|independent)",
           "description": "Creates new independent panel"
+        }
+      ]
+    },
+    {
+      "id": "ec-v29-1",
+      "prompt": "Review panel this — only use VoltAgent agents, don't use any generic personas",
+      "category": "v29_voltagent_only",
+      "expected_behavior": "Use VoltAgent agents where available but explain Devil's Advocate stays generic intentionally",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(devil|advocate|generic|intentional|contrarian)",
+          "description": "v2.9: Explains Devil's Advocate stays generic by design"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(voltagent|specialist)",
+          "description": "v2.9: Uses VoltAgent for other personas"
+        }
+      ]
+    },
+    {
+      "id": "ec-v29-2",
+      "prompt": "Review panel this React component — I have voltagent-lang installed but not voltagent-qa-sec",
+      "category": "v29_partial_install",
+      "expected_behavior": "Use voltagent-lang:react-specialist for signal-detected reviewer, suggest installing voltagent-qa-sec for core personas, graceful fallback for unavailable agents",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(react|frontend|voltagent-lang)",
+          "description": "v2.9: Uses available language specialist"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(install|voltagent-qa-sec|suggest|recommend)",
+          "description": "v2.9: Suggests missing family that would help"
+        }
+      ]
+    },
+    {
+      "id": "ec-v29-3",
+      "prompt": "Do a review panel with VoltAgent agents on this Go microservice that uses gRPC and PostgreSQL",
+      "category": "v29_multi_signal",
+      "expected_behavior": "Maps multiple signals: Go → voltagent-lang:golang-pro, PostgreSQL → voltagent-data-ai:postgres-pro, microservices → voltagent-core-dev:microservices-architect",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(go|golang|voltagent-lang)",
+          "description": "v2.9: Detects Go signal and maps to language specialist"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(postgres|database|voltagent-data-ai)",
+          "description": "v2.9: Detects PostgreSQL signal and maps to data specialist"
         }
       ]
     }

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.9 (2026-03-29) — VoltAgent Specialist Agent Integration
+
+- **VoltAgent integration** — when [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) are installed (127+ across 10 families), the panel upgrades generic persona-prompted reviewers to domain-specific agents via `subagent_type`.
+- **3-tier mapping** — core persona mapping (16 personas), signal-detected specialist mapping (35 content signals → language/domain agents), orchestration phase mapping (completeness audit, claim/severity verification).
+- **Smart installation prompts** — suggests relevant `claude install-skill voltagent-*` commands when specialist agents would help but aren't installed. Non-blocking, once per session.
+- **Graceful fallback** — all functionality works without VoltAgent; it's a transparent upgrade.
+- **Credits:** [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) for the 127+ agent catalog across `voltagent-qa-sec`, `voltagent-data-ai`, `voltagent-infra`, `voltagent-lang`, `voltagent-core-dev`, `voltagent-biz`, `voltagent-domains`, `voltagent-meta`, `voltagent-dev-exp`, `voltagent-research`.
+
+Born from real production use: 4 VoltAgent specialists reviewing a test plan produced 38 findings with <10% overlap vs generic persona agents.
+
+---
+
 ## v2.8 (2026-03-26) — Severity Calibration, Coverage Check, Verify-Before-Claim, Precise/Exhaustive Mode
 
 Motivated by panel review of 6 proposed changes (see `docs/archive/review_panel_report.md`).

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -4,7 +4,7 @@
 
 - **VoltAgent integration** — when [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) are installed (127+ across 10 families), the panel upgrades generic persona-prompted reviewers to domain-specific agents via `subagent_type`.
 - **3-tier mapping** — core persona mapping (16 personas), signal-detected specialist mapping (35 content signals → language/domain agents), orchestration phase mapping (completeness audit, claim/severity verification).
-- **Smart installation prompts** — suggests relevant `claude install-skill voltagent-*` commands when specialist agents would help but aren't installed. Non-blocking, once per session.
+- **Smart installation prompts** — suggests relevant `claude plugin install voltagent-*` commands when specialist agents would help but aren't installed. Non-blocking, once per session.
 - **Graceful fallback** — all functionality works without VoltAgent; it's a transparent upgrade.
 - **Credits:** [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) for the 127+ agent catalog across `voltagent-qa-sec`, `voltagent-data-ai`, `voltagent-infra`, `voltagent-lang`, `voltagent-core-dev`, `voltagent-biz`, `voltagent-domains`, `voltagent-meta`, `voltagent-dev-exp`, `voltagent-research`.
 


### PR DESCRIPTION
## Summary
- Adds VoltAgent specialist agent integration (v2.9) to the review panel — upgrades generic persona-prompted reviewers to domain-specific agents when available
- Maps 16 core personas + 35 content-signal-detected specialists + 4 orchestration phases to VoltAgent agents across all 10 plugin families
- Smart installation prompts suggest relevant VoltAgent families (both CLI and marketplace methods)
- Graceful fallback to generic agents when VoltAgent is not installed
- Updates all docs: README, HOW_WE_BUILT_THIS (Step 15), ROADMAP, changelog
- Updates eval suite from v2.0 to v2.9 (49 triggers, 10 test cases, 11 edge cases)
- Fixes install command from fake `claude install-skill` to correct `claude plugin install` / `/plugin install`

## Commits (7)
- `d5631ee` feat: VoltAgent integration (v2.9) — 127+ specialist agent mapping
- `a1fd182` docs: update README, HOW_WE_BUILT_THIS, ROADMAP, changelog for v2.9
- `5d57289` test: update eval suite for v2.9 VoltAgent integration
- `2a56b91` fix: correct install command from 'claude install-skill' to 'claude plugin install'
- `5467246` fix: remaining install-skill references in README and changelog
- `1039291` fix: use correct /plugin marketplace add + /plugin install syntax
- `436a5fb` fix: show both CLI and marketplace install methods for VoltAgent

## Design decisions
- Devil's Advocate and Supreme Judge stay generic (contrarian/neutral roles benefit from no domain bias)
- Persona prompts still included with VoltAgent (review-specific context like agreement intensity)
- Installation suggestion is non-blocking ("Continue without them? They're optional"), fires once per session
- Both install methods shown: `claude plugin install` (CLI) and `/plugin marketplace add` (in-session)
- Catalog source: [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents)

## Test plan
- [x] Verified VoltAgent agents available: voltagent-qa-sec, voltagent-data-ai, voltagent-infra, voltagent-meta, voltagent-research
- [x] Used 4 VoltAgent specialists in real review panel session (38 findings, <10% overlap)
- [x] Verified graceful fallback when VoltAgent not installed
- [x] Tested install commands: `claude plugin install` works for all published families
- [x] Updated eval suite with v2.9 triggers, test cases, edge cases
- [x] voltagent-lang: installed successfully via `claude plugin install voltagent-lang` (requires session restart to appear in agent list)
- [x] voltagent-domains: installed successfully via `claude plugin install voltagent-domains` (requires session restart to appear in agent list)
- [x] Verify voltagent-lang and voltagent-domains agents work in a review panel — confirmed working: python-pro, typescript-pro, fintech-engineer, iot-engineer all respond correctly (session 12, 2026-03-29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)