### PR TITLE
docs: update README, CHANGELOG, ROADMAP, HOW_WE_BUILT_THIS for v2.10–v2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 All notable changes to Agent Review Panel.
 
+## [2.15.0] — 2026-04-07
+
+### Added
+- **Expandable 10-section issue cards in Phase 15.3 HTML report.** Each issue card is a native `<details>` element that expands to reveal a nested accordion with 10 sections: 📖 Narrative (full reviewer reasoning, verbatim), 📄 Code Evidence (Prism.js-highlighted snippets with file:line headers), 👥 Raised by (per-reviewer rating + reasoning), 🔍 Verification Trail (full VR agent output), 💬 Debate (round-by-round transcript), ⚖️ Judge Ruling, 🛠️ Fix Recommendation (proposed change + before/after code + regression test + blast radius + effort), 🔗 Cross-references (related findings with relationship labels), 🏷️ Epistemic Tags (hover tooltips), 📊 Prior Runs (meta-review comparison).
+- **8 new REQUIRED fields** in the Phase 15.3 schema per action item: `narrative`, `codeEvidence`, `reviewerRatings`, `debateTranscript`, `judgeRuling`, `fixRecommendation`, `crossRefs`, `priorRuns`. Empty arrays/null acceptable but the field must be present. Empty sections render "No {section} data" placeholders so every card has consistent structure.
+- **Phase 15.2 process history passed as Reference Input to Phase 15.3** — the HTML agent now receives the verbatim process history alongside the summarized report, enabling it to extract real narratives, debate exchanges, and judge rulings per finding. Token cost: ~10–20KB per review.
+- **Deep-link support** — `report.html#issue-A1` auto-opens the matching card, scrolls to it, and pulses a highlight ring.
+- **Keyboard navigation** — ↑/↓ between cards, Enter/Space expands, Home/End jump to first/last, `/` focuses search.
+- **Expand all / Collapse all** buttons at the top of the Issues tab (operates on visible cards only).
+- **Print-friendly `@media print` CSS** — forces all details open, inverts dark theme, hides charts and filters, sets `page-break-inside: avoid` per card.
+- **Prism.js CDN dependency** (new) — `https://cdn.jsdelivr.net/npm/prismjs@1.29.0` for syntax highlighting. Uses prism-tomorrow theme + autoloader plugin. Graceful fallback to unstyled `<pre>` if CDN unreachable.
+- **Soft 500KB size cap** with optional slim mode that drops verbatim `fullEvidence` and `debateTranscript` when exceeded.
+- 4 new manifest-consistency tests: 10-section spec coverage, 8 new schema fields present, Prism.js documented, SKILL.md mentions v2.15 features.
+- v2.15 eval-suite category + coverage describe block + 3 new triggers.
+
+### Motivation
+A compliance gap in the v2.13 nice-shtern sample: the Phase 15.3 HTML rendered 22 flat issue cards with no expand mechanism, even though the prompt template already specified a "▶ View evidence" button. Root cause: the schema only populated rich evidence fields for findings that went through Phase 13 verification. For non-verified findings, the HTML agent had nothing to expand, so it silently omitted the expand button entirely — degrading the whole UX to one-liner cards. v2.15 fixes this by making all 8 deep-detail fields required (with empty-placeholder rendering) and routing Phase 15.2 content into Phase 15.3.
+
+## [2.14.0] — 2026-04-07
+
+### Added
+- **Phase 2: Data Flow Trace** — a dedicated agent traces data through the critical path(s) of the work BEFORE reviewers begin, targeting composition defects (two individually-correct functions producing incorrect results together — the `apply_date_mask` + `prep_df` class of bug). Uses Meta's semi-formal certificate prompting (2026, 78%→93% accuracy): at each function boundary, produce INPUT_SCHEMA → TRANSFORM → OUTPUT_SCHEMA → COMPOSITION_CHECK → INVARIANT_STATUS. Five mandatory invariant checks: schema preservation, transform/back-transform completeness, row count stability, null semantics, temporal consistency. Three user-selectable tiers: **Standard** (default, single path, ~5 min), **Thorough** (top 3 paths + completeness checks, ~15 min), **Exhaustive** (all paths, no token limit, aims to catch all bugs). Skipped for pure docs/plans or code with no data transforms.
+- **Multi-Run Union Protocol + Phase 16: Merge** — invoke `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions, then merge via Phase 16. Rotation: Run 1 = standard base, Run 2 = complementary (Code Quality Auditor + Performance Specialist + Methodology Analyst + DA), Run 3 = adversarial-heavy (3 DAs with different reasoning strategies + Correctness Hawk), Run 4+ cycles. **Key rule:** content classification runs ONCE (Run 1) and is reused — eliminates the primary source of cross-run variance documented in the v2.10 consistency analysis. Phase 16 deduplicates by location + bug class, scores stability as `[K/N RUNS]`, uses highest severity when runs disagree, resolves judge divergence.
+- **Force `model: "opus"` on all launches** — fixes a silent bug introduced in v2.9: the skill said "all agents use opus" but the VoltAgent Step 4 launch instructions omitted the model parameter, causing agents to fall through to their frontmatter-declared default model (potentially sonnet or haiku). Now ALWAYS pass `model: "opus"` explicitly alongside `subagent_type`. New `manifest-consistency` test greps all `subagent_type:` launches and asserts `model: "opus"` on the same line.
+- **Two new checklists** in `references/signals-and-checklists.md`: Transform/Back-Transform Completeness (8 items) + Data Flow Invariants (8 items). Used by the Phase 2 Data Flow Tracer.
+- **Two new prompt templates** in `references/prompt-templates.md`: Phase 2 Data Flow Tracer (~90 lines), Phase 16 Merge Agent (~60 lines).
+
+### Changed
+- **Integer phase renumbering** — all phases renumbered from decimal hierarchy (1, 2, 2.5, 3, 3.5, 4, 4.5, 4.55, 4.6, 4.7, 4.8, 4.8a, 4.8b, 4.9, 5, 6, 6.1, 6.2, 6.3) to sequential integers (1–16). Phase 15 retains sub-phases 15.1/15.2/15.3 as parent "Output Generation" because those represent parallel output generation. Phase 12 retains sub-parts 12a and 12b (two-step tier assignment pipeline).
+
+### Motivation
+Two identical panel runs on the same Schuh webapp (v2.10) produced only ~30% finding overlap, each missing a different P0 bug. Root causes: (1) LLM-driven content classification produces different persona compositions, (2) single-run coverage catches only ~60-70% of discoverable issues, (3) composition/seam bugs require dedicated tracing — no prior phase targeted this bug class, (4) silent model mixing via VoltAgent `subagent_type` without explicit `model: "opus"` override.
+
+## [2.13.0] — 2026-04-03
+
+### Added
+- **Persona profiles surfaced in both process history and HTML dashboard.** Every agent now has a structured profile: role, agreement intensity (panelists), reasoning strategy, domain focus, agent type (VoltAgent or generic), matched-claim-type (Phase 13 agents), phases active.
+- **Phase 15.2 (Process History):** Persona Profiles Registry at the top listing all agents, plus inline profile blocks immediately before each agent's first output.
+- **Phase 15.3 (HTML):** Panel Gallery section with three sub-groups — Panel Reviewers (avatar cards, click to filter issues), Verification Specialists (linked to dispute points), Support Agents (compact cards with phase badges). Issue cards show "Raised by" avatar chips and verification agent persona in the expanded evidence panel. Cross-linking: clicking a persona chip scrolls to and highlights that agent's card in the Panel Gallery.
+
+## [2.12.0] — 2026-04-03
+
+### Added
+- **Triple output format.** Phase 6 restructured from 1 → 3 output files:
+  1. **`review_panel_report.md`** — existing primary report (unchanged)
+  2. **`review_panel_process.md`** — verbatim "director's cut" of every agent's output in chronological order. Orchestrator-assembled, no new agent needed.
+  3. **`review_panel_report.html`** — interactive dashboard generated by a dedicated Opus agent. Tailwind CSS + Chart.js via CDN. Stats row, three charts (confidence distribution, tier breakdown, verdict breakdown), filterable/sortable issue cards with expandable evidence panels, collapsible consensus/disagreement sections.
+- Phase 6.1 runs first; 6.2 (orchestrator write) and 6.3 (Opus agent) run in parallel.
+
+## [2.11.0] — 2026-04-03
+
+### Added
+- **Phase 4.8: Verification Tier Assignment** — a two-step pipeline. 4.8a (no agent): orchestrator derives initial tiers from Phase 2.5 confidence ratings + debate round signals. Low-confidence or multi-round unresolved → Deep; mixed → Standard; all-high + simple fact → Light. 4.8b (Opus agent): reviews the draft and overrides where signals are misleading.
+- **Phase 4.9: Targeted Verification Agents** — one agent per dispute, launched in parallel. Persona-matched to claim type (statistical → Data Scientist, code correctness → Code Reviewer, security → Security Auditor). VoltAgent specialists preferred when available. Tiered budgets: Light ~2k tokens (read-only), Standard ~8k (multi-file), Deep ~32k (web search). Verdicts: `[VR_CONFIRMED]`, `[VR_REFUTED]`, `[VR_PARTIAL]`, `[VR_INCONCLUSIVE]`, `[VR_NEW_FINDING]`.
+- **Phase 5 judge updated** to receive the Verification Round Summary as 8th input. Step 2 ("Rule on Each Disagreement") now gives significant weight to VR verdicts.
+- Inspired by [MiroFish](https://github.com/666ghj/MiroFish)'s heterogeneous agent architecture — distinct agent personalities matched to tasks based on the task's domain characteristics.
+
 ## [2.10.0] — 2026-03-30
 
 ### Added

--- a/HOW_WE_BUILT_THIS.md
+++ b/HOW_WE_BUILT_THIS.md
@@ -576,29 +576,173 @@ Every agent now has a structured persona profile surfaced in both output files:
 
 ---
 
+## Step 17: Data Flow Trace + Multi-Run Union + Force Opus (v2.14, 2026-04-07)
+
+### Motivation
+
+Two identical panel runs on the same Schuh webapp (v2.10, `epic-poincare` and `thirsty-nobel` worktrees) produced only ~30% finding overlap. Each run missed a different P0 bug the other caught. A consistency analysis identified four root causes:
+
+1. **LLM-driven content classification produces different persona compositions across runs.** The same "webapp + methodology" scope was classified differently in each run, cascading into entirely different finding profiles (Correctness Hawk vs Code Quality Auditor as the lead reviewer).
+2. **Single-run coverage catches only ~60-70% of discoverable issues.** Research on independent code review (Dunsmore et al., 2000) puts the inter-reviewer overlap at 20-40% — consistent with our observation.
+3. **Composition/seam bugs require dedicated tracing.** The `apply_date_mask` + `prep_df` bug — where function A correctly removes masked Nov-Jan rows and function B correctly reindexes with `fillna(0)`, silently reintroducing the masked rows as zero-revenue days — is structurally invisible to reviewers who read each function in isolation. No prior phase targeted this bug class.
+4. **Silent model mixing via VoltAgent.** The skill said "all agents use opus" at lines 60 and 422 of SKILL.md, but the VoltAgent Step 4 launch instructions at lines 410-412 omitted `model: "opus"`, causing reviewers to fall through to the VoltAgent agent's default model (potentially sonnet or haiku). Reasoning depth varies by model, so this introduced invisible cross-run variance on top of persona variation. This was a latent bug introduced in v2.9 and went undetected for 6 minor releases.
+
+### Implementation
+
+**Phase 2: Data Flow Trace.** A dedicated agent traces data through critical path(s) BEFORE reviewers begin, producing a structured Data Flow Map injected into every reviewer's Phase 3 prompt. Uses Meta's semi-formal certificate prompting (arXiv:2603.01896, 2026, 78%→93% accuracy gain): at each function boundary, the agent produces
+
+```
+FUNCTION: {name} ({file}:{line})
+INPUT_SCHEMA: {types, constraints, tainted fields}
+TRANSFORM: {what the function does + external calls}
+OUTPUT_SCHEMA: {return type, derived fields, invariants}
+COMPOSITION_CHECK: {does OUTPUT_SCHEMA satisfy next INPUT_SCHEMA?}
+INVARIANT_STATUS: {preserved or violated — violations flagged as P0 candidates}
+```
+
+Five mandatory invariant checks at every boundary: schema preservation, transform/back-transform completeness, row count stability, null semantics, temporal consistency. Three user-selectable tiers: Standard (default, single top-ranked path, ~5 min), Thorough (top 3 paths + transform completeness, ~15 min), Exhaustive (all paths, no token limit — aims to catch all bugs). Skipped for pure docs/plans or code with no detectable transforms.
+
+**Multi-Run Union Protocol + Phase 16: Merge.** User invokes `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions:
+
+- **Run 1:** Standard content-type base set + signal specialists
+- **Run 2:** Complementary set (Code Quality Auditor, Performance Specialist, Methodology Analyst, DA)
+- **Run 3:** Adversarial-heavy (3 Devil's Advocates with different reasoning strategies — analogical, adversarial simulation, failure mode enumeration — plus 1 Correctness Hawk)
+- **Run 4+:** Cycle through 1-3 with shuffled signal specialists
+
+**Key rule:** content classification runs ONCE in Run 1 and is FIXED for all subsequent runs. Phase 2 also runs once and is cached. This eliminates the primary source of cross-run non-determinism (LLM-driven classification) while preserving the benefits of persona rotation.
+
+Phase 16 Merge Agent deduplicates findings by location + bug class (same file + same function OR lines within 10, AND same bug class), scores stability as `[K/N RUNS]`, uses HIGHEST severity when runs disagree (conservative), resolves judge divergence (>2 point spread) with independent assessment. Single-run findings are NOT demoted — they often represent unique persona insights.
+
+**Force `model: "opus"` on all launches.** Three edits to SKILL.md (Dependencies section, Phase 1 VoltAgent Step 4, Core Persona Mapping intro) plus one to `references/prompt-templates.md`. New manifest-consistency test greps all `subagent_type:` occurrences and asserts `model: "opus"` co-occurs on the same line.
+
+**Integer phase renumbering.** All phases renumbered from decimal hierarchy (1, 2, 2.5, 3, 3.5, 4, 4.5, 4.55, 4.6, 4.7, 4.8, 4.8a, 4.8b, 4.9, 5, 6, 6.1, 6.2, 6.3) to sequential integers (1–16). Phase 15 retains sub-phases 15.1/15.2/15.3 as parent "Output Generation" (parallel output generation, not sequential pipeline steps). Phase 12 retains sub-parts 12a and 12b (two-step tier assignment pipeline — confidence-based draft + judge-advised refinement).
+
+### Testing
+
+All 380 tests pass (up from 363) — 13 new tests for v2.14 coverage:
+
+- **4 new manifest-consistency tests:** 16 integer phases present, `subagent_type` + `model: "opus"` co-occurrence on every real launch, no decimal phases remain (except allowed 15.x), SKILL.md mentions v2.14 features
+- **v2.14 category validation** in eval-suite-integrity (positive-v214, negative-v214, edge-v214)
+- **v2.14 coverage describe block** (3 tests: positive triggers exist, negative triggers exist, triggers cover both multi-run and data flow trace features)
+- **6 new eval-suite triggers** (4 positive, 2 negative)
+
+### Lessons
+
+30. **Independent test coverage lags silently.** The v2.9 VoltAgent integration omitted `model: "opus"` from launch calls, and this went undetected for 6 minor releases because there was no test covering the invariant. The fix was a ~20-line regex-based test that would have caught the bug in v2.9. **Rule:** when adding new launch syntax (subagents, specialist agents, etc.), add a test that asserts the invariant you intend — not just that the launch syntax works.
+
+31. **Composition bugs live at function boundaries.** The entire class of bugs where two individually-correct functions produce incorrect results together is structurally invisible to per-function review. Dedicated data flow tracing catches them; adversarial debate does not. The Data Flow Tracer is the biggest coverage improvement since the Completeness Auditor (v2.0).
+
+32. **Content classification non-determinism cascades.** One LLM decision at Phase 1 ("is this pure code or mixed content?") cascades through the entire pipeline because persona selection depends on it. Multi-Run Union mitigates by rotating personas directly (no classification per run). A future v2.16+ could eliminate this entirely with rule-based classification.
+
+33. **Hand-in-hand data enrichment + rendering spec is required to prevent agent compliance drift.** The v2.13 HTML prompt already specified expandable issue cards with a "▶ View evidence" button. But the schema only populated `fullEvidence` for verified findings, so for the other 19 findings the HTML agent had nothing to expand — and it silently omitted the expand button entirely. When requiring agents to render rich UI, the DATA must also be required (required fields, empty placeholders OK) so agents can't shortcut the spec. This lesson directly motivated v2.15's "all 10 sections always present, empty ones show placeholders" rule.
+
+---
+
+## Step 18: Expandable Issue Cards in Phase 15.3 HTML Report (v2.15, 2026-04-07)
+
+### Motivation
+
+A sample v2.13 HTML output (`review_panel_report_consolidated.html` in the nice-shtern worktree) rendered 22 flat issue cards with no expand mechanism. The prompt already specified `▶ View evidence` — but the agent omitted it because the schema lacked rich data for non-verified findings (see lesson 33 above).
+
+Process history (`review_panel_process.md`) had ~600 lines of full narratives, debate transcripts, and VR agent outputs per review — all of which was available in the skill's output but NEVER passed to the HTML agent. The HTML was rendering from the summarized `review_panel_report.md` only.
+
+### Implementation
+
+**Schema extension.** 8 new REQUIRED fields per action item in the Phase 15.3 prompt:
+
+- `narrative` — full multi-paragraph reviewer reasoning (verbatim, not summarized)
+- `codeEvidence` — array of `{file, lineRange, language, snippet, caption}`
+- `reviewerRatings` — per-reviewer severity + reasoning
+- `debateTranscript` — round-by-round Phase 5 exchanges
+- `judgeRuling` — full Phase 14 reasoning + severity-change explanation
+- `fixRecommendation` — proposed change + before/after code + regression test + blast radius + effort
+- `crossRefs` — related findings with relationship labels (root-cause, same-class, depends-on, blocks)
+- `priorRuns` — meta-review comparison across prior runs
+
+Critical rule: fields are required-but-possibly-empty. Empty arrays or null values are acceptable, but the field must be present. The HTML renderer shows "No {section} data" placeholders for empty sections so every card has consistent structure. This prevents the v2.13 compliance gap from recurring — agents can't skip sections with no data because the spec demands the placeholder.
+
+**Phase 15.2 as Reference Input.** The HTML agent now receives the full Phase 15.2 process history (`review_panel_process.md` content) alongside the structured summary. It extracts verbatim narratives, debate exchanges, and judge rulings per finding. Token cost: ~10–20KB per review. This is the critical bridge — the data was always generated, just never passed to the HTML agent.
+
+**10-section accordion layout.** Each card is a native `<details>` element. The `<summary>` contains the collapsed card header. Expanding reveals a nested accordion of 10 `<details>` sections (open by default):
+
+1. 📖 Narrative
+2. 📄 Code Evidence (Prism.js-highlighted with file:line headers)
+3. 👥 Raised by (per-reviewer rating + reasoning grid)
+4. 🔍 Verification Trail (full VR agent output if verified)
+5. 💬 Debate (round-by-round transcript if disputed)
+6. ⚖️ Judge Ruling (full reasoning + severity-change explanation)
+7. 🛠️ Fix Recommendation (proposed + before/after + test + blast radius + effort)
+8. 🔗 Cross-references (clickable scroll-to-target with pulse highlight)
+9. 🏷️ Epistemic Tags (hover tooltips explaining each label)
+10. 📊 Prior Runs (meta-review comparison table)
+
+**Card-level UX features.** Deep-link support (`#issue-A1` auto-opens), keyboard navigation (↑/↓/Enter/Home/End/`/`), expand-all / collapse-all buttons, print-friendly `@media print` CSS (forces all details open, inverts theme, hides charts), soft 500KB size cap with optional slim mode.
+
+**New CDN dependency:** Prism.js (prism-tomorrow theme + autoloader plugin) for code syntax highlighting. Third CDN alongside Tailwind and Chart.js. Graceful fallback to unstyled `<pre>` if unreachable.
+
+### Testing
+
+All 393 tests pass (up from 380) — 13 new tests for v2.15 coverage:
+
+- **4 new manifest-consistency tests:** Phase 15.3 spec documents all 10 expandable card sections, 8 new schema fields present, Prism.js CDN documented, SKILL.md mentions v2.15 features
+- **v2.15 category validation** in eval-suite-integrity (positive-v215, negative-v215, edge-v215)
+- **v2.15 coverage describe block** (3 tests: positive triggers exist, negative triggers exist, triggers mention expandable/deep-detail features)
+- **3 new eval-suite triggers** (2 positive, 1 negative — the negative catches "expand my code" debugging context, not expandable cards)
+
+### Sample regenerated output
+
+Hand-rendered a new demo HTML at `review_panel_report_consolidated_v215.html` (190KB, 2370 lines — up from 51KB, 821 lines for v2.13) with 25 expandable cards:
+
+- 3 fully populated (A1, B1, C1) with all 10 accordion sections showing real extracted content from the process history
+- 22 with placeholder accordion content demonstrating consistent structure even when source data is absent
+- All v2.15 features wired up: Prism.js, deep-linking, keyboard navigation, expand/collapse all, print styles, cross-references
+
+### Lessons
+
+34. **Required-but-possibly-empty fields beat optional fields for forcing compliance.** When a rendering agent has a choice between "populate rich UI with empty data" and "skip the rich UI entirely", agents reliably choose "skip". Making fields required with empty-placeholder rendering removes the choice — the agent must produce the structure, even if the data is empty. This is the architectural fix for lesson 33.
+
+35. **Cross-phase data routing is an underappreciated fix.** Phase 15.2 generates verbatim agent reasoning. Phase 15.3 renders HTML. For 3 versions (v2.12–v2.14), the two phases ran in isolation — Phase 15.3 never saw Phase 15.2's verbatim content. The fix was not to regenerate data or rewrite agents, but simply to route Phase 15.2's output into Phase 15.3's input. Before assuming you need new data generation, check whether existing data is being thrown away at phase boundaries.
+
+36. **Native `<details>` is the right primitive for expandable UI in self-contained HTML.** It requires zero JavaScript for the expand/collapse behavior, works in print media queries (with `details > *:not(summary)` forced open), keyboard-accessible by default (Tab + Enter/Space), and nests cleanly for accordion patterns. The alternative — JS-driven toggle state — adds framework dependencies and print-unfriendly state management.
+
+---
+
 ## File Inventory
 
 ```
-├── SKILL.md                           # The skill itself (v2.13, ~800 lines)
+├── SKILL.md                           # The skill itself (v2.15, ~1220 lines — 16 phases + sub-phases)
 ├── skills/agent-review-panel/
-│   └── SKILL.md                       # Plugin copy (synced with root)
+│   └── SKILL.md                       # Plugin copy (byte-identical to root; enforced by manifest test)
 ├── references/
-│   ├── signals-and-checklists.md      # 9 signal groups + domain checklists
-│   ├── prompt-templates.md            # All phase prompt templates (incl. 4.8/4.9/6.2/6.3)
-│   ├── changelog.md                   # Version history (v2–v2.13)
-│   └── research-v28.md               # 19-source v2.8 research compilation
+│   ├── signals-and-checklists.md      # 11 signal groups + domain checklists (includes v2.14 Transform + Data Flow Invariants checklists)
+│   ├── prompt-templates.md            # All phase prompt templates (incl. Phase 2 Data Flow Tracer + Phase 16 Merge + Phase 15.3 10-section expandable cards)
+│   ├── changelog.md                   # Version history (v2–v2.15)
+│   └── research-v28.md                # 19-source v2.8 research compilation
+├── tests/
+│   ├── trigger-classification.test.mjs  # Trigger phrase classification (55+ prompts)
+│   ├── manifest-consistency.test.mjs    # 16 phases, opus enforcement, 10-section spec coverage
+│   ├── eval-suite-integrity.test.mjs    # Category validation + v2.9/v2.14/v2.15 coverage blocks
+│   ├── report-structure.test.mjs        # Report format validation
+│   ├── behavioral-assertions.test.mjs   # Fixture-based behavioral assertions
+│   ├── golden-file.test.mjs             # Golden fingerprint snapshots
+│   ├── fixtures/                        # Sample reports (valid, minimal, low-confidence)
+│   └── golden/                          # Golden JSON fingerprints
 ├── docs/
-│   ├── demo-flow.png                  # Architecture diagram (referenced by README)
+│   ├── research-foundations.md        # Full research foundations breakdown (9+ papers)
+│   ├── hero-flow.svg                  # Pipeline architecture diagram
+│   ├── demo.gif                       # Animated demo
 │   └── archive/                       # Historical artifacts
 │       ├── SKILL.v2.md, SKILL.v2.1.md # Old skill versions
 │       ├── review_panel_report.md     # v2.8 roadmap panel review
 │       └── v25-vs-v26-comparison.md   # A/B test results
 ├── .claude-plugin/
-│   ├── plugin.json                    # Plugin metadata
-│   └── marketplace.json               # Marketplace listing
-├── README.md                          # User-facing documentation
-├── HOW_WE_BUILT_THIS.md               # This file
-├── ROADMAP.md                         # Unified research + trust roadmap (17+ papers, 14 projects)
-├── eval-suite.json                    # Schliff eval suite (triggers + assertions)
+│   ├── plugin.json                    # Plugin metadata (name, version 2.15.0, repo)
+│   └── marketplace.json               # Marketplace listing (v2.15.0, author, tags)
+├── README.md                          # User-facing documentation (install via /plugin marketplace add)
+├── HOW_WE_BUILT_THIS.md               # This file (Steps 1–18 chronicling v1–v2.15)
+├── ROADMAP.md                         # Unified research + trust roadmap (22+ papers, 14 projects)
+├── CHANGELOG.md                       # Top-level changelog (v1.0 → v2.15)
+├── eval-suite.json                    # Schliff eval suite (triggers + assertions, 60+ entries)
+├── package.json                       # Node.js test runner config (version 2.15.0)
 └── LICENSE                            # MIT
 ```

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ A [Claude Code](https://claude.ai/code) skill that orchestrates multi-agent adve
 
 ## Quick Start
 
-**Install:**
-```bash
-git clone https://github.com/wan-huiyan/agent-review-panel.git ~/.claude/skills/agent-review-panel
+**Install (recommended — Claude Code marketplace):**
+```
+/plugin marketplace add wan-huiyan/agent-review-panel
+/plugin install agent-review-panel@agent-review-panel
 ```
 
 **Use:**
@@ -29,7 +30,7 @@ git clone https://github.com/wan-huiyan/agent-review-panel.git ~/.claude/skills/
 **What you get:** Three output files:
 - `review_panel_report.md` — executive summary, consensus, disagreements (with judge rulings), prioritized action items tagged with epistemic labels
 - `review_panel_process.md` — full "director's cut" log of every agent's verbatim output with persona profiles
-- `review_panel_report.html` — interactive dashboard with filterable issue cards, charts, and a Panel Gallery
+- `review_panel_report.html` — interactive dashboard with **expandable 10-section issue cards** (Narrative, Code Evidence, Debate, Judge Ruling, Fix Recommendation, and more — new in v2.15), filterable issue cards, charts, and a Panel Gallery
 
 <details>
 <summary><strong>Example report output (truncated)</strong></summary>
@@ -66,13 +67,43 @@ timeout. [VERIFIED] against actual code.
 
 ## Installation
 
-### Claude Code (v1.0+)
+### Claude Code marketplace (recommended)
+
+Add this repo as a marketplace and install the plugin:
+
+```
+/plugin marketplace add wan-huiyan/agent-review-panel
+/plugin install agent-review-panel@agent-review-panel
+```
+
+Or from the shell via the CLI:
+
+```bash
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install agent-review-panel@agent-review-panel
+```
+
+Claude Code downloads the plugin to its cache, loads the skill, and activates the trigger phrases automatically. The skill then triggers when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel`.
+
+**Why the marketplace path?** The repo ships with `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests that Claude Code reads to register the plugin. The marketplace install handles caching, version tracking, and automatic activation in one step. The manual clone path below still works but doesn't use the manifests — the marketplace flow is the canonical path for v2.14+.
+
+### Manual clone (development / custom setup)
+
+For local development, forking, or air-gapped environments:
 
 ```bash
 git clone https://github.com/wan-huiyan/agent-review-panel.git ~/.claude/skills/agent-review-panel
 ```
 
-The skill triggers automatically when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel`.
+Or load a cloned repo as a local plugin for testing without committing to marketplace install:
+
+```bash
+claude --plugin-dir ./agent-review-panel
+```
+
+### Claude Code version requirement
+
+**Claude Code v1.0+** (the skill uses the Agent tool for parallel subagent spawning and `model: "opus"` overrides — v2.14+ forces opus on all launches including VoltAgent specialist agents).
 
 ### Cursor (experimental)
 
@@ -113,14 +144,16 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 
 ## How It Works
 
+16 phases + optional multi-run merge. Phase numbers are sequential integers (v2.14 cleanup — old decimal numbering like Phase 4.55 retired).
+
 | Stage | Phase | Action |
 |---|---|---|
-| **Gather** | 1. | Context & Setup — scan sibling dirs, trace references, discover safeguards |
-| | 2. | Detect Specialists — signal detection, persona selection, knowledge mining |
+| **Gather** | 1. | Setup — scan sibling dirs, trace references, discover safeguards, detect signals, select personas |
+| | 2. | **Data Flow Trace** *(v2.14, code only)* — trace critical path(s), document schemas at each function boundary, flag composition/seam bugs |
 | **Review** | 3. | Independent Review — 4-6 reviewers evaluate in parallel (no cross-talk) |
 | | 4. | Private Reflection — each reviewer re-reads and rates own confidence |
 | **Debate** | 5. | Adversarial Debate (1-3 rounds) — reviewers engage + find new issues |
-| | 6. | Summarize — distill resolved/unresolved points between rounds |
+| | 6. | Round Summarization — distill resolved/unresolved points between rounds |
 | | 7. | Blind Final — each reviewer gives final score independently |
 | **Verify** | 8. | Completeness Audit — dedicated agent scans for what the panel missed |
 | | 9. | Verify Commands — run reviewer grep/read commands for P0/P1 findings (advisory) |
@@ -129,7 +162,8 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 | | 12. | Tier Assignment — confidence-based draft → judge-advised refinement per dispute |
 | | 13. | Targeted Verification — persona-matched agents investigate each dispute point |
 | **Adjudicate** | 14. | Supreme Judge — Opus arbitrates everything including verification round evidence |
-| **Output** | 15. | Primary Report (`.md`) + Process History (`.md`) + Interactive Dashboard (`.html`) |
+| **Output** | 15. | Triple output: Primary Report (`.md`) + Process History (`.md`) + **Expandable-card Dashboard (`.html`)** *(v2.15)* |
+| **Merge** | 16. | **Multi-Run Merge** *(v2.14, optional)* — deduplicate findings across runs, score stability, resolve judge divergence |
 
 ## Features
 
@@ -146,6 +180,8 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 - Defect classification: findings labeled [EXISTING_DEFECT] or [PLAN_RISK] — P0 requires existing defect evidence
 - Completeness audit: post-debate agent re-reads source line-by-line for what everyone missed
 - **Targeted verification round (v2.11):** each unresolved dispute gets a tiered (Light ~2k / Standard ~8k / Deep ~32k tokens) verification agent matched to the claim type (statistician for stats claims, security auditor for security claims, etc.) — verdicts feed directly into the judge's rulings
+- **Data Flow Trace (v2.14):** a dedicated agent traces data through critical paths before reviewers begin, flagging composition/seam bugs (two individually-correct functions producing incorrect results together). Three tiers: Standard (default, single path), Thorough (top 3 paths + transform-completeness checks), Exhaustive (all paths, no token limit — aims to catch all bugs). Uses Meta's semi-formal certificate prompting (2026, 78%→93% accuracy). Skipped for pure docs/plans or code with no data transforms.
+- **Force opus on all launches (v2.14):** every `subagent_type` launch — including VoltAgent specialist agents — must pass `model: "opus"`. Fixes an invisible source of cross-run variance where VoltAgent agents silently fell through to their frontmatter-declared default model (potentially sonnet or haiku), producing different reasoning depths across otherwise identical runs.
 
 **Anti-groupthink safeguards:**
 - Blind final scoring, private reflection, calibrated skepticism levels (20-60%)
@@ -157,11 +193,12 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 **Output (three files per review):**
 - **Primary report** (`review_panel_report.md`): executive summary, consensus, disagreements (with judge rulings), prioritized action items with epistemic labels ([VERIFIED], [CONSENSUS], [SINGLE-SOURCE], [UNVERIFIED], [DISPUTED])
 - **Process history** (`review_panel_process.md`): verbatim "director's cut" of every agent's output with persona profiles at each entry point — full transparency into the panel's reasoning
-- **Interactive HTML dashboard** (`review_panel_report.html`): filterable/sortable issue cards with severity chips, confidence bars, verification verdict badges; Panel Gallery with avatar cards for every agent; confidence distribution and tier breakdown charts (Tailwind CSS + Chart.js)
+- **Interactive HTML dashboard** (`review_panel_report.html`) with **expandable 10-section issue cards (v2.15)**: each card expands to reveal a nested accordion with 📖 Narrative (full reviewer reasoning), 📄 Code Evidence (Prism.js-highlighted snippets with file:line headers), 👥 Raised by (per-reviewer rating + reasoning), 🔍 Verification Trail (full VR agent output), 💬 Debate (round-by-round transcript), ⚖️ Judge Ruling, 🛠️ Fix Recommendation (proposed change + before/after code + regression test + blast radius + effort), 🔗 Cross-references, 🏷️ Epistemic Tags (with hover tooltips), and 📊 Prior Runs. Plus: deep-link support (`report.html#issue-A1`), keyboard navigation, expand all/collapse all controls, print-friendly `@media print` CSS. Dashboard also includes a filterable/sortable issue list, Panel Gallery with avatar cards for every agent, and confidence/tier/verdict charts (Tailwind CSS + Chart.js + Prism.js via CDN).
 - Scope & limitations disclosure — every report states what the panel cannot evaluate
 
 **Advanced:**
-- VoltAgent integration — maps personas to 127+ specialist agents for deeper domain-specific reviews when installed
+- VoltAgent integration — maps personas to 127+ specialist agents for deeper domain-specific reviews when installed (all launches forced to opus in v2.14)
+- **Multi-Run Union Protocol (v2.14)** — invoke `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions (Run 1: standard base; Run 2: complementary set; Run 3: adversarial-heavy 3 DAs + Correctness Hawk). Phase 16 merges findings by location + bug class, scores stability as `[K/N RUNS]`, uses highest severity when runs disagree, resolves judge divergence. Eliminates the ~30% single-run blind spot documented in the v2.10→v2.14 consistency analysis.
 - Codebase state check — detects worktree/branch divergence to prevent false "missing code" findings
 - Tiered knowledge mining (L0/L1/L2) — scans index lines first, then summaries, then full content only for relevant items
 - Deep research mode — opt-in web research for domain best practices
@@ -214,16 +251,23 @@ Agent Review Panel is grounded in [9 peer-reviewed papers](docs/research-foundat
 
 ## Tests
 
-The project includes a comprehensive test suite (363 tests) using Node.js built-in test runner (zero dependencies):
+The project includes a comprehensive test suite (393 tests) using Node.js built-in test runner (zero dependencies):
 
 ```bash
-npm test                    # run all 363 tests
-npm run test:triggers       # trigger classification (49 prompts)
-npm run test:manifest       # manifest consistency across files
+npm test                    # run all 393 tests
+npm run test:triggers       # trigger classification (55+ prompts)
+npm run test:manifest       # manifest consistency + phase/opus enforcement
+npm run test:eval-suite     # eval suite integrity + v2.14/v2.15 coverage
 npm run test:report         # report structure validation
 npm run test:behavioral     # behavioral assertion framework
 npm run test:golden         # golden-file structural snapshots
 ```
+
+Manifest tests enforce key invariants introduced in v2.14/v2.15:
+- All 16 phases present in SKILL.md (Phase 1 through Phase 16, no decimal numbering)
+- Every `subagent_type:` launch co-occurs with `model: "opus"` (force-opus enforcement)
+- Phase 15.3 spec documents all 10 expandable-card accordion sections
+- Both `SKILL.md` files (root + `skills/agent-review-panel/`) remain byte-identical
 
 ## Companion Skills
 
@@ -243,6 +287,13 @@ Please open an issue to discuss before submitting large PRs.
 
 ## Uninstalling
 
+**If installed via marketplace:**
+```
+/plugin uninstall agent-review-panel@agent-review-panel
+/plugin marketplace remove agent-review-panel
+```
+
+**If installed via manual clone:**
 ```bash
 rm -rf ~/.claude/skills/agent-review-panel
 ```
@@ -253,6 +304,8 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history. See [ROADMAP.md](
 
 | Version | Highlights |
 |---------|------------|
+| **v2.15** | Expandable 10-section issue cards in HTML dashboard (narrative, code evidence, debate, judge ruling, fix, cross-refs, prior runs); Prism.js syntax highlighting; deep-linking; keyboard nav; print-friendly |
+| **v2.14** | Phase 2 Data Flow Trace (composition bug detector, 3 tiers); Multi-Run Union Protocol + Phase 16 Merge; force `model: "opus"` on all launches; integer phase renumbering (1–16) |
 | v2.13 | Persona profiles in process history + Panel Gallery in HTML dashboard |
 | v2.12 | Triple output: primary report + process history + interactive HTML dashboard |
 | v2.11 | Verification round: tiered (Light/Standard/Deep) persona-matched agents per dispute |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,9 @@ A living document mapping academic research and open-source projects to skill fe
 
 ---
 
-## Already Incorporated (v1–v2.13)
+## Already Incorporated (v1–v2.15)
 
-These foundations form the core architecture. Research adopted in v1–v2.5; structural optimisation in v2.6; verification round in v2.11.
+These foundations form the core architecture. Research adopted in v1–v2.5; structural optimisation in v2.6; verification round in v2.11; triple output + persona profiles in v2.12–v2.13; Data Flow Trace + Multi-Run Union + Force Opus in v2.14; expandable issue cards in v2.15.
 
 | Source | What We Took | Version |
 |--------|-------------|---------|
@@ -16,6 +16,11 @@ These foundations form the core architecture. Research adopted in v1–v2.5; str
 | **MachineSoM** (zjunlp/MachineSoM, ACL 2024) | Private reflection rounds, conformity tracking (tf/ft/tt/ff) | v2 |
 | **DebateLLM** (instadeepai/DebateLLM) | Agreement intensity modulation, round summarization, judge-mediated convergence | v2 |
 | **MiroFish** ([666ghj/MiroFish](https://github.com/666ghj/MiroFish)) | Heterogeneous agent personalities matched to task characteristics; influenced auto-persona detection (v2.1) and persona-matched verification agents (v2.11) | v2.1, v2.11 |
+| **Meta Agentic Code Reasoning** (arXiv:2603.01896, 2026) | Semi-formal certificate prompting — INPUT_SCHEMA → TRANSFORM → OUTPUT_SCHEMA → COMPOSITION_CHECK per function; 78%→93% accuracy gain. Adopted as the core reasoning template for the Phase 2 Data Flow Tracer. | v2.14 |
+| **LLMDFA** (NeurIPS 2024) | Few-shot chain-of-thought dataflow facts per function, then compose across call graph. Adopted as the mental model for tier-based path traversal in Phase 2. | v2.14 |
+| **RepoAudit** (ICML 2025) | Demand-driven exploration with memory — fetch function definitions only when encountered on the path. Informs Phase 2's orchestrator path-ranking heuristic. | v2.14 |
+| **BugLens** (ASE 2025) | Static-analyzer-plus-LLM pattern: use high-recall candidate finder first, then LLM for feasibility validation (7x false positive reduction). Informs Phase 2 violation flagging → Phase 3 reviewer validation. | v2.14 |
+| **ZeroFalse** (arXiv:2510.02534, 2025) | Domain-specialized prompting with dynamic path reconstruction (F1 0.955). Informs the Phase 2 per-function certificate structure. | v2.14 |
 
 ### Key findings from each
 
@@ -264,6 +269,12 @@ Techniques evaluated and rejected for our use case.
 | v2.7 | 2026-03-26 | Severity verification, temporal scope, defect classification |
 | v2.8 | 2026-03-26 | Panel-reviewed: severity dampening, coverage check, verify-before-claim, auto mode |
 | v2.9 | 2026-03-29 | VoltAgent specialist agent integration (127+ agents, 10 families) |
+| v2.10 | 2026-03-30 | Codebase state check — prevents false "missing code" findings in worktrees |
+| v2.11 | 2026-04-03 | Verification round — Phase 4.8 tier assignment + Phase 4.9 targeted verification agents (persona-matched to claim type, tiered Light/Standard/Deep budgets) |
+| v2.12 | 2026-04-03 | Triple output format — primary markdown report + process history + interactive HTML dashboard |
+| v2.13 | 2026-04-03 | Persona profiles surfaced in process history (Registry section, inline blocks) and HTML dashboard (Panel Gallery with avatar cards, filter-by-reviewer) |
+| v2.14 | 2026-04-07 | **Phase 2 Data Flow Trace** (composition bug detector with Standard/Thorough/Exhaustive tiers), **Multi-Run Union Protocol** + Phase 16 Merge, **Force `model: "opus"`** on all subagent launches, integer phase renumbering (1–16 with sub-phases 12a/12b + 15.1/15.2/15.3) |
+| v2.15 | 2026-04-07 | **Expandable 10-section issue cards** in Phase 15.3 HTML dashboard (narrative, code evidence, debate, judge ruling, fix recommendation, cross-references, prior runs), deep-linking, keyboard nav, expand all/collapse all, print-friendly CSS, Prism.js syntax highlighting (CDN) |
 
 ---
 


### PR DESCRIPTION
## Summary

- **README:** canonical marketplace install (\`/plugin marketplace add wan-huiyan/agent-review-panel\` + \`/plugin install agent-review-panel@agent-review-panel\`) + v2.14/v2.15 features + updated phase table (16 integer phases + multi-run) + test count (363 → 393)
- **CHANGELOG:** added entries for v2.11, v2.12, v2.13, v2.14, v2.15 (changelog had stopped at v2.10 — 5 minor versions of drift)
- **ROADMAP:** added 5 new research sources adopted in v2.14's Data Flow Trace + extended Version History table from v2.9 → v2.15
- **HOW_WE_BUILT_THIS:** added Step 17 (v2.14) and Step 18 (v2.15) chronicles with 7 new lessons (30-36) + updated File Inventory

Zero SKILL.md or test changes — pure docs update. All 393 tests still pass.

## The marketplace install gap

You noticed: *\"our recommended install doesn't include marketplace plugin anymore\"* — and you were right. The repo has had working \`.claude-plugin/marketplace.json\` and \`.claude-plugin/plugin.json\` manifests since v2.9, but the README only ever documented \`git clone ~/.claude/skills/agent-review-panel\` — which works but bypasses the marketplace system entirely.

### What I verified

I queried the claude-code-guide agent to get the canonical install syntax from the latest Claude Code docs:

1. **The canonical install command** is \`/plugin marketplace add wan-huiyan/agent-review-panel\` followed by \`/plugin install agent-review-panel@agent-review-panel\` (plugin@marketplace — both happen to be named \`agent-review-panel\`).
2. **Marketplace install auto-activates the skill.** No manual symlinking needed. Claude Code downloads the plugin to its cache, loads the skill, and the trigger phrases activate immediately.
3. **Manual clone still works** but doesn't use the manifests. \`git clone\` is kept as a fallback for development, forking, and air-gapped environments.
4. **CLI equivalents exist** (\`claude plugin marketplace add ...\`, \`claude plugin install ...\`) for users who prefer shell commands.
5. **\`--plugin-dir ./path\`** is the canonical way to test a local clone as a plugin without publishing.

Source: [Discover and install prebuilt plugins](https://code.claude.com/docs/en/discover-plugins.md) and [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces.md).

## Changes

### README.md (+85 lines / -28)

- **Quick Start install** updated to marketplace flow
- **Installation section** fully rewritten: marketplace (recommended) → manual clone (development) → Claude Code version requirement → Cursor (experimental). The marketplace path is now the primary recommendation with a short \"Why the marketplace path?\" explanation. Git-clone is kept as a fallback.
- **How It Works phase table** rewritten to show 16 integer phases (v2.14 renumbering) with Phase 2 (Data Flow Trace) and Phase 16 (Multi-Run Merge) highlighted
- **Features section** extended with v2.14 bullets (Data Flow Trace 3 tiers, Force Opus, Multi-Run Union) and v2.15 bullets (expandable 10-section cards with full feature list)
- **Tests section:** 363 → 393 tests, added \`test:eval-suite\` script, documented new manifest invariants (16 phases, opus enforcement, 10-section spec coverage, byte-identical mirror)
- **Uninstalling section** extended to cover both marketplace and manual-clone paths
- **Version History table** extended with v2.14 and v2.15 entries at the top

### CHANGELOG.md (+57 lines / 0)

Added entries for v2.11, v2.12, v2.13, v2.14, v2.15. Each follows the existing Added/Changed/Motivation structure. The changelog had stopped at v2.10 — 5 minor versions of drift.

- **v2.15:** Expandable 10-section issue cards, Phase 15.2 as Reference Input, deep-linking, keyboard nav, print styles, Prism.js CDN
- **v2.14:** Phase 2 Data Flow Trace, Multi-Run Union + Phase 16, Force opus, integer phase renumbering
- **v2.13:** Persona profiles in process history + HTML Panel Gallery
- **v2.12:** Triple output format (markdown + process history + HTML)
- **v2.11:** Verification round (Phase 4.8 tier assignment + Phase 4.9 targeted verification agents)

### ROADMAP.md (+15 lines / -5)

- Added 5 new research sources to the \"Already Incorporated\" table — all adopted in v2.14's Data Flow Trace: Meta Agentic Code Reasoning (2026), LLMDFA (NeurIPS 2024), RepoAudit (ICML 2025), BugLens (ASE 2025), ZeroFalse (2025)
- Extended the Version History table from v2.9 → v2.15 (6 new rows)
- Updated the intro blurb (\"v1–v2.13\" → \"v1–v2.15\") with a one-line v2.12–v2.15 theme summary

### HOW_WE_BUILT_THIS.md (+170 lines / -4)

Added two new chronicle steps with detailed motivation, implementation, testing, and lessons:

**Step 17: Data Flow Trace + Multi-Run Union + Force Opus (v2.14)**

Motivation traced to the Schuh consistency analysis (two identical runs, 30% finding overlap, each missing a different P0). Four root causes documented. Implementation details for each feature. 4 new lessons:

- **Lesson 30:** Independent test coverage lags silently. The force-opus bug lived undetected for 6 minor releases because no test covered the invariant.
- **Lesson 31:** Composition bugs live at function boundaries. Data Flow Tracer is the biggest coverage improvement since the Completeness Auditor (v2.0).
- **Lesson 32:** Content classification non-determinism cascades. One Phase 1 decision propagates through the entire pipeline.
- **Lesson 33:** Hand-in-hand data enrichment + rendering spec is required to prevent agent compliance drift. This directly motivated v2.15's required-but-possibly-empty fields rule.

**Step 18: Expandable Issue Cards in Phase 15.3 (v2.15)**

Motivation from the nice-shtern compliance gap. Implementation of schema extension, Phase 15.2 as Reference Input, the 10-section accordion, card-level UX features, Prism.js dependency. Sample regenerated output stats. 3 new lessons:

- **Lesson 34:** Required-but-possibly-empty fields beat optional fields for forcing compliance. Agents reliably choose \"skip rich UI\" over \"populate rich UI with empty data\" — making fields required with empty-placeholder rendering removes the choice.
- **Lesson 35:** Cross-phase data routing is an underappreciated fix. Phase 15.2 had all the data; Phase 15.3 just needed permission to see it. Before assuming you need new data generation, check whether existing data is being thrown away at phase boundaries.
- **Lesson 36:** Native \`<details>\` is the right primitive for expandable UI in self-contained HTML. Zero JavaScript needed for expand/collapse, works in print media queries, keyboard-accessible by default.

**File Inventory updated** with current structure: SKILL.md v2.15 (~1220 lines), all 6 test files listed, docs/ directory with research-foundations.md + hero-flow.svg + demo.gif, CHANGELOG.md + package.json + eval-suite.json (60+ entries).

## Test plan

- [x] \`npm test\` — all 393 tests pass (same as v2.15 merge commit, no manifest invariants broken)
- [x] No SKILL.md or test file changes — pure prose updates
- [x] All docs reference v2.15 consistently
- [x] Install commands match the .claude-plugin/marketplace.json contents
- [x] Phase table in README matches the 16 integer phases in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)