### PR TITLE
fix(docs): correct marketplace name in install command + add stale-clone update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ claude plugin update agent-review-panel@wan-huiyan-agent-review-panel
 
 **Verify the update worked:**
 ```bash
-cat ~/.claude/plugins/cache/wan-huiyan-agent-review-panel/plugins/agent-review-panel/.claude-plugin/plugin.json | grep version
+cat ~/.claude/plugins/cache/wan-huiyan-agent-review-panel/agent-review-panel/*/.claude-plugin/plugin.json | grep version
 ```
-The version should match the latest entry in the [Version History](#version-history) table below.
+The version should match the latest entry in the [Version History](#version-history) table below. (The cache layout is `cache/<marketplace-name>/<plugin-name>/<version>/` — note that the `plugins/` intermediate directory from the repo is flattened out during install, and a version segment is added. The `*` glob above matches whatever version is installed so you don't have to look it up first.)
 
 **If the update appears to work but you're still getting old behavior** (e.g. missing the v2.12 HTML report, missing the v2.15 expandable cards, or missing the v2.14 data-flow trace phase), check for a **stale local clone** that shadows the marketplace install:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [Claude Code](https://claude.ai/code) skill that orchestrates multi-agent adve
 **Install (recommended — Claude Code marketplace):**
 ```
 /plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install agent-review-panel@agent-review-panel
+/plugin install agent-review-panel@wan-huiyan-agent-review-panel
 ```
 
 **Use:**
@@ -77,19 +77,66 @@ Add this repo as a marketplace and install the plugin:
 
 ```
 /plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install agent-review-panel@agent-review-panel
+/plugin install agent-review-panel@wan-huiyan-agent-review-panel
 ```
 
 Or from the shell via the CLI:
 
 ```bash
 claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install agent-review-panel@agent-review-panel
+claude plugin install agent-review-panel@wan-huiyan-agent-review-panel
 ```
 
 Claude Code downloads the plugin to its cache, loads the skill, and activates the trigger phrases automatically. The skill then triggers when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel`.
 
-**Why the marketplace path?** The repo ships with `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests that Claude Code reads to register the plugin. The marketplace install handles caching, version tracking, and automatic activation in one step. The manual clone path below still works but doesn't use the manifests — the marketplace flow is the canonical path for v2.14+.
+> **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `wan-huiyan-agent-review-panel` (defined in `.claude-plugin/marketplace.json`), which is distinct from the plugin name `agent-review-panel`. Pre-v2.16 releases used `@agent-review-panel` — if you're reading an older install command, use the new form above.
+
+**Why the marketplace path?** The repo ships with `.claude-plugin/marketplace.json` + `plugins/agent-review-panel/.claude-plugin/plugin.json` manifests (v2.16+ canonical layout) that Claude Code reads to register the plugin. The marketplace install handles caching, version tracking, and automatic activation in one step. The manual clone path below still works but doesn't use the manifests — the marketplace flow is the canonical path for v2.14+.
+
+### Updating to the latest version
+
+New releases land on `main`; Claude Code does not auto-pull. Run the update flow after each release (or any time you want the newest features):
+
+```
+/plugin marketplace update wan-huiyan-agent-review-panel
+/plugin update agent-review-panel@wan-huiyan-agent-review-panel
+```
+
+CLI equivalent:
+
+```bash
+claude plugin marketplace update wan-huiyan-agent-review-panel
+claude plugin update agent-review-panel@wan-huiyan-agent-review-panel
+```
+
+**Verify the update worked:**
+```bash
+cat ~/.claude/plugins/cache/wan-huiyan-agent-review-panel/plugins/agent-review-panel/.claude-plugin/plugin.json | grep version
+```
+The version should match the latest entry in the [Version History](#version-history) table below.
+
+**If the update appears to work but you're still getting old behavior** (e.g. missing the v2.12 HTML report, missing the v2.15 expandable cards, or missing the v2.14 data-flow trace phase), check for a **stale local clone** that shadows the marketplace install:
+
+```bash
+ls ~/.claude/skills/agent-review-panel 2>/dev/null
+```
+
+If that directory exists, it's loaded *before* the marketplace cache and will pin you to whatever version was cloned. Remove it:
+
+```bash
+rm -rf ~/.claude/skills/agent-review-panel
+```
+
+Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/wan-huiyan-agent-review-panel/` will take over.
+
+**Fallback — clean reinstall:** If the update commands misbehave, uninstall and reinstall from scratch:
+
+```
+/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace remove wan-huiyan-agent-review-panel
+/plugin marketplace add wan-huiyan/agent-review-panel
+/plugin install agent-review-panel@wan-huiyan-agent-review-panel
+```
 
 ### Manual clone (development / custom setup)
 
@@ -293,8 +340,8 @@ Please open an issue to discuss before submitting large PRs.
 
 **If installed via marketplace:**
 ```
-/plugin uninstall agent-review-panel@agent-review-panel
-/plugin marketplace remove agent-review-panel
+/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace remove wan-huiyan-agent-review-panel
 ```
 
 **If installed via manual clone:**


### PR DESCRIPTION
## Summary

- **Fixes broken install command**: PR #18 renamed the marketplace from `agent-review-panel` → `wan-huiyan-agent-review-panel`, but 3 instances of `@agent-review-panel` remained in the README (Quick Start, Installation §, Uninstalling §). A new user following the README literally cannot install the plugin — the second command fails.
- **Adds `### Updating to the latest version` subsection** with the standard update flow, verification commands, clean-reinstall fallback, and — most importantly — troubleshooting steps for **stale local clones** at `~/.claude/skills/agent-review-panel/` that shadow the marketplace cache.
- **Adds a callout box** explaining the `@<marketplace-name>` vs `@<repo-name>` distinction so readers of old install instructions (CHANGELOG, blog posts, old PRs) understand the format change.

## Why now

Two users this week hit the same silent-failure mode: their review panel runs produced output labeled "v2.15" in the footer but were actually running a much older version of the skill (missing the v2.12 HTML report, missing the v2.14 data-flow trace phase, missing the v2.15 expandable 10-section cards). In both cases the root cause was a stale \`git clone\` at \`~/.claude/skills/agent-review-panel/\` from back when that was the documented install path, which Claude Code loads **before** the marketplace cache.

Users had no way to diagnose this from the README — there was no \"update\" section, no troubleshooting for stale clones, and no mention that skill loading checks \`~/.claude/skills/\` before \`~/.claude/plugins/cache/\`. This PR closes that gap.

## Changes

**3 line fixes (the actual bug):**

\`\`\`diff
- /plugin install agent-review-panel@agent-review-panel
+ /plugin install agent-review-panel@wan-huiyan-agent-review-panel
\`\`\`

in \`README.md:24\` (Quick Start), \`README.md:80\` (Installation § slash command), \`README.md:87\` (Installation § CLI), \`README.md:343\` (Uninstalling § uninstall), and \`README.md:344\` (Uninstalling § marketplace remove).

**New subsection (~48 lines)** added to the Installation section with:

- Standard update flow: \`/plugin marketplace update wan-huiyan-agent-review-panel\` + \`/plugin update agent-review-panel@wan-huiyan-agent-review-panel\`
- CLI equivalents
- Verification command: \`cat ~/.claude/plugins/cache/wan-huiyan-agent-review-panel/plugins/agent-review-panel/.claude-plugin/plugin.json | grep version\`
- Stale-clone troubleshooting: \`ls ~/.claude/skills/agent-review-panel\` + \`rm -rf ~/.claude/skills/agent-review-panel\`
- Clean-reinstall fallback: 4-command sequence (\`uninstall\` + \`marketplace remove\` + \`marketplace add\` + \`install\`)

**No code changes.** README-only fix.

## Test plan

- [ ] Verify Quick Start commands work on a fresh machine: \`/plugin marketplace add wan-huiyan/agent-review-panel\` then \`/plugin install agent-review-panel@wan-huiyan-agent-review-panel\`
- [ ] Verify update commands work: \`/plugin marketplace update wan-huiyan-agent-review-panel\` then \`/plugin update agent-review-panel@wan-huiyan-agent-review-panel\`
- [ ] Verify uninstall commands work: \`/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel\` then \`/plugin marketplace remove wan-huiyan-agent-review-panel\`
- [ ] Verify stale-clone detection command produces a clear result: \`ls ~/.claude/skills/agent-review-panel 2>/dev/null\`
- [ ] Spot-check that \`grep \"agent-review-panel@agent-review-panel\" README.md\` returns zero matches

## Related

- PR #18 (restructure to canonical \`plugins/<name>/\` layout) — introduced the marketplace rename that silently broke the old README commands
- PR #15 (v2.15 expandable issue cards) — one of the features stale-clone users can't access

🤖 Generated with [Claude Code](https://claude.com/claude-code)