### PR TITLE
feat(bundle): rename marketplace to 'plugin' + bundle plan-review-integrator + multi-plugin tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "wan-huiyan-agent-review-panel",
-  "description": "Single-plugin marketplace for agent-review-panel — Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research.",
+  "name": "plugin",
+  "description": "Claude Code plugin marketplace for multi-agent review workflows — bundles agent-review-panel (panel-based code/plan review) and plan-review-integrator (integrate review findings into implementation plans). The full review→integrate pipeline in one marketplace.",
   "owner": {
     "name": "wan-huiyan"
   },
@@ -9,8 +9,14 @@
     {
       "name": "agent-review-panel",
       "source": "./plugins/agent-review-panel",
-      "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research.",
-      "version": "2.16.0"
+      "version": "2.16.1",
+      "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research."
+    },
+    {
+      "name": "plan-review-integrator",
+      "source": "./plugins/plan-review-integrator",
+      "version": "2.0.0",
+      "description": "Integrate structured review panel findings into implementation plan documents with full traceability. Pairs with agent-review-panel as the integrate stage of a review→integrate pipeline."
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Agent Review Panel.
 
+## [2.16.1] — 2026-04-08
+
+### Changed — Marketplace bundle (PR #22)
+- **Renamed marketplace** `wan-huiyan-agent-review-panel` → `plugin`. Install command is now `/plugin install agent-review-panel@plugin` (was `@wan-huiyan-agent-review-panel`).
+- **Bundled `plan-review-integrator` v2.0.0** as a second plugin in the same marketplace. The full review→integrate pipeline now ships from one repo. The old standalone `wan-huiyan/plan-review-integrator` repo is archived in favor of `/plugin install plan-review-integrator@plugin`.
+- **Per-plugin `eval-suite.json`** — moved from repo root to `plugins/agent-review-panel/eval-suite.json` and added `plugins/plan-review-integrator/eval-suite.json`. Tests discover eval-suites under each plugin's directory; the multi-plugin manifest test iterates all plugins independently.
+- **Refactored `tests/manifest-consistency.test.mjs` and `tests/trigger-classification.test.mjs`** to multi-plugin discovery. Each plugin's plugin.json, eval-suite.json, SKILL.md, and marketplace entry are validated independently. Red-test validation: drifting either plugin's `plugin.json` version produces ≥3 independent failures (eval-suite cross-version, marketplace cross-version, SKILL.md H1 header).
+- **Cross-version assertions from PR #21** generalized for multi-plugin: the H1 header check (`# <title> v<major>.<minor>`) and HTML footer check are now run per-plugin and skip cleanly when a plugin's SKILL.md doesn't carry that pattern (e.g. plan-review-integrator has no HTML footer instruction).
+- **Breaking change for existing installs.** Anyone who installed via `wan-huiyan-agent-review-panel` or `wan-huiyan-plan-review-integrator` must uninstall + reinstall under the new `@plugin` marketplace name. See README "Migration from previous marketplaces" for the exact commands.
+
+### Bumped
+- `plugins/agent-review-panel/.claude-plugin/plugin.json`: 2.16.0 → 2.16.1
+- `plugins/agent-review-panel/eval-suite.json`: 2.16.0 → 2.16.1
+- `package.json`: 2.16.0 → 2.16.1
+- `plugins/plan-review-integrator/.claude-plugin/plugin.json`: 1.4.0 → 2.0.0 (major bump marks marketplace move; plugin behavior unchanged)
+- `plugins/plan-review-integrator/eval-suite.json`: 1.0.0 → 2.0.0 (was upstream-drifted from plugin.json's 1.4.0 since the file's first commit; brought into lockstep here)
+- `plugins/plan-review-integrator/SKILL.md`: header `v1.3` → `v2.0` (matched plugin.json)
+- `.claude-plugin/marketplace.json`: top-level `name` renamed; plugin entries updated; new `plan-review-integrator` entry added
+
 ## [2.16.0] — 2026-04-07
 
 ### Changed — Plugin layout (PR #18)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ A [Claude Code](https://claude.ai/code) **plugin** that orchestrates multi-agent
 **Install (recommended — Claude Code marketplace):**
 ```
 /plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install agent-review-panel@wan-huiyan-agent-review-panel
+/plugin install agent-review-panel@plugin
+/plugin install plan-review-integrator@plugin    # optional companion: integrate review findings into plans
 ```
+
+> The marketplace bundles **two plugins**: `agent-review-panel` (this project) and `plan-review-integrator` (the review→integrate companion). See [Bundled plugins](#bundled-plugins) below.
 
 **Use:**
 ```
@@ -99,12 +102,12 @@ The two install commands are shown in [Quick Start](#quick-start) above. This se
 
 ```bash
 claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install agent-review-panel@wan-huiyan-agent-review-panel
+claude plugin install agent-review-panel@plugin
 ```
 
 Claude Code downloads the plugin to its cache, loads the `agent-review-panel` skill inside it, and activates the trigger phrases automatically. The plugin then activates when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel`.
 
-> **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `wan-huiyan-agent-review-panel` (defined in `.claude-plugin/marketplace.json`), which is distinct from the plugin name `agent-review-panel`. Pre-v2.16 releases used `@agent-review-panel` — if you're reading an older install command, use the new form above.
+> **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `plugin` (defined in `.claude-plugin/marketplace.json`), which is distinct from the plugin name `agent-review-panel`. Pre-v2.16.1 releases used `@wan-huiyan-agent-review-panel`; pre-v2.16 used `@agent-review-panel`. If you installed under an older marketplace name, see the [Migration](#migration-from-previous-marketplaces) section to switch.
 
 **Why the marketplace path?** The repo ships with `.claude-plugin/marketplace.json` + `plugins/agent-review-panel/.claude-plugin/plugin.json` manifests (v2.16+ canonical layout) that Claude Code reads to register the plugin. The marketplace install handles caching, version tracking, and automatic activation in one step. The manual clone path below still works but doesn't use the manifests — the marketplace flow is the canonical path for v2.14+.
 
@@ -113,20 +116,20 @@ Claude Code downloads the plugin to its cache, loads the `agent-review-panel` sk
 New releases land on `main`; Claude Code does not auto-pull. Run the update flow after each release (or any time you want the newest features):
 
 ```
-/plugin marketplace update wan-huiyan-agent-review-panel
-/plugin update agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace update plugin
+/plugin update agent-review-panel@plugin
 ```
 
 CLI equivalent:
 
 ```bash
-claude plugin marketplace update wan-huiyan-agent-review-panel
-claude plugin update agent-review-panel@wan-huiyan-agent-review-panel
+claude plugin marketplace update plugin
+claude plugin update agent-review-panel@plugin
 ```
 
 **Verify the update worked:**
 ```bash
-cat ~/.claude/plugins/cache/wan-huiyan-agent-review-panel/agent-review-panel/*/.claude-plugin/plugin.json | grep version
+cat ~/.claude/plugins/cache/plugin/agent-review-panel/*/.claude-plugin/plugin.json | grep version
 ```
 The version should match the latest entry in the [Version History](#version-history) table below. (The cache layout is `cache/<marketplace-name>/<plugin-name>/<version>/` — note that the `plugins/` intermediate directory from the repo is flattened out during install, and a version segment is added. The `*` glob above matches whatever version is installed so you don't have to look it up first.)
 
@@ -142,15 +145,15 @@ If that directory exists, it's loaded *before* the marketplace cache and will pi
 rm -rf ~/.claude/skills/agent-review-panel
 ```
 
-Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/wan-huiyan-agent-review-panel/` will take over.
+Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/plugin/` will take over.
 
 **Fallback — clean reinstall:** If the update commands misbehave, uninstall and reinstall from scratch:
 
 ```
-/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
-/plugin marketplace remove wan-huiyan-agent-review-panel
+/plugin uninstall agent-review-panel@plugin
+/plugin marketplace remove plugin
 /plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install agent-review-panel@wan-huiyan-agent-review-panel
+/plugin install agent-review-panel@plugin
 ```
 
 ### Manual clone (development / custom setup)
@@ -335,11 +338,47 @@ Manifest tests enforce key invariants introduced in v2.14/v2.15:
 - Phase 15.3 spec documents all 10 expandable-card accordion sections
 - The canonical `SKILL.md` lives at `plugins/agent-review-panel/SKILL.md` (v2.16+ plugin layout, see PR #18)
 
-## Companion Skills
+## Bundled plugins
 
-| Skill | What It Does | When to Use |
-|---|---|---|
-| [plan-review-integrator](https://github.com/wan-huiyan/plan-review-integrator) | Takes review panel output and integrates findings into an implementation plan — classifies each finding, applies concrete edits, produces a traceability summary | After a panel review of a plan document |
+This marketplace ships **two plugins** in one repository. They are independently installable; install only what you need.
+
+| Plugin | Source | What It Does | When to Use |
+|---|---|---|---|
+| `agent-review-panel` | [`plugins/agent-review-panel/`](plugins/agent-review-panel/) | Multi-agent adversarial review panel — 4–6 reviewers debate, judge renders final verdict (this project, v2.16.1) | When you need a structured review of code, plans, docs, or configs |
+| `plan-review-integrator` | [`plugins/plan-review-integrator/`](plugins/plan-review-integrator/) | Takes review panel output and integrates findings into an implementation plan — classifies each finding, applies concrete edits, produces a traceability summary (v2.0.0) | After a panel review of a plan document, when you need findings reflected in the plan with traceability |
+
+Install both for the full review→integrate pipeline:
+```
+/plugin install agent-review-panel@plugin
+/plugin install plan-review-integrator@plugin
+```
+
+`plan-review-integrator` was previously published as a standalone repo at `wan-huiyan/plan-review-integrator`. That repo is now **archived** in favor of the bundled distribution here. See [Migration](#migration-from-previous-marketplaces) for upgrade instructions.
+
+## Migration from previous marketplaces
+
+If you installed before v2.16.1, you used one of the old marketplace names. Migrate with:
+
+```
+# Old agent-review-panel install
+/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace remove wan-huiyan-agent-review-panel
+
+# Old plan-review-integrator standalone install (if applicable)
+/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
+/plugin marketplace remove wan-huiyan-plan-review-integrator
+
+# New bundled install
+/plugin marketplace add wan-huiyan/agent-review-panel
+/plugin install agent-review-panel@plugin
+/plugin install plan-review-integrator@plugin
+```
+
+Verify both are loaded under the new marketplace:
+```
+ls ~/.claude/plugins/cache/plugin/
+# expected: agent-review-panel  plan-review-integrator
+```
 
 ## Contributing
 
@@ -355,8 +394,8 @@ Please open an issue to discuss before submitting large PRs.
 
 **If installed via marketplace:**
 ```
-/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
-/plugin marketplace remove wan-huiyan-agent-review-panel
+/plugin uninstall agent-review-panel@plugin
+/plugin marketplace remove plugin
 ```
 
 **If installed via manual clone:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "private": true,
   "description": "Multi-agent adversarial review panel for Claude Code",
   "scripts": {

--- a/plugins/agent-review-panel/.claude-plugin/plugin.json
+++ b/plugins/agent-review-panel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Multi-agent adversarial review panel — 4-6 AI reviewers debate your code/plans, then a judge delivers a structured verdict with epistemic labels",
   "author": {
     "name": "wan-huiyan",

--- a/plugins/agent-review-panel/eval-suite.json
+++ b/plugins/agent-review-panel/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "agent-review-panel",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "created_by": "manual",
   "updated": "2026-04-07",
   "triggers": [

--- a/plugins/plan-review-integrator/.claude-plugin/plugin.json
+++ b/plugins/plan-review-integrator/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "plan-review-integrator",
+  "version": "2.0.0",
+  "author": "wan-huiyan",
+  "description": "Integrate structured review panel findings into implementation plan documents with full traceability.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "code-review",
+    "implementation-planning",
+    "review-integration",
+    "multi-agent",
+    "voltagent-integration"
+  ]
+}

--- a/plugins/plan-review-integrator/SKILL.md
+++ b/plugins/plan-review-integrator/SKILL.md
@@ -1,0 +1,504 @@
+---
+name: plan-review-integrator
+version: 2.0.0
+author: wan-huiyan
+description: >
+  Integrate structured review panel findings into an implementation plan document.
+  Takes output from agent-review-panel (or any structured review with severity-rated
+  findings) and cross-references each finding against the plan, classifies it into
+  an action category, applies concrete edits, and produces a traceability summary.
+  Trigger when the user says "update the plan with review findings", "incorporate
+  review feedback into the plan", "integrate review results", "apply review
+  recommendations to the plan", "cross-reference review output against the plan",
+  "merge review findings into the implementation plan", "what needs to change in the
+  plan based on the review", "take the review panel output and update my plan",
+  "reconcile the review feedback with the current plan", or invokes
+  /plan-review-integrator. Does NOT trigger for running a review panel (use
+  agent-review-panel), writing a plan from scratch, general code review, summarizing
+  review findings without applying them, or brainstorming implementation approaches.
+consumes_from: agent-review-panel
+hands_off_to: implementation-executor
+output_contract: >
+  Returns: (1) updated plan document with edits applied, (2) traceability summary
+  table mapping each finding to its disposition, (3) optional peripheral updates
+  (ADRs, runbooks, memory files), (4) integration_log.jsonl append. Idempotent:
+  re-running on the same review+plan produces the same result if no user overrides
+  are applied.
+---
+
+# Plan-Review Integrator v2.0
+
+Consumes structured review panel output and integrates findings into an
+implementation plan document -- turning review feedback into concrete plan updates
+with full traceability.
+
+> **Key insight:** Review panels often identify correct *symptoms* but prescribe
+> wrong *fixes* when they lack domain context. Always validate recommendations
+> against domain-specific constraints before applying them.
+
+---
+
+## Quick Reference
+
+| Stage | Phase | Action | Output |
+|-------|-------|--------|--------|
+| **Gather** | 1. Gather Inputs | Collect review reports + plan + domain context | Input set |
+| | 2. VoltAgent Detection | Detect specialists, suggest install if beneficial | Available specialist map |
+| **Analyze** | 3. Extract Findings | Parse findings with severity, source, citations | Structured finding list |
+| | 4. Cross-Reference | Match each finding against plan content | Category per finding |
+| | 5. Actionability Filter | Score actionability, drop low-signal findings | Filtered finding list |
+| | 6. Classify | Assign action category (epistemic-weighted) | must-fix / bundle / defer / info |
+| **Apply** | 7. Apply Edits | Edit plan document with rollback on coherence break | Updated plan |
+| | 8. Verify | Re-read modified plan, check coherence | Verified plan or rollback |
+| **Finalize** | 9. Update Peripherals | Update ADRs, runbooks, memory | Supporting docs |
+| | 10. Produce Summary | Traceability table | Audit trail |
+| | 11. Persistent Log | Append decisions to integration log | integration_log.jsonl |
+
+---
+
+## Phase 1: Gather Inputs
+
+Collect three things:
+
+1. **Review report(s)** -- file path, inline paste, or reference to prior conversation
+2. **Plan document** -- markdown plan, design doc, RFC, or architecture proposal
+3. **Domain context** -- memory files, config files, related docs, session history
+
+Domain context is essential for validating reviewer recommendations. Do NOT skip it.
+
+**Empty review guard:** If the review contains no actionable findings (clean pass),
+produce no classifications and output: "No action items identified. Plan unchanged."
+Skip Phases 3-8 and go directly to Phase 10 with a summary confirming the clean review.
+
+---
+
+## VoltAgent Specialist Verification (v1.3)
+
+VoltAgent specialist agents (127+ across 10 families) have built-in domain
+expertise via their system prompts. Unlike agent-review-panel (which replaces
+reviewer personas with VoltAgent agents), this skill uses VoltAgent as an
+**optional second-opinion verifier** for high-severity edits. The skill remains
+single-agent; specialists are consulted, not orchestrated.
+Full catalog: github.com/VoltAgent/awesome-claude-code-subagents
+
+**Step 1: Detection.** During Phase 1 (Gather Inputs), scan the system-reminder
+agent list for any `voltagent-*` prefixed agents. Note which families are
+installed (e.g., `voltagent-data-ai`, `voltagent-infra`, `voltagent-lang`).
+If none found, skip all VoltAgent steps silently -- everything works without them.
+
+**Step 2: Content-signal routing.** Match plan content signals to specialists:
+
+| Content Signal | VoltAgent Specialist | Verification Use |
+|---|---|---|
+| SQL / database queries | `voltagent-data-ai:database-optimizer` | Verify query correctness in must-fix edits |
+| Data pipelines / ETL | `voltagent-data-ai:data-engineer` | Verify pipeline logic changes |
+| ML / model training | `voltagent-data-ai:ml-engineer` | Verify model config / hyperparameter fixes |
+| Python code | `voltagent-lang:python-pro` | Verify code snippet corrections |
+| TypeScript code | `voltagent-lang:typescript-pro` | Verify TS code corrections |
+| Go code | `voltagent-lang:golang-pro` | Verify Go code corrections |
+| Rust code | `voltagent-lang:rust-engineer` | Verify Rust code corrections |
+| Java / Spring | `voltagent-lang:java-architect` | Verify Java code corrections |
+| Terraform / IaC | `voltagent-infra:terraform-engineer` | Verify infra changes in plan edits |
+| Kubernetes / k8s | `voltagent-infra:kubernetes-specialist` | Verify k8s manifest changes |
+| Docker / containers | `voltagent-infra:docker-expert` | Verify container config changes |
+| CI/CD / pipelines | `voltagent-infra:deployment-engineer` | Verify deployment procedure edits |
+| Security / auth | `voltagent-qa-sec:security-auditor` | Verify security fix correctness |
+| Performance / scaling | `voltagent-qa-sec:performance-engineer` | Verify performance-related changes |
+| API design / REST | `voltagent-core-dev:api-designer` | Verify API contract changes |
+| GraphQL | `voltagent-core-dev:graphql-architect` | Verify schema changes |
+| React / frontend | `voltagent-lang:react-specialist` | Verify frontend code corrections |
+| Compliance / GDPR | `voltagent-qa-sec:compliance-auditor` | Verify regulatory compliance of edits |
+
+**Step 3: Suggest installation when beneficial.** If content signals match
+VoltAgent specialists but the relevant agent families are not available,
+suggest installation to the user:
+
+> "This integration would benefit from VoltAgent specialist agents for
+> domain-specific edit verification. You can install the relevant families with:
+>
+> **Quick install (CLI):**
+> `claude plugin install voltagent-qa-sec`  -- security, code review, testing
+> `claude plugin install voltagent-data-ai` -- data science, ML, databases
+> `claude plugin install voltagent-infra`   -- DevOps, cloud, Terraform
+> `claude plugin install voltagent-lang`    -- language specialists (TS, Python, Go, Rust)
+>
+> **Or browse via marketplace:**
+> `/plugin marketplace add VoltAgent/awesome-claude-code-subagents`
+> then `/plugin install <name>@voltagent-subagents`
+>
+> Continue without them? They're optional -- all verification works without
+> VoltAgent specialists."
+
+Only suggest installation **once per session**. List only the families relevant
+to the detected content signals, not all 10. If the user declines or the agents
+are not available, proceed silently with the standard single-agent workflow.
+
+**Step 4: When to spawn specialists.** VoltAgent spawns are gated by priority,
+phase, and a hard cap:
+
+1. **Priority gate:** ONLY for P0 or P1 effective priority findings (from
+   Phase 6 epistemic-weighted classification). P2 and informational findings
+   never trigger specialist verification.
+2. **Phase gate:** ONLY during Phase 4 (cross-reference validation) and
+   Phase 7 (edit verification). Optionally Phase 8 (post-integration
+   coherence check) if spawns remain.
+3. **Spawn cap:** Maximum **3** specialist spawns per integration run. If more
+   than 3 P0/P1 findings qualify, prioritize: P0 before P1, Corrections before
+   Gaps, security/data-integrity domains before others.
+4. **Specialist prompt:** Each specialist receives:
+   - The specific finding (ID, severity, detail, prescribed fix)
+   - The plan section being modified (2 paragraphs of surrounding context)
+   - Domain context gathered in Phase 1
+   - Focused question: "Is the prescribed fix correct for this domain? If not,
+     what should change?"
+5. **Response handling:** Specialist responses are **advisory**. If a specialist
+   flags the prescribed fix as incorrect:
+   - Document the specialist's concern in the traceability table
+   - Apply the specialist's suggested alternative if it passes coherence check
+   - Or flag for human review if disagreement cannot be resolved
+6. **Fallback:** If the specialist spawn fails or times out, proceed without it.
+   Log `"voltagent_verification": "unavailable"` in `integration_log.jsonl`.
+
+Note: findings downgraded by the actionability filter (Phase 5, where
+groundedness < 0.3 caps severity at MEDIUM) will not reach P0/P1 threshold
+for specialist verification. This is correct behavior.
+
+---
+
+## Phase 3: Extract Findings
+
+For each finding, capture:
+
+| Field | Description |
+|-------|-------------|
+| ID | Sequential: R1-F01, R1-F02, ... R2-F01, ... |
+| Severity | CRITICAL / HIGH / MEDIUM / LOW |
+| Source | Reviewer name, "Completeness Audit", or "Judge" |
+| Summary | One-line description |
+| Detail | Full context with code snippets/citations |
+| Prescribed | Reviewer's recommended fix |
+| Consensus | Consensus / disputed / unilateral |
+| Location | Plan section, line, or code block |
+
+**Multiple reports:** Deduplicate and merge overlapping findings (note all sources). Flag conflicting recommendations. Keep unique findings separate.
+
+**High-signal items:** Completeness audit findings (systematic gaps), judge rulings (authoritative), items "resolved during debate" (may still need documentation).
+
+---
+
+## Phase 4: Cross-Reference
+
+Categorize each finding's relationship to the plan:
+
+| Category | Meaning |
+|----------|---------|
+| Already addressed | Plan handles it; reviewer may have missed it |
+| Gap | Plan should address this but doesn't |
+| Correction | Plan addresses it but contains an error |
+| New concern | Affects scope/timeline/approach; may need structural changes |
+| Pre-existing | Valid concern, but not introduced or worsened by this plan |
+
+**Domain validation checklist** -- for each finding ask:
+- Does the prescribed fix make sense given domain constraints?
+- Is the reviewer assuming something untrue about the system?
+- Would the fix break something the reviewer doesn't know about?
+- Is the concern already mitigated by a mechanism the reviewer didn't see?
+
+Document cases where the finding is valid but the prescribed fix is wrong.
+Override the reviewer's prescribed fix when domain validation shows it is incorrect,
+and supply the correct fix. Record the override in the key decisions section of the summary.
+
+**VoltAgent verification (v1.3):** When a P0/P1 finding's cross-reference
+judgment is ambiguous (especially "Already addressed" vs "Gap"), and a relevant
+VoltAgent specialist is available, spawn the specialist to validate the judgment.
+The specialist sees the finding, the plan section claimed to address it, and
+asks: "Does this plan section genuinely address this concern, or is there a gap?"
+This catches false "Already addressed" classifications that domain context alone
+might miss. Counts toward the 3-spawn-per-run cap.
+
+---
+
+## Phase 5: Actionability Filter
+
+> Inspired by Atlassian's RovoDev comment ranker (ICSE 2026, arXiv:2601.01129),
+> which found that filtering LLM-generated review comments with a quality predictor
+> improved resolution rates from ~33% to 40-45%, approaching human reviewer performance.
+
+Score each finding on two dimensions before classification:
+
+| Dimension | Question | Score |
+|-----------|----------|-------|
+| **Actionability** | Does this finding identify a specific, objectively verifiable issue with a concrete action? | 0.0 - 1.0 |
+| **Groundedness** | Is the finding supported by code citations, line references, or verifiable claims? | 0.0 - 1.0 |
+
+**Filter rules:**
+- **Drop** findings with actionability < 0.3 (conversational, acknowledgements, vague concerns)
+- **Flag for human review** findings with actionability 0.3-0.5 (valid concern, unclear action)
+- **Pass through** findings with actionability >= 0.5 (specific issue, concrete fix path)
+- Groundedness < 0.3 caps maximum severity at MEDIUM regardless of original rating
+
+**Epistemic label weighting** (from upstream agent-review-panel):
+- `[VERIFIED]` or `[CMD_CONFIRMED]`: +0.2 actionability bonus
+- `[CONSENSUS]`: no adjustment
+- `[SINGLE-SOURCE]`: -0.1 actionability penalty
+- `[UNVERIFIED]` or `[DISPUTED]`: -0.2 actionability penalty
+
+Record the filter decision (pass/flag/drop) and scores for each finding in the traceability table.
+
+---
+
+## Phase 6: Classify
+
+Assign each finding to one action category. Classification uses **epistemic-weighted
+severity** -- the effective priority of a finding depends on both its raw severity and
+the confidence of the evidence behind it.
+
+> Informed by research on multi-agent debate quality (arXiv:2511.07784, "Can LLM Agents
+> Really Debate?") showing that eloquent-but-wrong agents can sway consensus, and that
+> debate gains may reduce to ensembling effects. Epistemic labels from upstream reviews
+> are the best available signal for evidence quality.
+
+### Epistemic-Weighted Severity
+
+| Raw Severity | Epistemic Label | Effective Priority |
+|---|---|---|
+| CRITICAL | `[VERIFIED]` / `[CMD_CONFIRMED]` | P0 -- immediate must-fix |
+| CRITICAL | `[CONSENSUS]` | P0 -- must-fix with verification step |
+| CRITICAL | `[SINGLE-SOURCE]` / `[DISPUTED]` | P1 -- flag for human review before acting |
+| HIGH | `[VERIFIED]` | P1 -- must-fix |
+| HIGH | `[CONSENSUS]` | P1 -- must-fix or bundle |
+| HIGH | `[SINGLE-SOURCE]` / `[DISPUTED]` | P2 -- bundle or defer |
+| MEDIUM/LOW | any | P2 -- bundle, defer, or informational |
+
+A `[VERIFIED]` HIGH finding outranks a `[SINGLE-SOURCE]` CRITICAL finding. When in doubt,
+present the conflict to the user rather than auto-resolving.
+
+### Must-fix
+P0 or P1 effective priority + Correction or Gap + affects correctness/data integrity/security. For example, a wrong SQL WHERE clause or missing temporal guard. Applied immediately.
+
+### Bundle into implementation
+Valid items that are implementation details, not plan defects, e.g., pipeline quality gates or additional test cases. Added to checklists.
+
+### Defer
+LOW severity, pre-existing debt not worsened by plan, or different workstream. For instance, refactoring code not touched by this plan. Documented with rationale. Add a TODO or backlog item for tracking.
+
+### Informational
+Raised, debated, and resolved during review. No plan changes needed.
+
+### Conflict resolution
+- CRITICAL + pre-existing: defer, but add caveat with risk note and future work item
+- Panels disagree on severity: use higher severity, note disagreement
+- Valid finding + wrong fix: classify on finding severity, supply correct fix
+
+---
+
+## Phase 7: Apply Edits
+
+| Category | Edit type |
+|----------|-----------|
+| Must-fix | Direct plan edits: fix code, add guards, correct values |
+| Bundle | Add to implementation checklists and verification sections |
+| Gap (new section) | Add pre-impl checks, go/no-go criteria, rollback, monitoring |
+| Caveat | Inline `> **Review note:** [concern + mitigation]` near relevant content |
+
+**Edit discipline:**
+- Minimum necessary change per finding
+- Preserve plan voice and structure
+- Do not rewrite correct sections
+- Link edits to finding IDs for traceability
+
+**VoltAgent verification (v1.3):** For must-fix edits where a domain specialist
+is available, spawn the specialist to verify the edit BEFORE applying it. The
+specialist receives the original finding, the proposed edit, and the surrounding
+plan context, and confirms the edit is technically correct for the domain. This
+catches wrong fixes that general domain context might miss (e.g., a SQL fix that
+is syntactically valid but semantically wrong for the specific database engine).
+Counts toward the 3-spawn-per-run cap.
+
+**Rollback on coherence break:**
+
+> Inspired by AutoDW's dual rollback strategy (arXiv:2512.04445), which achieved 90%
+> completion on document workflow tasks by validating each state change and reverting
+> when edits break document coherence.
+
+After each must-fix edit, re-read the surrounding section (2 paragraphs before and after).
+If the edit introduces inconsistency, contradiction, or breaks the logical flow:
+
+1. **Argument-level rollback** (first attempt): Rephrase the edit to fit the surrounding
+   context while preserving the finding's intent. Keep the same finding ID linkage.
+2. **API-level rollback** (if rephrasing fails): Revert the edit entirely. Add the finding
+   to the traceability table with disposition "ROLLBACK -- requires manual integration"
+   and include the coherence issue encountered.
+
+Do not force edits that break the plan. A clean plan with a flagged finding is better than
+a corrupted plan with a forced fix.
+
+---
+
+## Phase 8: Post-Integration Verification
+
+> Inspired by Self-Refine (NeurIPS 2023, arXiv:2303.17651), which demonstrated 20%
+> average improvement from generate-critique-refine cycles, and ARIS's auto-review-loop
+> (github.com/wanshuiyin/Auto-claude-code-research-in-sleep) which chains cross-model
+> review for overnight autonomous quality improvement.
+
+After all Phase 7 edits are applied, perform a single verification pass:
+
+1. **Coherence check** -- Re-read the full updated plan. Flag any section where edits
+   from different findings contradict each other or create logical gaps.
+2. **Completeness check** -- Verify every must-fix finding has a corresponding edit.
+   Every bundle finding appears in a checklist. Every defer finding has a rationale.
+3. **Voice check** -- Confirm edits match the plan's existing tone and style. Rewrite
+   any edit that reads like injected review commentary rather than plan content.
+4. **Cross-reference check** -- If edits reference other plan sections (e.g., "see Phase 4"),
+   verify those references are still valid after modifications.
+5. **Domain coherence check (optional, v1.3)** -- If any VoltAgent specialist spawns remain
+   unused (under the 3-spawn cap), use one to re-read the full set of must-fix edits and
+   confirm they are mutually consistent from a domain perspective. This catches cases where
+   individually correct edits interact poorly.
+
+If verification surfaces issues, apply targeted fixes (not a full re-integration).
+Record verification findings in the traceability summary as "V-01", "V-02", etc.
+
+---
+
+## Phase 9: Update Peripherals
+
+- **Memory files:** Document findings affecting future sessions, new conventions, updated action items
+- **ADRs:** Create/update for architectural decisions validated or modified by review
+- **Runbooks:** Update deployment/rollback/operational procedures if changed
+- **Config:** Note specific files and values to change; add to pre-implementation checklist
+
+---
+
+## Phase 10: Produce Summary
+
+Example output:
+
+| ID | Severity | Summary | Category | Action Taken |
+|----|----------|---------|----------|--------------|
+| R1-F01 | CRITICAL | Missing temporal guard | Must-fix | Added guard to step 3 query |
+| R1-F02 | HIGH | Stale default in config | Bundle | Added to checklist item 3 |
+| R1-F03 | MEDIUM | Refactor identity resolution | Defer | Pre-existing, tracked as future work |
+
+Include statistics in this format: `Total findings: {N} | Must-fix: {n} | Bundle: {n} | Defer: {n} | Info: {n}`. Include key decisions (e.g., why a reviewer fix was overridden). Present summary to user and ask if they want to adjust classifications before finalizing.
+
+---
+
+## Phase 11: Persistent Integration Log
+
+> Inspired by pi-autoresearch's append-only `autoresearch.jsonl` experiment log
+> (github.com/davebcn87/pi-autoresearch), which enables fresh agent sessions to resume
+> exactly where previous sessions stopped and learn from prior optimization decisions.
+
+Append one JSON line per finding to `integration_log.jsonl` in the project root:
+
+```json
+{
+  "timestamp": "2026-03-26T14:30:00Z",
+  "plan": "tasks/implementation_plan.md",
+  "review_source": "review_panel_report.md",
+  "finding_id": "R1-F01",
+  "severity": "CRITICAL",
+  "epistemic_label": "[VERIFIED]",
+  "effective_priority": "P0",
+  "actionability_score": 0.85,
+  "category": "must-fix",
+  "disposition": "applied",
+  "rollback": false,
+  "verification_passed": true,
+  "voltagent_verification": "confirmed",
+  "notes": "Added temporal guard to step 3 query"
+}
+```
+
+**Why:** Over multiple integration runs, this log reveals patterns -- which finding types
+are consistently deferred, which sources produce the most actionable findings, and which
+severity levels correlate with actual plan changes. Future runs can use this history to
+calibrate actionability scoring.
+
+If `integration_log.jsonl` already exists, read it before Phase 5 to inform actionability
+scoring: findings matching historically-deferred patterns get a -0.1 penalty; findings
+matching historically-applied patterns get a +0.1 bonus.
+
+---
+
+## Upstream Schema Contract
+
+> This section defines the expected input format from `agent-review-panel` to prevent
+> silent misparse when the upstream skill evolves. Version-pinned for compatibility.
+
+**Compatible with:** `agent-review-panel` v2.0+ (v2.9+ for VoltAgent-enriched findings)
+
+**Required fields per finding:**
+- Severity tier: `P0` / `P1` / `P2` (maps to CRITICAL / HIGH / MEDIUM-LOW)
+- Epistemic label: one of `[VERIFIED]`, `[CMD_CONFIRMED]`, `[CONSENSUS]`, `[SINGLE-SOURCE]`, `[UNVERIFIED]`, `[DISPUTED]`
+- Defect type: `[EXISTING_DEFECT]` or `[PLAN_RISK]`
+- Source attribution: reviewer persona name or "Completeness Audit" or "Judge"
+
+**Required report sections:**
+- `## Action Items` -- tagged findings with severity + epistemic labels
+- `## Consensus Points` -- agreed findings (can be processed as `[CONSENSUS]`)
+- `## Disagreement Points` -- with Side A, Side B, Judge's ruling
+
+**Optional but utilized:**
+- `## Completeness Audit Findings` -- elevated weight in classification
+- `## Severity Verification Table` -- used to validate P0 claims
+- Verification annotations: `[CMD_CONFIRMED]`, `[CMD_CONTRADICTED]`, `[CMD_INCONCLUSIVE]`
+
+**Graceful degradation:** If input lacks epistemic labels, treat all findings as
+`[SINGLE-SOURCE]`. If input lacks defect types, infer from context (code citations
+suggest `[EXISTING_DEFECT]`, speculative concerns suggest `[PLAN_RISK]`).
+
+---
+
+## Composability
+
+This skill expects structured review output as input (requires a file path or inline findings).
+Do not use for running review panels or writing plans from scratch.
+If integration fails, gracefully degrade by presenting unmodified findings for manual triage.
+After integration, then use the implementation executor to begin building.
+This skill depends on `agent-review-panel` upstream. Works with review v1.0 output format and above.
+
+| Field | Value |
+|-------|-------|
+| Consumes from | `agent-review-panel` (or any structured review with severity-rated findings) |
+| Hands off to | Implementation executor; updated plan feeds into build phases |
+| Output contract | Updated plan + traceability summary + optional ADRs/runbooks |
+| Namespace | All edits scoped to provided plan document; no global state modification |
+| Idempotency | Re-running on same inputs produces same result (absent user overrides) |
+
+---
+
+## Anti-Patterns
+
+1. **Applying fixes blindly** -- always validate against domain context
+2. **CRITICAL != plan defect** -- some are verification steps (add to checklist, not correction)
+3. **Ignoring completeness audit** -- highest-signal items; systematic gaps all reviewers missed
+4. **Pre-existing debt as must-fix** -- if plan doesn't worsen it, defer with backlog link
+5. **Plan as findings dump** -- each finding lands in exactly the right place, not a giant appendix
+6. **Skipping user confirmation** -- present classification summary; let user adjust before applying
+7. **Severity-only triage** -- a `[SINGLE-SOURCE]` CRITICAL is weaker than a `[VERIFIED]` HIGH; always use epistemic-weighted severity
+8. **Forcing incoherent edits** -- if an edit breaks plan coherence, rollback; a flagged finding beats a corrupted plan
+9. **Ignoring integration history** -- check `integration_log.jsonl` for patterns before classifying; don't repeat deferred decisions without re-evaluation
+10. **Over-spawning specialists** -- VoltAgent is a verification tool here, not an orchestrator; cap at 3 spawns per run and only for P0/P1 findings
+
+---
+
+## Research Credits
+
+Design decisions are informed by the following research:
+
+| Feature | Source | Reference |
+|---------|--------|-----------|
+| Actionability filter | Atlassian RovoDev Code Reviewer | ICSE 2026 SEIP, arXiv:2601.01129 |
+| Epistemic-weighted severity | "Can LLM Agents Really Debate?" | arXiv:2511.07784 |
+| Dual rollback strategy | AutoDW document workflow orchestration | arXiv:2512.04445 |
+| Post-integration verification | Self-Refine (Madaan et al.) | NeurIPS 2023, arXiv:2303.17651 |
+| Cross-model review pattern | ARIS (Auto-Research-In-Sleep) | github.com/wanshuiyin/Auto-claude-code-research-in-sleep |
+| Persistent experiment log | pi-autoresearch (davebcn87) | github.com/davebcn87/pi-autoresearch |
+| Fine-grained comment classification | Review comment taxonomy | arXiv:2508.09832 |
+| Multi-agent debate protocols | Voting vs Consensus (Kaesberg et al.) | ACL 2025 Findings, arXiv:2502.19130 |
+| Anti-sycophancy mechanisms | CONSENSAGENT | ACL 2025 Findings |
+| Feedback-to-section mapping | Friction (Zhang et al.) | CHI 2025 |
+| VoltAgent specialist routing | awesome-claude-code-subagents (VoltAgent) | github.com/VoltAgent/awesome-claude-code-subagents |

--- a/plugins/plan-review-integrator/eval-suite.json
+++ b/plugins/plan-review-integrator/eval-suite.json
@@ -1,0 +1,172 @@
+{
+  "version": "2.0.0",
+  "skill": "plan-review-integrator",
+  "triggers": [
+    {"prompt": "update the plan with review findings", "should_trigger": true},
+    {"prompt": "incorporate review feedback into the plan", "should_trigger": true},
+    {"prompt": "integrate review results", "should_trigger": true},
+    {"prompt": "apply review recommendations to the plan", "should_trigger": true},
+    {"prompt": "cross-reference review output against the plan", "should_trigger": true},
+    {"prompt": "merge review findings into the implementation plan", "should_trigger": true},
+    {"prompt": "what needs to change in the plan based on the review", "should_trigger": true},
+    {"prompt": "take the review panel output and update my plan", "should_trigger": true},
+    {"prompt": "the review is done, now update the implementation plan", "should_trigger": true},
+    {"prompt": "apply the agent-review-panel findings to the plan document", "should_trigger": true},
+    {"prompt": "here are the review results, integrate them into the plan", "should_trigger": true},
+    {"prompt": "reconcile the review feedback with the current plan", "should_trigger": true},
+    {"prompt": "run a review panel on my plan", "should_trigger": false},
+    {"prompt": "review this code for me", "should_trigger": false},
+    {"prompt": "write me an implementation plan from scratch", "should_trigger": false},
+    {"prompt": "create a new plan document", "should_trigger": false},
+    {"prompt": "do a code review of this PR", "should_trigger": false},
+    {"prompt": "summarize the review findings without changing anything", "should_trigger": false},
+    {"prompt": "what did the reviewers say", "should_trigger": false},
+    {"prompt": "brainstorm ideas for the implementation", "should_trigger": false},
+    {"prompt": "give me feedback on this design", "should_trigger": false},
+    {"prompt": "run the agent-review-panel skill", "should_trigger": false}
+  ],
+  "test_cases": [
+    {
+      "id": "TC01",
+      "name": "Single review report with mixed severities",
+      "input": "Here is the review output (review-report.md) and the plan (plan.md). Integrate the findings into the plan.",
+      "assertions": [
+        {"type": "contains", "value": "finding", "description": "Extracts all findings with severity levels"},
+        {"type": "contains", "value": "must-fix", "description": "Classifies findings into action categories"},
+        {"type": "pattern", "value": "\\|.*ID.*Severity.*Summary.*Category.*Action", "description": "Produces a traceability summary table"},
+        {"type": "contains", "value": "adjust", "description": "Asks user to confirm classifications before finalizing"}
+      ]
+    },
+    {
+      "id": "TC02",
+      "name": "Multiple review reports with overlapping findings",
+      "input": "Two review panels reviewed the same plan. Here are both reports. Integrate them into plan.md.",
+      "assertions": [
+        {"type": "contains", "value": "deduplicate", "description": "Deduplicates findings across reports"},
+        {"type": "contains", "value": "source", "description": "Notes all sources for merged findings"},
+        {"type": "contains", "value": "conflict", "description": "Flags conflicting recommendations"}
+      ]
+    },
+    {
+      "id": "TC03",
+      "name": "Review with completeness audit findings",
+      "input": "The review includes a completeness audit section. Integrate all findings including the completeness audit into the plan.",
+      "assertions": [
+        {"type": "contains", "value": "completeness", "description": "Identifies completeness audit findings"},
+        {"type": "contains", "value": "systematic", "description": "Treats completeness findings as high-signal"},
+        {"type": "excludes", "value": "skip completeness", "description": "Does not dismiss completeness audit items"}
+      ]
+    },
+    {
+      "id": "TC04",
+      "name": "Inline review findings without file",
+      "input": "Here are the review findings:\n- CRITICAL: SQL missing WHERE clause on date\n- HIGH: No retry logic for API calls\n- LOW: Use constants instead of magic numbers\nIntegrate these into my plan at plan.md.",
+      "assertions": [
+        {"type": "contains", "value": "CRITICAL", "description": "Parses inline findings and extracts severity"},
+        {"type": "contains", "value": "must-fix", "description": "Classifies CRITICAL SQL issue as must-fix"},
+        {"type": "format", "value": "markdown_table", "description": "Produces structured summary table"}
+      ]
+    },
+    {
+      "id": "TC05",
+      "name": "Peripheral updates needed",
+      "input": "The review found we need to update the deployment runbook and add an ADR for the caching decision. Integrate the review into the plan.",
+      "assertions": [
+        {"type": "contains", "value": "ADR", "description": "Creates or updates ADR for architectural decisions"},
+        {"type": "contains", "value": "runbook", "description": "Updates runbook for operational changes"},
+        {"type": "contains", "value": "memory", "description": "Updates memory files with new conventions"}
+      ]
+    }
+  ],
+  "edge_cases": [
+    {
+      "id": "EC01",
+      "category": "empty_input",
+      "name": "Empty review with no findings",
+      "input": "The review panel found no issues. The plan passed all checks. Integrate the review.",
+      "expected_behavior": "Produces summary confirming clean review. Does not make edits to the plan. Notes the plan passed review.",
+      "assertions": [
+        {"type": "excludes", "value": "must-fix", "description": "No must-fix items when review is clean"},
+        {"type": "contains", "value": "no action", "description": "States no plan changes required"}
+      ]
+    },
+    {
+      "id": "EC02",
+      "category": "invalid_classification",
+      "name": "CRITICAL finding that is pre-existing tech debt",
+      "input": "The review found a CRITICAL issue about identity resolution. But this is pre-existing tech debt not introduced by the plan. Integrate the review into the plan.",
+      "expected_behavior": "Classifies as defer (not must-fix). Adds caveat noting the risk. Links to future TODO. Does not block the plan.",
+      "assertions": [
+        {"type": "contains", "value": "defer", "description": "Pre-existing debt classified as defer"},
+        {"type": "contains", "value": "TODO", "description": "Links to future TODO"},
+        {"type": "excludes", "value": "block", "description": "Does not block plan on pre-existing debt"}
+      ]
+    },
+    {
+      "id": "EC03",
+      "category": "invalid_fix",
+      "name": "Reviewer prescribes wrong fix for valid finding",
+      "input": "The review identified a real gap in error handling but the prescribed fix would break our rate limiter. Integrate this into the plan.",
+      "expected_behavior": "Validates prescribed fix against domain context. Identifies fix is incorrect. Supplies correct fix. Documents override in key decisions.",
+      "assertions": [
+        {"type": "contains", "value": "domain", "description": "Validates against domain context"},
+        {"type": "contains", "value": "override", "description": "Documents why reviewer fix was overridden"}
+      ]
+    },
+    {
+      "id": "EC04",
+      "category": "minimal_input",
+      "name": "Review with only informational items",
+      "input": "The review panel found some concerns but the judge resolved all of them as not applicable. Integrate the review into the plan.",
+      "expected_behavior": "Classifies all items as informational. Does not make unnecessary edits to the plan. Produces summary noting no changes needed.",
+      "assertions": [
+        {"type": "contains", "value": "informational", "description": "All items classified as informational"},
+        {"type": "excludes", "value": "edit", "description": "No unnecessary plan edits"}
+      ]
+    },
+    {
+      "id": "EC05",
+      "category": "invalid_assumption",
+      "name": "CRITICAL finding that is actually a verification step",
+      "input": "Review flagged a CRITICAL: 'verify column X exists in BigQuery before running'. Integrate this into the plan.",
+      "expected_behavior": "Classifies as bundle-into-implementation (checklist item), not must-fix. Does not treat verification steps as design flaws.",
+      "assertions": [
+        {"type": "contains", "value": "checklist", "description": "Adds to implementation checklist"},
+        {"type": "excludes", "value": "plan defect", "description": "Does not treat as plan correction"}
+      ]
+    },
+    {
+      "id": "EC06",
+      "category": "missing_context",
+      "name": "Domain context contradicts reviewer assumption",
+      "input": "The reviewer assumed we use REST APIs but we use gRPC. Their fix suggests adding HTTP retry headers. Integrate this review into the plan.",
+      "expected_behavior": "Checks domain context. Identifies incorrect assumption. Adapts fix to gRPC context. Documents domain context gap.",
+      "assertions": [
+        {"type": "contains", "value": "domain context", "description": "Checks domain context before applying"},
+        {"type": "contains", "value": "assumption", "description": "Identifies incorrect reviewer assumption"}
+      ]
+    },
+    {
+      "id": "EC07",
+      "category": "scale_large",
+      "name": "Large review with 20+ findings across multiple panels",
+      "input": "Three review panels produced 25 findings total with significant overlap. Integrate all findings into the plan.",
+      "expected_behavior": "Deduplicates across all three panels. Processes all 25 findings. Produces complete traceability table. Does not drop any findings.",
+      "assertions": [
+        {"type": "contains", "value": "deduplicate", "description": "Handles deduplication at scale"},
+        {"type": "pattern", "value": "Total findings: \\d+", "description": "Reports total finding count"}
+      ]
+    },
+    {
+      "id": "EC08",
+      "category": "missing_plan",
+      "name": "Plan already addresses the concern",
+      "input": "The reviewer flagged missing rollback steps, but the plan already has a rollback section in Phase 4. Integrate the review.",
+      "expected_behavior": "Cross-references finding against existing plan content. Identifies as already addressed. Notes relevant plan section. Does not duplicate existing content.",
+      "assertions": [
+        {"type": "contains", "value": "already addressed", "description": "Identifies finding as already covered"},
+        {"type": "excludes", "value": "add rollback", "description": "Does not duplicate existing content"}
+      ]
+    }
+  ]
+}

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -8,7 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
 const evalSuite = JSON.parse(
-  readFileSync(resolve(ROOT, "eval-suite.json"), "utf-8")
+  readFileSync(resolve(ROOT, "plugins/agent-review-panel/eval-suite.json"), "utf-8")
 );
 
 // Discover SKILL.md in canonical (plugins/<name>/) or legacy layout.

--- a/tests/eval-suite-integrity.test.mjs
+++ b/tests/eval-suite-integrity.test.mjs
@@ -8,7 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
 const evalSuite = JSON.parse(
-  readFileSync(resolve(ROOT, "eval-suite.json"), "utf-8")
+  readFileSync(resolve(ROOT, "plugins/agent-review-panel/eval-suite.json"), "utf-8")
 );
 
 function findSkillMd() {

--- a/tests/manifest-consistency.test.mjs
+++ b/tests/manifest-consistency.test.mjs
@@ -1,10 +1,10 @@
 /**
- * Manifest Consistency Tests — Generalized Template
+ * Manifest Consistency Tests — Multi-Plugin Marketplace
  *
- * Cross-validates version, name, and description across all manifest files.
- * Dynamically discovers which files exist and only tests those present.
- *
- * Works for any Claude Code skill repo with at minimum a .claude-plugin/plugin.json.
+ * Cross-validates version, name, and description across all manifest files
+ * for ALL plugins in this marketplace. Iterates over plugins/<name>/ entries
+ * and validates each plugin's manifests independently against the marketplace
+ * entry, plus shared root files (package.json) where applicable.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -32,365 +32,389 @@ function extractFrontmatter(md) {
 }
 
 // ---------------------------------------------------------------------------
-// Discover available manifest files
+// Discover ALL plugins under plugins/<name>/.claude-plugin/plugin.json
 // ---------------------------------------------------------------------------
 
-const files = {};
-
-// The canonical Claude Code plugin layout nests each plugin inside a
-// plugins/<name>/ subdirectory, with its manifest at
-// plugins/<name>/.claude-plugin/plugin.json. We discover the first plugin
-// manifest anywhere under plugins/ and fall back to the legacy
-// .claude-plugin/plugin.json location for backwards compatibility.
-function findPluginJson() {
-  // Prefer the canonical plugins/<name>/.claude-plugin/plugin.json layout
+function discoverPlugins() {
   const pluginsRoot = resolve(ROOT, "plugins");
+  const plugins = [];
+
   if (existsSync(pluginsRoot)) {
     for (const entry of readdirSync(pluginsRoot, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        const candidate = resolve(pluginsRoot, entry.name, ".claude-plugin/plugin.json");
-        if (existsSync(candidate)) return candidate;
+      if (!entry.isDirectory()) continue;
+      const dir = resolve(pluginsRoot, entry.name);
+      const pluginJsonPath = resolve(dir, ".claude-plugin/plugin.json");
+      if (!existsSync(pluginJsonPath)) continue;
+
+      const skillMdPath = resolve(dir, "SKILL.md");
+      const evalSuitePath = resolve(dir, "eval-suite.json");
+
+      // Optional secondary nested SKILL.md at plugins/<name>/skills/<sub>/SKILL.md
+      let nestedSkillMdPath = null;
+      const skillsSubdir = resolve(dir, "skills");
+      if (existsSync(skillsSubdir)) {
+        try {
+          for (const sub of readdirSync(skillsSubdir, { withFileTypes: true })) {
+            if (!sub.isDirectory()) continue;
+            const candidate = resolve(skillsSubdir, sub.name, "SKILL.md");
+            if (existsSync(candidate)) {
+              nestedSkillMdPath = candidate;
+              break;
+            }
+          }
+        } catch { /* ignore */ }
       }
+
+      plugins.push({
+        dirName: entry.name,
+        pluginJsonPath,
+        pluginJson: JSON.parse(readFileSync(pluginJsonPath, "utf-8")),
+        skillMdPath: existsSync(skillMdPath) ? skillMdPath : null,
+        skillMd: existsSync(skillMdPath) ? readFileSync(skillMdPath, "utf-8") : null,
+        evalSuitePath: existsSync(evalSuitePath) ? evalSuitePath : null,
+        evalSuite: existsSync(evalSuitePath)
+          ? JSON.parse(readFileSync(evalSuitePath, "utf-8"))
+          : null,
+        nestedSkillMdPath,
+        nestedSkillMd: nestedSkillMdPath ? readFileSync(nestedSkillMdPath, "utf-8") : null,
+      });
     }
   }
-  // Legacy fallback: plugin.json at marketplace root
-  const legacy = resolve(ROOT, ".claude-plugin/plugin.json");
-  return existsSync(legacy) ? legacy : null;
+
+  // Legacy fallback: a single plugin.json at the marketplace root
+  if (plugins.length === 0) {
+    const legacyPluginJson = resolve(ROOT, ".claude-plugin/plugin.json");
+    if (existsSync(legacyPluginJson)) {
+      const legacySkillMd = resolve(ROOT, "SKILL.md");
+      const legacyEvalSuite = resolve(ROOT, "eval-suite.json");
+      plugins.push({
+        dirName: "(legacy-root)",
+        pluginJsonPath: legacyPluginJson,
+        pluginJson: JSON.parse(readFileSync(legacyPluginJson, "utf-8")),
+        skillMdPath: existsSync(legacySkillMd) ? legacySkillMd : null,
+        skillMd: existsSync(legacySkillMd) ? readFileSync(legacySkillMd, "utf-8") : null,
+        evalSuitePath: existsSync(legacyEvalSuite) ? legacyEvalSuite : null,
+        evalSuite: existsSync(legacyEvalSuite)
+          ? JSON.parse(readFileSync(legacyEvalSuite, "utf-8"))
+          : null,
+        nestedSkillMdPath: null,
+        nestedSkillMd: null,
+      });
+    }
+  }
+
+  return plugins;
 }
 
-const pluginJsonPath = findPluginJson();
-if (pluginJsonPath && existsSync(pluginJsonPath)) {
-  files.pluginJson = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
-}
+const plugins = discoverPlugins();
 
+// Shared root files
 const marketplaceJsonPath = resolve(ROOT, ".claude-plugin/marketplace.json");
-if (existsSync(marketplaceJsonPath)) {
-  files.marketplaceJson = JSON.parse(readFileSync(marketplaceJsonPath, "utf-8"));
-}
-
-const evalSuitePath = resolve(ROOT, "eval-suite.json");
-if (existsSync(evalSuitePath)) {
-  files.evalSuite = JSON.parse(readFileSync(evalSuitePath, "utf-8"));
-}
+const marketplaceJson = existsSync(marketplaceJsonPath)
+  ? JSON.parse(readFileSync(marketplaceJsonPath, "utf-8"))
+  : null;
 
 const packageJsonPath = resolve(ROOT, "package.json");
-if (existsSync(packageJsonPath)) {
-  files.packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-}
-
-// Discover the plugin's SKILL.md. In the canonical layout it lives at
-// plugins/<name>/SKILL.md (next to the plugin's .claude-plugin/plugin.json).
-// Fall back to a root SKILL.md for repos using the legacy flat layout.
-function findRootSkillMd() {
-  // Canonical: plugins/<name>/SKILL.md
-  const pluginsRoot = resolve(ROOT, "plugins");
-  if (existsSync(pluginsRoot)) {
-    for (const entry of readdirSync(pluginsRoot, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        const candidate = resolve(pluginsRoot, entry.name, "SKILL.md");
-        if (existsSync(candidate)) return candidate;
-      }
-    }
-  }
-  // Legacy: SKILL.md at the repo root
-  const legacy = resolve(ROOT, "SKILL.md");
-  return existsSync(legacy) ? legacy : null;
-}
-
-const rootSkillMdPath = findRootSkillMd();
-if (rootSkillMdPath && existsSync(rootSkillMdPath)) {
-  files.rootSkillMd = readFileSync(rootSkillMdPath, "utf-8");
-}
-
-// Optional secondary SKILL.md: some plugins also expose a nested
-// plugins/<name>/skills/<skill>/SKILL.md. Skip if the layout doesn't use it.
-let nestedSkillMdPath = null;
-const pluginsRootForSkills = resolve(ROOT, "plugins");
-if (existsSync(pluginsRootForSkills)) {
-  for (const pluginEntry of readdirSync(pluginsRootForSkills, { withFileTypes: true })) {
-    if (!pluginEntry.isDirectory()) continue;
-    const skillsDir = resolve(pluginsRootForSkills, pluginEntry.name, "skills");
-    if (!existsSync(skillsDir)) continue;
-    try {
-      const subdirs = readdirSync(skillsDir, { withFileTypes: true })
-        .filter((d) => d.isDirectory());
-      for (const subdir of subdirs) {
-        const candidate = resolve(skillsDir, subdir.name, "SKILL.md");
-        if (existsSync(candidate)) {
-          nestedSkillMdPath = candidate;
-          files.nestedSkillMd = readFileSync(candidate, "utf-8");
-          break;
-        }
-      }
-    } catch { /* ignore */ }
-    if (nestedSkillMdPath) break;
-  }
-}
-
-// Derive the canonical skill name from plugin.json (authoritative source)
-const SKILL_NAME = files.pluginJson?.name;
+const packageJson = existsSync(packageJsonPath)
+  ? JSON.parse(readFileSync(packageJsonPath, "utf-8"))
+  : null;
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("Manifest consistency", () => {
-  describe("plugin.json", () => {
-    it("exists and has required fields", () => {
-      assert.ok(files.pluginJson, ".claude-plugin/plugin.json must exist");
-      assert.ok(files.pluginJson.name, "must have name");
-      assert.ok(files.pluginJson.version, "must have version");
-      assert.ok(files.pluginJson.description, "must have description");
-    });
-
-    it("has valid semver version", () => {
-      assert.match(
-        files.pluginJson.version,
-        /^\d+\.\d+\.\d+$/,
-        "version must be semver (e.g., 1.2.3)"
-      );
+  describe("Plugin discovery", () => {
+    it("found at least one plugin", () => {
+      assert.ok(plugins.length > 0, "must discover at least one plugin");
     });
   });
 
-  if (files.marketplaceJson) {
-    describe("marketplace.json", () => {
-      it("has required fields", () => {
-        assert.ok(files.marketplaceJson.name, "must have name");
-        assert.ok(files.marketplaceJson.description, "must have description");
-        assert.ok(files.marketplaceJson.plugins, "must have plugins array");
-        assert.ok(files.marketplaceJson.plugins.length > 0, "must have at least one plugin");
-      });
+  // ---------------------------------------------------------------------------
+  // Per-plugin assertions: every plugin's manifests are internally consistent
+  // ---------------------------------------------------------------------------
+  for (const plugin of plugins) {
+    describe(`Plugin: ${plugin.dirName}`, () => {
+      describe("plugin.json", () => {
+        it("has required fields", () => {
+          assert.ok(plugin.pluginJson.name, "must have name");
+          assert.ok(plugin.pluginJson.version, "must have version");
+          assert.ok(plugin.pluginJson.description, "must have description");
+        });
 
-      it("plugin entry has required fields", () => {
-        const plugin = files.marketplaceJson.plugins[0];
-        assert.ok(plugin.name, "plugin must have name");
-        assert.ok(plugin.description, "plugin must have description");
-        assert.ok(plugin.source, "plugin must have source");
-      });
-
-      it("first plugin entry name matches plugin.json", () => {
-        // The marketplace's own `name` can be anything (e.g. owner-prefixed
-        // "wan-huiyan-causal-impact-campaign"). The real invariant is that the
-        // first plugin entry must match the plugin.json name, because that's
-        // what users type in `claude plugin install <plugin-name>@<marketplace>`.
-        assert.equal(files.marketplaceJson.plugins[0].name, SKILL_NAME);
-      });
-
-      if (files.marketplaceJson.plugins[0]?.version) {
-        it("plugin version matches plugin.json version", () => {
-          assert.equal(
-            files.marketplaceJson.plugins[0].version,
-            files.pluginJson.version,
-            "marketplace plugin version must match plugin.json version"
+        it("has valid semver version", () => {
+          assert.match(
+            plugin.pluginJson.version,
+            /^\d+\.\d+\.\d+$/,
+            "version must be semver (e.g., 1.2.3)"
           );
         });
-      }
+      });
 
-      it("skills paths resolve to existing locations", () => {
-        const plugin = files.marketplaceJson.plugins[0];
-        if (plugin.skills) {
-          for (const skillPath of plugin.skills) {
-            const fullPath = resolve(ROOT, skillPath);
-            assert.ok(
-              existsSync(fullPath),
-              `skill path "${skillPath}" must exist at ${fullPath}`
+      if (plugin.evalSuite) {
+        describe("eval-suite.json", () => {
+          const evalSkillName =
+            plugin.evalSuite.skill_name || plugin.evalSuite.skill;
+
+          it("has required top-level fields", () => {
+            assert.ok(evalSkillName, "must have skill_name or skill field");
+            assert.ok(plugin.evalSuite.version, "must have version");
+          });
+
+          it("skill name matches plugin.json", () => {
+            assert.equal(
+              evalSkillName,
+              plugin.pluginJson.name,
+              `eval-suite skill name "${evalSkillName}" must match plugin.json name "${plugin.pluginJson.name}"`
             );
+          });
+
+          it("eval-suite version matches plugin.json version", () => {
+            assert.equal(
+              plugin.evalSuite.version,
+              plugin.pluginJson.version,
+              `eval-suite version "${plugin.evalSuite.version}" must match plugin.json version "${plugin.pluginJson.version}"`
+            );
+          });
+
+          if (plugin.evalSuite.triggers) {
+            it("has triggers array with entries", () => {
+              assert.ok(
+                plugin.evalSuite.triggers.length > 0,
+                "triggers must not be empty"
+              );
+            });
+
+            it("trigger IDs are unique (where present)", () => {
+              const ids = plugin.evalSuite.triggers
+                .map((t) => t.id)
+                .filter(Boolean);
+              if (ids.length > 0) {
+                const unique = new Set(ids);
+                assert.equal(ids.length, unique.size, "all trigger IDs must be unique");
+              }
+            });
           }
-        }
-      });
+
+          if (plugin.evalSuite.test_cases) {
+            it("test_case IDs are unique", () => {
+              const ids = plugin.evalSuite.test_cases.map((t) => t.id).filter(Boolean);
+              if (ids.length > 0) {
+                const unique = new Set(ids);
+                assert.equal(ids.length, unique.size, "all test_case IDs must be unique");
+              }
+            });
+          }
+
+          if (plugin.evalSuite.edge_cases) {
+            it("edge_case IDs are unique", () => {
+              const ids = plugin.evalSuite.edge_cases.map((t) => t.id).filter(Boolean);
+              if (ids.length > 0) {
+                const unique = new Set(ids);
+                assert.equal(ids.length, unique.size, "all edge_case IDs must be unique");
+              }
+            });
+          }
+
+          it("no duplicate IDs across all sections", () => {
+            const allIds = [
+              ...(plugin.evalSuite.triggers || []).map((t) => t.id),
+              ...(plugin.evalSuite.test_cases || []).map((t) => t.id),
+              ...(plugin.evalSuite.edge_cases || []).map((e) => e.id),
+            ].filter(Boolean);
+            if (allIds.length > 0) {
+              const seen = new Set();
+              const dupes = [];
+              for (const id of allIds) {
+                if (seen.has(id)) dupes.push(id);
+                seen.add(id);
+              }
+              assert.equal(
+                dupes.length,
+                0,
+                `Found duplicate IDs across sections: ${dupes.join(", ")}`
+              );
+            }
+          });
+        });
+      }
+
+      if (plugin.skillMd) {
+        describe("SKILL.md", () => {
+          it("has YAML frontmatter with name", () => {
+            const fm = extractFrontmatter(plugin.skillMd);
+            assert.ok(fm.name, "SKILL.md must have a name in frontmatter");
+          });
+
+          it("frontmatter name matches plugin.json", () => {
+            const fm = extractFrontmatter(plugin.skillMd);
+            assert.equal(fm.name, plugin.pluginJson.name);
+          });
+
+          // Cross-version consistency: SKILL.md body version references must
+          // match plugin.json version. Catches the silent drift documented in
+          // PR #20 where PR #18 bumped plugin.json but SKILL.md still read
+          // the previous major.minor in its H1 and footer instruction.
+          //
+          // Convention: version references in SKILL.md body use v<major>.<minor>
+          // (no patch segment). The H1 check is generic — any "# <title> v<X>.<Y>"
+          // pattern. The HTML footer check fires only if the SKILL.md actually
+          // contains a Phase-15-style 'HTML footer should read "<title> v<X>.<Y>"'
+          // instruction (so plugins without HTML output skip cleanly).
+          const semverMatch = plugin.pluginJson.version?.match(/^(\d+)\.(\d+)\.\d+/);
+          if (semverMatch) {
+            const [, pluginMajor, pluginMinor] = semverMatch;
+
+            it("H1 header version matches plugin.json major.minor (if H1 carries a version)", () => {
+              // Extract the first H1 with a v<major>.<minor> suffix.
+              const headerMatch = plugin.skillMd.match(
+                /^#\s+.+?\sv(\d+)\.(\d+)\b/m
+              );
+              if (!headerMatch) {
+                // SKILL.md H1 has no version suffix — nothing to drift.
+                return;
+              }
+              const [, headerMajor, headerMinor] = headerMatch;
+              assert.equal(
+                `${headerMajor}.${headerMinor}`,
+                `${pluginMajor}.${pluginMinor}`,
+                `SKILL.md H1 header reads "v${headerMajor}.${headerMinor}" but plugin.json is "${plugin.pluginJson.version}" — expected "v${pluginMajor}.${pluginMinor}"`
+              );
+            });
+
+            it("HTML footer instruction version matches plugin.json major.minor (if present)", () => {
+              const footerMatch = plugin.skillMd.match(
+                /HTML footer should read "[^"]+?\sv(\d+)\.(\d+)/
+              );
+              if (!footerMatch) {
+                // No HTML footer instruction — plugin doesn't render HTML reports.
+                return;
+              }
+              const [, footerMajor, footerMinor] = footerMatch;
+              assert.equal(
+                `${footerMajor}.${footerMinor}`,
+                `${pluginMajor}.${pluginMinor}`,
+                `SKILL.md HTML footer instruction reads "v${footerMajor}.${footerMinor}" but plugin.json is "${plugin.pluginJson.version}" — expected "v${pluginMajor}.${pluginMinor}"`
+              );
+            });
+          }
+
+          if (plugin.nestedSkillMd) {
+            it("nested skills/ SKILL.md has matching frontmatter name", () => {
+              const nestedFm = extractFrontmatter(plugin.nestedSkillMd);
+              assert.ok(nestedFm.name, "nested SKILL.md must have a name in frontmatter");
+              assert.equal(nestedFm.name, plugin.pluginJson.name);
+            });
+          }
+        });
+      }
     });
   }
 
-  if (files.evalSuite) {
-    describe("eval-suite.json", () => {
-      // Handle both "skill_name" and "skill" field names
-      const evalSkillName = files.evalSuite.skill_name || files.evalSuite.skill;
-
+  // ---------------------------------------------------------------------------
+  // marketplace.json must reference every plugin and match versions
+  // ---------------------------------------------------------------------------
+  if (marketplaceJson) {
+    describe("marketplace.json", () => {
       it("has required top-level fields", () => {
-        assert.ok(evalSkillName, "must have skill_name or skill field");
-        assert.ok(files.evalSuite.version, "must have version");
+        assert.ok(marketplaceJson.name, "must have name");
+        assert.ok(marketplaceJson.description, "must have description");
+        assert.ok(marketplaceJson.plugins, "must have plugins array");
+        assert.ok(marketplaceJson.plugins.length > 0, "must have at least one plugin");
       });
 
-      it("skill name matches plugin.json", () => {
-        assert.equal(
-          evalSkillName,
-          SKILL_NAME,
-          `eval-suite skill name "${evalSkillName}" must match plugin.json name "${SKILL_NAME}"`
-        );
-      });
-
-      it("version matches plugin.json version", () => {
-        // Prevents silent drift where plugin.json is bumped (e.g. by a
-        // plugin-restructure PR) but eval-suite.json is forgotten. Caught
-        // by PR #20's dogfooding after PR #18 left eval-suite at 2.15.0
-        // while plugin.json was already at 2.16.0.
-        assert.equal(
-          files.evalSuite.version,
-          files.pluginJson.version,
-          `eval-suite.json version "${files.evalSuite.version}" must match plugin.json version "${files.pluginJson.version}"`
-        );
-      });
-
-      if (files.evalSuite.triggers) {
-        it("has triggers array with entries", () => {
-          assert.ok(files.evalSuite.triggers.length > 0, "triggers must not be empty");
-        });
-
-        it("trigger IDs are unique", () => {
-          const ids = files.evalSuite.triggers.map((t) => t.id).filter(Boolean);
-          if (ids.length > 0) {
-            const unique = new Set(ids);
-            assert.equal(ids.length, unique.size, "all trigger IDs must be unique");
-          }
-        });
-      }
-
-      if (files.evalSuite.test_cases) {
-        it("test_case IDs are unique", () => {
-          const ids = files.evalSuite.test_cases.map((t) => t.id).filter(Boolean);
-          if (ids.length > 0) {
-            const unique = new Set(ids);
-            assert.equal(ids.length, unique.size, "all test_case IDs must be unique");
-          }
-        });
-      }
-
-      if (files.evalSuite.edge_cases) {
-        it("edge_case IDs are unique", () => {
-          const ids = files.evalSuite.edge_cases.map((t) => t.id).filter(Boolean);
-          if (ids.length > 0) {
-            const unique = new Set(ids);
-            assert.equal(ids.length, unique.size, "all edge_case IDs must be unique");
-          }
-        });
-      }
-
-      it("no duplicate IDs across all sections", () => {
-        const allIds = [
-          ...(files.evalSuite.triggers || []).map((t) => t.id),
-          ...(files.evalSuite.test_cases || []).map((t) => t.id),
-          ...(files.evalSuite.edge_cases || []).map((e) => e.id),
-        ].filter(Boolean);
-        if (allIds.length > 0) {
-          const seen = new Set();
-          const dupes = [];
-          for (const id of allIds) {
-            if (seen.has(id)) dupes.push(id);
-            seen.add(id);
-          }
-          assert.equal(
-            dupes.length, 0,
-            `Found duplicate IDs across sections: ${dupes.join(", ")}`
-          );
+      it("each marketplace entry has required fields", () => {
+        for (const entry of marketplaceJson.plugins) {
+          assert.ok(entry.name, `plugin entry must have name (got ${JSON.stringify(entry)})`);
+          assert.ok(entry.description, `plugin entry "${entry.name}" must have description`);
+          assert.ok(entry.source, `plugin entry "${entry.name}" must have source`);
         }
       });
+
+      it("marketplace plugin count matches discovered plugins", () => {
+        assert.equal(
+          marketplaceJson.plugins.length,
+          plugins.length,
+          `marketplace lists ${marketplaceJson.plugins.length} plugins but discovered ${plugins.length} on disk`
+        );
+      });
+
+      // Per-entry version + source path validation
+      for (const entry of marketplaceJson.plugins) {
+        describe(`marketplace entry: ${entry.name}`, () => {
+          const matchedPlugin = plugins.find(
+            (p) => p.pluginJson.name === entry.name
+          );
+
+          it("matches a discovered plugin by name", () => {
+            assert.ok(
+              matchedPlugin,
+              `marketplace entry "${entry.name}" has no matching plugin on disk`
+            );
+          });
+
+          if (matchedPlugin && entry.version) {
+            it("version matches plugin.json version", () => {
+              assert.equal(
+                entry.version,
+                matchedPlugin.pluginJson.version,
+                `marketplace entry version "${entry.version}" must match plugin.json version "${matchedPlugin.pluginJson.version}"`
+              );
+            });
+          }
+
+          if (matchedPlugin && entry.source) {
+            it("source path resolves to the plugin directory", () => {
+              const sourceAbs = resolve(ROOT, entry.source);
+              const expected = resolve(ROOT, "plugins", matchedPlugin.dirName);
+              assert.equal(
+                sourceAbs,
+                expected,
+                `marketplace source "${entry.source}" must resolve to ${expected}`
+              );
+            });
+          }
+
+          if (entry.skills) {
+            it("skills paths resolve to existing locations", () => {
+              for (const skillPath of entry.skills) {
+                const fullPath = resolve(ROOT, skillPath);
+                assert.ok(
+                  existsSync(fullPath),
+                  `skill path "${skillPath}" must exist at ${fullPath}`
+                );
+              }
+            });
+          }
+        });
+      }
     });
   }
 
-  if (files.packageJson) {
+  // ---------------------------------------------------------------------------
+  // package.json: a workspace-level test runner. We only verify it has a test
+  // script and (where the workspace package name matches a plugin) that the
+  // version stays in lockstep with that plugin.
+  // ---------------------------------------------------------------------------
+  if (packageJson) {
     describe("package.json", () => {
-      it("name matches plugin.json", () => {
-        assert.equal(files.packageJson.name, SKILL_NAME);
-      });
-
       it("has test script", () => {
         assert.ok(
-          files.packageJson.scripts?.test,
+          packageJson.scripts?.test,
           "package.json must have a test script"
         );
       });
 
-      if (files.packageJson.version) {
-        it("version matches plugin.json version", () => {
-          // Prevents silent drift where plugin.json is bumped (e.g. by a
-          // plugin-restructure PR) but package.json is forgotten. Caught
-          // during PR #20's dogfooding after PR #18 left package.json at
-          // 2.15.0 while plugin.json was already at 2.16.0. This test only
-          // fires if package.json has a version field at all (some internal
-          // tooling repos omit it).
+      const matchingPlugin = plugins.find(
+        (p) => p.pluginJson.name === packageJson.name
+      );
+      if (matchingPlugin && packageJson.version) {
+        it(`version matches plugin.json version for "${packageJson.name}"`, () => {
           assert.equal(
-            files.packageJson.version,
-            files.pluginJson.version,
-            `package.json version "${files.packageJson.version}" must match plugin.json version "${files.pluginJson.version}"`
+            packageJson.version,
+            matchingPlugin.pluginJson.version,
+            `package.json version "${packageJson.version}" must match plugin.json version "${matchingPlugin.pluginJson.version}"`
           );
-        });
-      }
-    });
-  }
-
-  if (files.rootSkillMd) {
-    describe("SKILL.md", () => {
-      it("has YAML frontmatter with name", () => {
-        const fm = extractFrontmatter(files.rootSkillMd);
-        assert.ok(fm.name, "root SKILL.md must have a name in frontmatter");
-      });
-
-      it("frontmatter name matches plugin.json", () => {
-        const fm = extractFrontmatter(files.rootSkillMd);
-        assert.equal(fm.name, SKILL_NAME);
-      });
-
-      // ---------------------------------------------------------------------
-      // Cross-version consistency: SKILL.md body version references must
-      // match plugin.json version. Catches the silent drift documented in
-      // PR #20 where PR #18 bumped plugin.json to 2.16.0 but SKILL.md
-      // still read "# Agent Review Panel v2.15" and the HTML footer
-      // instruction still said "Agent Review Panel v2.15".
-      //
-      // Convention: version references in SKILL.md body use v<major>.<minor>
-      // format (no patch segment). We parse plugin.json's semver and
-      // assert that every "Agent Review Panel v<major>.<minor>" string in
-      // SKILL.md matches plugin.json's major.minor.
-      // ---------------------------------------------------------------------
-      const semverMatch = files.pluginJson?.version?.match(/^(\d+)\.(\d+)\.\d+/);
-      if (semverMatch) {
-        const [, pluginMajor, pluginMinor] = semverMatch;
-        const expectedVersionTag = `v${pluginMajor}.${pluginMinor}`;
-
-        it("H1 header version matches plugin.json major.minor", () => {
-          // Extract the first line matching "# Agent Review Panel v<X>.<Y>"
-          const headerMatch = files.rootSkillMd.match(
-            /^# Agent Review Panel v(\d+)\.(\d+)/m
-          );
-          assert.ok(
-            headerMatch,
-            "SKILL.md must contain an H1 header matching '# Agent Review Panel v<major>.<minor>'"
-          );
-          const [, headerMajor, headerMinor] = headerMatch;
-          assert.equal(
-            `${headerMajor}.${headerMinor}`,
-            `${pluginMajor}.${pluginMinor}`,
-            `SKILL.md H1 header reads "v${headerMajor}.${headerMinor}" but plugin.json is "${files.pluginJson.version}" — expected "${expectedVersionTag}"`
-          );
-        });
-
-        it("HTML footer instruction version matches plugin.json major.minor", () => {
-          // The Phase 15.3 HTML report agent is instructed to render a
-          // footer with the product version. This string must track
-          // plugin.json so users' rendered reports show a truthful
-          // version number and stale skills can be diagnosed by
-          // comparing footer against plugin.json.
-          const footerMatch = files.rootSkillMd.match(
-            /HTML footer should read "Agent Review Panel v(\d+)\.(\d+)/
-          );
-          assert.ok(
-            footerMatch,
-            "SKILL.md must contain a Phase 15.3 footer instruction matching 'HTML footer should read \"Agent Review Panel v<major>.<minor>'"
-          );
-          const [, footerMajor, footerMinor] = footerMatch;
-          assert.equal(
-            `${footerMajor}.${footerMinor}`,
-            `${pluginMajor}.${pluginMinor}`,
-            `SKILL.md HTML footer instruction reads "v${footerMajor}.${footerMinor}" but plugin.json is "${files.pluginJson.version}" — expected "${expectedVersionTag}"`
-          );
-        });
-      }
-
-      if (files.nestedSkillMd) {
-        it("nested skills/ SKILL.md has matching frontmatter name", () => {
-          const nestedFm = extractFrontmatter(files.nestedSkillMd);
-          assert.ok(nestedFm.name, "nested SKILL.md must have a name in frontmatter");
-          assert.equal(nestedFm.name, SKILL_NAME);
         });
       }
     });

--- a/tests/trigger-classification.test.mjs
+++ b/tests/trigger-classification.test.mjs
@@ -1,15 +1,15 @@
 /**
- * Trigger Classification Tests — Generalized Template
+ * Trigger Classification Tests — Multi-Plugin Marketplace
  *
- * Validates that eval-suite.json trigger entries are structurally correct
- * and that positive triggers contain keywords from the SKILL.md description.
+ * Validates eval-suite.json trigger entries for ALL plugins in the marketplace.
+ * Iterates over plugins/<name>/eval-suite.json and runs the structural checks
+ * against each plugin's own SKILL.md.
  *
- * This is a structural validator, NOT a full trigger classifier (that's
- * skill-specific). It checks:
- * - Triggers have required fields (id, prompt, should_trigger, category)
- * - Positive triggers contain at least one keyword from SKILL.md description
- * - Negative triggers exist and cover anti-patterns
- * - SKILL.md frontmatter mentions the slash command
+ * Structural checks (NOT a full classifier):
+ * - Triggers have required fields (prompt, should_trigger)
+ * - Positive triggers reference the skill name / slash command / keywords
+ * - Negative triggers exist
+ * - SKILL.md frontmatter mentions the skill name
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -20,98 +20,84 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-const evalSuitePath = resolve(ROOT, "eval-suite.json");
-if (!existsSync(evalSuitePath)) {
-  describe("Trigger classification", () => {
-    it("eval-suite.json not present — skipping", { skip: "no eval-suite.json" }, () => {});
-  });
-} else {
-  const evalSuite = JSON.parse(readFileSync(evalSuitePath, "utf-8"));
+// ---------------------------------------------------------------------------
+// Discover all plugins with eval-suites
+// ---------------------------------------------------------------------------
 
-  if (!evalSuite.triggers || evalSuite.triggers.length === 0) {
-    describe("Trigger classification", () => {
-      it("eval-suite has no triggers — skipping", { skip: "no triggers array" }, () => {});
-    });
-  } else {
-    // Find the best SKILL.md to extract trigger keywords from.
-    // Priority:
-    //   1. plugins/<name>/SKILL.md (canonical plugin layout)
-    //   2. plugins/<name>/skills/<skill>/SKILL.md (skill-within-plugin layout)
-    //   3. skills/<name>/SKILL.md (legacy flat-skill layout)
-    //   4. SKILL.md at repo root (legacy single-file layout)
-    let skillMdContent = "";
+function discoverPluginEvalSuites() {
+  const pluginsRoot = resolve(ROOT, "plugins");
+  const found = [];
 
-    // 1. Canonical plugin layout
-    const pluginsRoot = resolve(ROOT, "plugins");
-    if (existsSync(pluginsRoot)) {
-      try {
-        for (const entry of readdirSync(pluginsRoot, { withFileTypes: true })) {
-          if (!entry.isDirectory()) continue;
-          const direct = resolve(pluginsRoot, entry.name, "SKILL.md");
-          if (existsSync(direct)) {
-            skillMdContent = readFileSync(direct, "utf-8");
-            break;
-          }
-          // 2. skills-within-plugin layout
-          const skillsDirInPlugin = resolve(pluginsRoot, entry.name, "skills");
-          if (existsSync(skillsDirInPlugin)) {
-            try {
-              const subdirs = readdirSync(skillsDirInPlugin, { withFileTypes: true })
-                .filter((d) => d.isDirectory());
-              for (const subdir of subdirs) {
-                const candidate = resolve(skillsDirInPlugin, subdir.name, "SKILL.md");
-                if (existsSync(candidate)) {
-                  skillMdContent = readFileSync(candidate, "utf-8");
-                  break;
-                }
-              }
-            } catch { /* ignore */ }
-          }
-          if (skillMdContent) break;
-        }
-      } catch { /* fallback below */ }
-    }
+  if (existsSync(pluginsRoot)) {
+    for (const entry of readdirSync(pluginsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = resolve(pluginsRoot, entry.name);
+      const evalSuitePath = resolve(dir, "eval-suite.json");
+      if (!existsSync(evalSuitePath)) continue;
 
-    // 3. Legacy flat-skill layout
-    if (!skillMdContent) {
-      const skillsDir = resolve(ROOT, "skills");
-      if (existsSync(skillsDir)) {
+      const skillMdPath = resolve(dir, "SKILL.md");
+      const nestedSkillsDir = resolve(dir, "skills");
+      let nestedSkillMdPath = null;
+      if (!existsSync(skillMdPath) && existsSync(nestedSkillsDir)) {
         try {
-          const subdirs = readdirSync(skillsDir, { withFileTypes: true })
-            .filter((d) => d.isDirectory());
-          for (const subdir of subdirs) {
-            const candidate = resolve(skillsDir, subdir.name, "SKILL.md");
+          for (const sub of readdirSync(nestedSkillsDir, { withFileTypes: true })) {
+            if (!sub.isDirectory()) continue;
+            const candidate = resolve(nestedSkillsDir, sub.name, "SKILL.md");
             if (existsSync(candidate)) {
-              skillMdContent = readFileSync(candidate, "utf-8");
+              nestedSkillMdPath = candidate;
               break;
             }
           }
-        } catch { /* fallback below */ }
+        } catch { /* ignore */ }
       }
+
+      const finalSkillMdPath = existsSync(skillMdPath) ? skillMdPath : nestedSkillMdPath;
+      found.push({
+        dirName: entry.name,
+        evalSuite: JSON.parse(readFileSync(evalSuitePath, "utf-8")),
+        skillMdContent: finalSkillMdPath ? readFileSync(finalSkillMdPath, "utf-8") : "",
+      });
+    }
+  }
+
+  // Legacy fallback: root-level eval-suite.json + root SKILL.md
+  if (found.length === 0) {
+    const legacyEval = resolve(ROOT, "eval-suite.json");
+    if (existsSync(legacyEval)) {
+      const legacySkill = resolve(ROOT, "SKILL.md");
+      found.push({
+        dirName: "(legacy-root)",
+        evalSuite: JSON.parse(readFileSync(legacyEval, "utf-8")),
+        skillMdContent: existsSync(legacySkill) ? readFileSync(legacySkill, "utf-8") : "",
+      });
+    }
+  }
+
+  return found;
+}
+
+const pluginEvalSuites = discoverPluginEvalSuites();
+
+if (pluginEvalSuites.length === 0) {
+  describe("Trigger classification", () => {
+    it("no eval-suite.json found in any plugin — skipping", { skip: "no eval-suite" }, () => {});
+  });
+} else {
+  for (const { dirName, evalSuite, skillMdContent } of pluginEvalSuites) {
+    if (!evalSuite.triggers || evalSuite.triggers.length === 0) {
+      describe(`Trigger classification — ${dirName}`, () => {
+        it("eval-suite has no triggers — skipping", { skip: "no triggers array" }, () => {});
+      });
+      continue;
     }
 
-    // 4. Legacy single-file layout
-    if (!skillMdContent) {
-      const rootSkillMd = resolve(ROOT, "SKILL.md");
-      if (existsSync(rootSkillMd)) {
-        skillMdContent = readFileSync(rootSkillMd, "utf-8");
-      }
-    }
-
-    // Extract skill name for slash command check
     const skillName = evalSuite.skill_name || evalSuite.skill || "";
-
-    // Extract keywords from SKILL.md description field (frontmatter)
     const frontmatterMatch = skillMdContent.match(/^---\n([\s\S]*?)\n---/);
     const frontmatterText = frontmatterMatch
       ? frontmatterMatch[1].replace(/\n\s+/g, " ").toLowerCase()
       : "";
 
-    // ---------------------------------------------------------------------------
-    // Tests
-    // ---------------------------------------------------------------------------
-
-    describe("Trigger classification", () => {
+    describe(`Trigger classification — ${dirName}`, () => {
       describe("Trigger entries are well-formed", () => {
         for (const trigger of evalSuite.triggers) {
           it(`${trigger.id || trigger.prompt?.slice(0, 50)}`, () => {
@@ -132,16 +118,16 @@ if (!existsSync(evalSuitePath)) {
         });
 
         if (skillName) {
-          // Check if at least one trigger references the skill name, slash command,
-          // or any word from the skill name (e.g., "feature" from "ml-feature-evaluator")
           it("at least one trigger references the skill name, slash command, or skill keywords", () => {
             const slashCommand = `/${skillName}`;
             const nameWords = skillName.split("-").filter((w) => w.length > 2);
             const hasReference = positives.some((t) => {
               const lower = t.prompt.toLowerCase();
-              return lower.includes(slashCommand.toLowerCase()) ||
-                     lower.includes(skillName.toLowerCase()) ||
-                     nameWords.some((w) => lower.includes(w.toLowerCase()));
+              return (
+                lower.includes(slashCommand.toLowerCase()) ||
+                lower.includes(skillName.toLowerCase()) ||
+                nameWords.some((w) => lower.includes(w.toLowerCase()))
+              );
             });
             assert.ok(
               hasReference,
@@ -158,8 +144,6 @@ if (!existsSync(evalSuitePath)) {
           assert.ok(negatives.length > 0, "must have at least one negative trigger");
         });
 
-        // Note: some eval-suites have minimal negative triggers without metadata.
-        // This test only validates that metadata exists when the eval-suite uses it.
         const negativesWithMetadata = negatives.filter((t) => t.notes || t.category || t.id);
         if (negativesWithMetadata.length > 0) {
           it("negative triggers with IDs have explanatory notes or category", () => {
@@ -176,9 +160,9 @@ if (!existsSync(evalSuitePath)) {
         }
       });
 
-      if (frontmatterText) {
+      if (frontmatterText && skillName) {
         describe("SKILL.md frontmatter contains skill name", () => {
-          it(`frontmatter mentions skill name`, () => {
+          it("frontmatter mentions skill name", () => {
             assert.ok(
               frontmatterText.includes(skillName.toLowerCase()),
               `SKILL.md frontmatter should contain the skill name "${skillName}"`


### PR DESCRIPTION
## Summary

- Renames marketplace `wan-huiyan-agent-review-panel` → `plugin`. Install command becomes the more memorable `/plugin install agent-review-panel@plugin`.
- Bundles **plan-review-integrator** (v2.0.0) into this marketplace as a second plugin alongside agent-review-panel (v2.16.1). The full review→integrate pipeline ships from one repo.
- Refactors the test framework to multi-plugin: `manifest-consistency` and `trigger-classification` discover all plugins under `plugins/<name>/` and validate each independently. PR #21's 4 cross-version assertions are preserved per-plugin.
- Per-plugin eval-suites: `eval-suite.json` moved from repo root to `plugins/agent-review-panel/eval-suite.json`; new `plugins/plan-review-integrator/eval-suite.json` added.
- 308 → **352 tests** (+44 from plan-review-integrator coverage). All passing.

## Why bundled?

`plan-review-integrator` and `agent-review-panel` form one workflow. Shipping them together means matching versions, shared CI, one changelog, and one install command for the full pipeline. The standalone `wan-huiyan/plan-review-integrator` repo will be archived (manual step, post-merge).

## Breaking change

Existing users on either old marketplace name must uninstall + reinstall:

```
# Old installs
/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
/plugin marketplace remove wan-huiyan-agent-review-panel
/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
/plugin marketplace remove wan-huiyan-plan-review-integrator

# New bundled install
/plugin marketplace add wan-huiyan/agent-review-panel
/plugin install agent-review-panel@plugin
/plugin install plan-review-integrator@plugin
```

README has a dedicated **Migration from previous marketplaces** section with the same instructions.

## Multi-plugin test framework — the tricky bit

`tests/manifest-consistency.test.mjs` and `tests/trigger-classification.test.mjs` were single-plugin: discover the first `plugins/<name>/.claude-plugin/plugin.json`, validate it, walk away. After this PR they iterate every plugin independently.

Key design points:

- `discoverPlugins()` enumerates `plugins/*/`, builds a per-plugin object with `pluginJson`, `skillMd`, `evalSuite`, `nestedSkillMd`. Legacy fallback for repos that still keep these at root.
- Per-plugin assertion blocks: every plugin gets its own `describe(`Plugin: ${name}`)` with the full set of plugin.json + eval-suite + SKILL.md checks.
- `marketplace.json` assertions iterate every entry in `plugins[]`, match each against a discovered plugin by name, validate version + source path independently. New assertion: marketplace entry count must match discovered plugin count (catches forgetting to add an entry when adding a plugin folder).
- PR #21's 4 cross-version assertions (eval-suite version, package.json version, SKILL.md H1 header, SKILL.md HTML footer instruction) are now applied per-plugin. The H1 and HTML footer checks skip cleanly when a plugin's SKILL.md doesn't carry that pattern — plan-review-integrator has no HTML footer instruction, so its block skips that single assertion while still running the H1 check.
- ARP-specific tests (`eval-suite-integrity`, `behavioral-assertions`, `report-structure`, `golden-file`) stay agent-review-panel-specific. They were never generic and shouldn't be — they assert on Phase 3 / Phase 5 / v2.9 / v2.14 / v2.15 features that only this plugin has. Their `eval-suite.json` path was updated to `plugins/agent-review-panel/eval-suite.json`.

### Red-test validation

I deliberately drifted each plugin's `plugin.json` version to `9.9.9` and re-ran the manifest test:

| Drift target | Failures | Which assertions caught it |
|---|---|---|
| `plugins/plan-review-integrator/.claude-plugin/plugin.json` | **3** | eval-suite cross-version, marketplace entry version, SKILL.md H1 header |
| `plugins/agent-review-panel/.claude-plugin/plugin.json` | **5** | eval-suite + marketplace + package.json + H1 header + HTML footer instruction |

Each plugin's drift is caught **independently** — the refactor does not silently collapse to validating only the first plugin. Restored both files; 352/352 pass.

## Versions bumped

| File | Before | After |
|---|---|---|
| `plugins/agent-review-panel/.claude-plugin/plugin.json` | 2.16.0 | 2.16.1 |
| `plugins/agent-review-panel/eval-suite.json` | 2.16.0 | 2.16.1 |
| `package.json` | 2.16.0 | 2.16.1 |
| `plugins/plan-review-integrator/.claude-plugin/plugin.json` | 1.4.0 | 2.0.0 (in c6da667) |
| `plugins/plan-review-integrator/eval-suite.json` | 1.0.0 | 2.0.0 (lockstep with plugin.json — was upstream-drifted since first commit) |
| `.claude-plugin/marketplace.json` | name `wan-huiyan-agent-review-panel`, 1 plugin entry | name `plugin`, 2 plugin entries |

## Commits

1. `c6da667` — feat(bundle): copy plan-review-integrator plugin from standalone repo (prior session, file copies + version bump 1.4.0 → 2.0.0)
2. `d4210fb` — feat(bundle): rename marketplace to 'plugin' + bundle plan-review-integrator + multi-plugin tests (this PR)
3. `3e71a1c` — docs: CHANGELOG + README for v2.16.1 bundled marketplace

## Test plan

- [x] `npm test` — 352/352 pass
- [x] Red test: drift `plugins/agent-review-panel/.claude-plugin/plugin.json` version → 5 failures, all expected
- [x] Red test: drift `plugins/plan-review-integrator/.claude-plugin/plugin.json` version → 3 failures, all expected
- [ ] CI green on this branch
- [ ] Post-merge dogfood: install both plugins under new `@plugin` marketplace name from a fresh Claude Code session, verify both load
- [ ] Post-merge: archive `wan-huiyan/plan-review-integrator` repo with the migration README (draft saved at `/tmp/archived-pri-readme-draft.md` on the dev machine)

## What this PR does NOT do

- Does **not** archive the standalone `wan-huiyan/plan-review-integrator` repo. Manual GitHub step done after this PR merges and dogfood confirms the bundled version loads.
- Does **not** modify any agent-review-panel feature behavior. SKILL.md content unchanged. Phase definitions unchanged. Reviewer prompts unchanged. This is purely packaging + version drift fixes + test framework generalization.
- Does **not** delete `tests/eval-suite-integrity.test.mjs` or split it for plan-review-integrator. The hand-tailored ARP-specific assertions (v2.9 / v2.14 / v2.15 categories) live as-is. PRI's eval-suite gets coverage from the generalized `manifest-consistency` and `trigger-classification` tests, which is sufficient for its surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
