### PR TITLE
test: add 4 cross-version consistency assertions to prevent silent drift

### DIFF
--- a/tests/manifest-consistency.test.mjs
+++ b/tests/manifest-consistency.test.mjs
@@ -219,6 +219,18 @@ describe("Manifest consistency", () => {
         );
       });
 
+      it("version matches plugin.json version", () => {
+        // Prevents silent drift where plugin.json is bumped (e.g. by a
+        // plugin-restructure PR) but eval-suite.json is forgotten. Caught
+        // by PR #20's dogfooding after PR #18 left eval-suite at 2.15.0
+        // while plugin.json was already at 2.16.0.
+        assert.equal(
+          files.evalSuite.version,
+          files.pluginJson.version,
+          `eval-suite.json version "${files.evalSuite.version}" must match plugin.json version "${files.pluginJson.version}"`
+        );
+      });
+
       if (files.evalSuite.triggers) {
         it("has triggers array with entries", () => {
           assert.ok(files.evalSuite.triggers.length > 0, "triggers must not be empty");
@@ -287,6 +299,22 @@ describe("Manifest consistency", () => {
           "package.json must have a test script"
         );
       });
+
+      if (files.packageJson.version) {
+        it("version matches plugin.json version", () => {
+          // Prevents silent drift where plugin.json is bumped (e.g. by a
+          // plugin-restructure PR) but package.json is forgotten. Caught
+          // during PR #20's dogfooding after PR #18 left package.json at
+          // 2.15.0 while plugin.json was already at 2.16.0. This test only
+          // fires if package.json has a version field at all (some internal
+          // tooling repos omit it).
+          assert.equal(
+            files.packageJson.version,
+            files.pluginJson.version,
+            `package.json version "${files.packageJson.version}" must match plugin.json version "${files.pluginJson.version}"`
+          );
+        });
+      }
     });
   }
 
@@ -301,6 +329,62 @@ describe("Manifest consistency", () => {
         const fm = extractFrontmatter(files.rootSkillMd);
         assert.equal(fm.name, SKILL_NAME);
       });
+
+      // ---------------------------------------------------------------------
+      // Cross-version consistency: SKILL.md body version references must
+      // match plugin.json version. Catches the silent drift documented in
+      // PR #20 where PR #18 bumped plugin.json to 2.16.0 but SKILL.md
+      // still read "# Agent Review Panel v2.15" and the HTML footer
+      // instruction still said "Agent Review Panel v2.15".
+      //
+      // Convention: version references in SKILL.md body use v<major>.<minor>
+      // format (no patch segment). We parse plugin.json's semver and
+      // assert that every "Agent Review Panel v<major>.<minor>" string in
+      // SKILL.md matches plugin.json's major.minor.
+      // ---------------------------------------------------------------------
+      const semverMatch = files.pluginJson?.version?.match(/^(\d+)\.(\d+)\.\d+/);
+      if (semverMatch) {
+        const [, pluginMajor, pluginMinor] = semverMatch;
+        const expectedVersionTag = `v${pluginMajor}.${pluginMinor}`;
+
+        it("H1 header version matches plugin.json major.minor", () => {
+          // Extract the first line matching "# Agent Review Panel v<X>.<Y>"
+          const headerMatch = files.rootSkillMd.match(
+            /^# Agent Review Panel v(\d+)\.(\d+)/m
+          );
+          assert.ok(
+            headerMatch,
+            "SKILL.md must contain an H1 header matching '# Agent Review Panel v<major>.<minor>'"
+          );
+          const [, headerMajor, headerMinor] = headerMatch;
+          assert.equal(
+            `${headerMajor}.${headerMinor}`,
+            `${pluginMajor}.${pluginMinor}`,
+            `SKILL.md H1 header reads "v${headerMajor}.${headerMinor}" but plugin.json is "${files.pluginJson.version}" — expected "${expectedVersionTag}"`
+          );
+        });
+
+        it("HTML footer instruction version matches plugin.json major.minor", () => {
+          // The Phase 15.3 HTML report agent is instructed to render a
+          // footer with the product version. This string must track
+          // plugin.json so users' rendered reports show a truthful
+          // version number and stale skills can be diagnosed by
+          // comparing footer against plugin.json.
+          const footerMatch = files.rootSkillMd.match(
+            /HTML footer should read "Agent Review Panel v(\d+)\.(\d+)/
+          );
+          assert.ok(
+            footerMatch,
+            "SKILL.md must contain a Phase 15.3 footer instruction matching 'HTML footer should read \"Agent Review Panel v<major>.<minor>'"
+          );
+          const [, footerMajor, footerMinor] = footerMatch;
+          assert.equal(
+            `${footerMajor}.${footerMinor}`,
+            `${pluginMajor}.${pluginMinor}`,
+            `SKILL.md HTML footer instruction reads "v${footerMajor}.${footerMinor}" but plugin.json is "${files.pluginJson.version}" — expected "${expectedVersionTag}"`
+          );
+        });
+      }
 
       if (files.nestedSkillMd) {
         it("nested skills/ SKILL.md has matching frontmatter name", () => {


### PR DESCRIPTION
## Summary

Adds 4 new assertions to `manifest-consistency.test.mjs` that catch the silent version drift surfaced during PR #20's dogfooding. Had these tests existed before PR #18, the drift would have been caught in that PR's CI run instead of being discovered weeks later.

**No production code changes.** Tests are additive only; no existing assertions modified. 308 tests pass (was 304; delta is exactly the 4 new tests).

## What was silently drifting

After PR #18 bumped `plugin.json` from 2.15.0 to 2.16.0, the following files were **left at 2.15.0** without any test catching it:

| File | Drifted value | Current (post-PR #20 sweep) |
|---|---|---|
| `package.json` | `"version": "2.15.0"` | `"version": "2.16.0"` |
| `eval-suite.json` | `"version": "2.15.0"` | `"version": "2.16.0"` |
| `plugins/agent-review-panel/SKILL.md` line 34 | `# Agent Review Panel v2.15` | `# Agent Review Panel v2.16` |
| `plugins/agent-review-panel/SKILL.md` line 1076 | `HTML footer should read "Agent Review Panel v2.15"` | `"v2.16"` |

PR #20 fixed all four manually. This PR ensures it never happens again.

## The 4 new assertions

All implemented as conditional `it()` blocks that only fire when the relevant file/field exists (the template pattern used throughout this file):

### 1. `eval-suite.json > version matches plugin.json version`
Already checked `eval-suite.json` HAS a version field, but never cross-referenced it.

### 2. `package.json > version matches plugin.json version`
Same gap. Wrapped in `if (files.packageJson.version)` so it skips cleanly for repos whose `package.json` omits version.

### 3. `SKILL.md > H1 header version matches plugin.json major.minor`
Parses `# Agent Review Panel v<major>.<minor>` from the first H1 in SKILL.md and asserts the major.minor pair matches `plugin.json`'s semver major.minor. Uses major.minor (not full semver) because the header convention is `v2.16`, not `v2.16.0` — patch versions don't appear in the header.

### 4. `SKILL.md > HTML footer instruction version matches plugin.json`
Parses `HTML footer should read "Agent Review Panel v<major>.<minor>` from SKILL.md's Phase 15.3 output spec. This instruction string tells the Phase 15.3 HTML agent what to render in every generated report footer — if it drifts, every HTML report silently lies about the product version. That exact bug led users to diagnose their skill version as "v2.15" when it was actually v2.14 or older (see project memory `reference_skill_version_diagnosis.md`).

## Red-test validation (performed before commit)

To prove the assertions actually catch drift, I deliberately introduced drift and ran the tests:

```bash
# Drift plugin.json version
sed -i '' 's/"version": "2.16.0"/"version": "9.9.9"/' plugins/agent-review-panel/.claude-plugin/plugin.json

# Run manifest tests
npm run test:manifest
```

**Output:** all 5 version-matching tests failed simultaneously with clear error messages:

```
not ok - marketplace.json > plugin version matches plugin.json version
not ok - eval-suite.json > version matches plugin.json version
not ok - package.json > version matches plugin.json version
not ok - SKILL.md > H1 header version matches plugin.json major.minor
not ok - SKILL.md > HTML footer instruction version matches plugin.json major.minor
```

(4 new + 1 pre-existing marketplace assertion, which confirms the red test is catching drift the same way the existing infrastructure does.)

After restoring `plugin.json`, all tests pass again. ✅

## Error messages are clear and actionable

Each assertion includes a helpful error message that identifies both sides of the mismatch:

- _`package.json version "2.15.0" must match plugin.json version "2.16.0"`_
- _`eval-suite.json version "2.15.0" must match plugin.json version "2.16.0"`_
- _`SKILL.md H1 header reads "v2.15" but plugin.json is "2.16.0" — expected "v2.16"`_
- _`SKILL.md HTML footer instruction reads "v2.15" but plugin.json is "2.16.0" — expected "v2.16"`_

So when a future contributor runs `npm test` after bumping `plugin.json`, they'll see exactly which files they forgot to update, not a cryptic `AssertionError: 2.15.0 !== 2.16.0`.

## Test plan

- [x] All 4 new assertions pass on current main (`npm run test:manifest` → 22/22 pass)
- [x] Full test suite passes (`npm test` → 308/308 across 53 suites)
- [x] Red-test validation: drift `plugin.json` → 5 failures → restore → 0 failures
- [x] Error messages include both sides of the mismatch
- [x] Assertions skip gracefully for repos missing the relevant files (conditional `if (files.X)` wrappers)

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `tests/manifest-consistency.test.mjs` | +84 | 4 new cross-version consistency assertions |

## Related

- PR #18 (`147f628`) — plugin restructure that bumped plugin.json to 2.16.0 but left package.json, eval-suite.json, and SKILL.md at 2.15.0 (the drift these tests would have caught)
- PR #20 (`c26ee62`) — swept the drifted versions manually and documented the gap; this PR codifies the invariant as an automated test

🤖 Generated with [Claude Code](https://claude.com/claude-code)