### PR TITLE
hotfix(plugin): add "skills": ["./"] — plugin was silently loading with zero skills since PR #18

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
     {
       "name": "agent-review-panel",
       "source": "./plugins/agent-review-panel",
-      "version": "2.16.1",
+      "version": "2.16.2",
       "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research."
     },
     {
       "name": "plan-review-integrator",
       "source": "./plugins/plan-review-integrator",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Integrate structured review panel findings into implementation plan documents with full traceability. Pairs with agent-review-panel as the integrate stage of a review→integrate pipeline."
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Agent Review Panel.
 
+## [2.16.2] — 2026-04-08
+
+### Fixed — Plugin layout bug that silently broke all marketplace installs
+- **`plugins/<name>/.claude-plugin/plugin.json` now declares `"skills": ["./"]`.** Without this field, Claude Code's plugin loader does NOT auto-discover `SKILL.md` at the plugin root — it only looks in the default `skills/<name>/SKILL.md` sub-directory. Every install since PR #18 (v2.16) has been silently loading the plugin with ZERO registered skills. Users hit `Unknown skill: agent-review-panel` the first time they tried the slash command on a clean install, because the skill was never loaded in the first place. Empirically confirmed by `claude --debug --plugin-dir ./plugins/agent-review-panel` reporting no skills loaded on the pre-fix layout, and reporting both `agent-review-panel:agent-review-panel` and `plan-review-integrator:plan-review-integrator` loaded on the post-fix layout.
+- **Why nobody noticed for two weeks:** users who previously had `~/.claude/skills/agent-review-panel/` from a pre-PR-#18 manual clone had that loose-skill install shadowing the broken marketplace install (exactly the stale-clone gotcha PR #19 documented). The plugin "worked" because the loose skill worked, not because the plugin did. Anyone who clean-installed for the first time hit the bug immediately.
+- **Structural tests didn't catch it** because `tests/manifest-consistency.test.mjs` validates file structure and JSON schema, not actual plugin-loader behavior. We now know: `claude plugin validate` checks the manifest schema but doesn't tell you whether the skill will actually load — the only empirical check is `claude --debug --plugin-dir ./plugins/<name> --print "list skills"` and reading the loaded-skills list. Consider adding this as a test step in a future PR.
+
+### Fixed — plan-review-integrator manifest schema error (inherited from upstream)
+- `author: "wan-huiyan"` (string) → `author: {"name": "wan-huiyan", "url": "https://github.com/wan-huiyan"}` (object). The schema requires an object; the string form was an upstream bug that `claude plugin validate` now rejects.
+
+### Fixed — README documented the wrong slash command
+- All `/agent-review-panel` slash command references updated to `/agent-review-panel:agent-review-panel` (the namespaced form that plugin skills actually get). A new ⚠️ callout explains the `/<plugin>:<skill>` convention and reminds users that natural-language invocation works either way.
+
+### Bumped
+- `plugins/agent-review-panel/.claude-plugin/plugin.json`: 2.16.1 → 2.16.2
+- `plugins/agent-review-panel/eval-suite.json`: 2.16.1 → 2.16.2
+- `package.json`: 2.16.1 → 2.16.2
+- `plugins/plan-review-integrator/.claude-plugin/plugin.json`: 2.0.0 → 2.0.1
+- `plugins/plan-review-integrator/eval-suite.json`: 2.0.0 → 2.0.1
+- `.claude-plugin/marketplace.json`: both entries bumped to match
+
 ## [2.16.1] — 2026-04-08
 
 ### Changed — Marketplace bundle (PR #22)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ A [Claude Code](https://claude.ai/code) **plugin** that orchestrates multi-agent
 ```
 > Review this implementation plan from multiple perspectives: docs/my_plan.md
 
-> /agent-review-panel
+> /agent-review-panel:agent-review-panel
 ```
+
+> ⚠️ **Plugin slash commands are namespaced as `/<plugin>:<skill>`**. Because both the plugin and its skill are named `agent-review-panel`, the slash form is `/agent-review-panel:agent-review-panel`. Natural-language invocation (the first example above — "Review this implementation plan from multiple perspectives: ...") works without the slash command because it triggers by the skill's description, not by exact slash match. Use whichever feels more natural.
 
 **What you get:** Three output files:
 - `review_panel_report.md` — executive summary, consensus, disagreements (with judge rulings), prioritized action items tagged with epistemic labels
@@ -91,7 +93,7 @@ This plugin **only works inside [Claude Code](https://claude.ai/code)** — the 
 - ❌ **claude.ai web chat** — same reason: no `Agent` tool, no subagent spawning, no local-filesystem access, no `/plugin` surface.
 - ❌ **Claude API direct** — same reason.
 
-**Why:** the panel spawns 4–6 reviewer subagents in parallel via Claude Code's `Agent` tool, reads/writes files on your local filesystem to generate the three output reports, and responds to the `/agent-review-panel` slash command. Only Claude Code surfaces expose those capabilities.
+**Why:** the panel spawns 4–6 reviewer subagents in parallel via Claude Code's `Agent` tool, reads/writes files on your local filesystem to generate the three output reports, and responds to the `/agent-review-panel:agent-review-panel` slash command (or any natural-language "review panel" request). Only Claude Code surfaces expose those capabilities.
 
 Don't have Claude Code yet? Install it from **[claude.ai/code](https://claude.ai/code)**, then come back and run the [Quick Start](#quick-start) commands above.
 
@@ -106,7 +108,7 @@ claude plugin marketplace add wan-huiyan/agent-review-panel
 claude plugin install agent-review-panel@plugin
 ```
 
-Claude Code downloads the plugin to its cache, loads the `agent-review-panel` skill inside it, and activates the trigger phrases automatically. The plugin then activates when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel`.
+Claude Code downloads the plugin to its cache, loads the `agent-review-panel` skill inside it, and activates the trigger phrases automatically. The plugin then activates when you ask for multi-perspective reviews, panel reviews, adversarial reviews, or invoke `/agent-review-panel:agent-review-panel`.
 
 > **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `plugin` (defined in `.claude-plugin/marketplace.json`), which is distinct from the plugin name `agent-review-panel`. Pre-v2.16.1 releases used `@wan-huiyan-agent-review-panel`; pre-v2.16 used `@agent-review-panel`. If you installed under an older marketplace name, see the [Migration](#migration-from-previous-marketplaces) section to switch.
 
@@ -278,7 +280,7 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 ```
 > Review this implementation plan from multiple perspectives: docs/my_plan.md
 
-> /agent-review-panel
+> /agent-review-panel:agent-review-panel
 
 > Get a panel review of the authentication module — I want to stress-test the design
 
@@ -286,9 +288,9 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 
 > Have agents debate whether this refactor is worth the complexity
 
-> /agent-review-panel deep              # adds web research for domain best practices
+> /agent-review-panel:agent-review-panel deep   # adds web research for domain best practices
 
-> Do a deep review of this ML pipeline   # also triggers deep research mode
+> Do a deep review of this ML pipeline          # also triggers deep research mode
 ```
 
 The skill auto-detects content type and selects appropriate personas and review mode. You can also specify custom reviewers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "private": true,
   "description": "Multi-agent adversarial review panel for Claude Code",
   "scripts": {

--- a/plugins/agent-review-panel/.claude-plugin/plugin.json
+++ b/plugins/agent-review-panel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Multi-agent adversarial review panel — 4-6 AI reviewers debate your code/plans, then a judge delivers a structured verdict with epistemic labels",
   "author": {
     "name": "wan-huiyan",
@@ -15,5 +15,6 @@
     "code-review",
     "adversarial",
     "evaluation"
-  ]
+  ],
+  "skills": ["./"]
 }

--- a/plugins/agent-review-panel/eval-suite.json
+++ b/plugins/agent-review-panel/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "agent-review-panel",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "created_by": "manual",
   "updated": "2026-04-07",
   "triggers": [

--- a/plugins/plan-review-integrator/.claude-plugin/plugin.json
+++ b/plugins/plan-review-integrator/.claude-plugin/plugin.json
@@ -1,7 +1,10 @@
 {
   "name": "plan-review-integrator",
-  "version": "2.0.0",
-  "author": "wan-huiyan",
+  "version": "2.0.1",
+  "author": {
+    "name": "wan-huiyan",
+    "url": "https://github.com/wan-huiyan"
+  },
   "description": "Integrate structured review panel findings into implementation plan documents with full traceability.",
   "keywords": [
     "claude-code",
@@ -11,5 +14,6 @@
     "review-integration",
     "multi-agent",
     "voltagent-integration"
-  ]
+  ],
+  "skills": ["./"]
 }

--- a/plugins/plan-review-integrator/eval-suite.json
+++ b/plugins/plan-review-integrator/eval-suite.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.0.1",
   "skill": "plan-review-integrator",
   "triggers": [
     {"prompt": "update the plan with review findings", "should_trigger": true},


### PR DESCRIPTION
## TL;DR

**Every marketplace install of this plugin since PR #18 (v2.16, 2026-04-07) has been silently broken.** The plugin loaded but registered zero skills, so any user who ran a clean install and typed `/agent-review-panel` got `Unknown skill: agent-review-panel`. Users with a pre-PR-#18 loose-skill clone at `~/.claude/skills/agent-review-panel/` didn't see the bug because the loose skill shadowed the broken plugin — the stale-clone gotcha documented in PR #19, hiding a different bug underneath.

## The bug

Claude Code's plugin loader default skill location is `plugins/<name>/skills/<skill>/SKILL.md`. A plugin with `SKILL.md` at the **plugin root** (not inside a `skills/<name>/` subdir) MUST declare `"skills": ["./"]` in `plugin.json` to tell the loader where the skill lives. Without that field, default discovery finds nothing and the plugin registers with zero skills.

PR #18 moved `SKILL.md` from the repo root to `plugins/agent-review-panel/SKILL.md` (plugin root) but never added the `"skills"` declaration. Same for `plan-review-integrator` when it was bundled in PR #22.

## How we found it

User ran the README's install commands today after cleaning up old marketplace state and hit `Unknown skill: agent-review-panel`. Their ground-truth reference plugin (VoltAgent) uses a completely different pattern — `"agents": [...]` with explicit file paths — so it didn't shed light on our layout. After confirming that `causal-impact-campaign` (same repo structure as ours) had never actually been empirically tested, we ran the definitive check:

```bash
claude --debug --plugin-dir ./plugins/agent-review-panel --print \
  "Loaded skills named 'agent-review-panel' or similar — YES or NO?"
```

**Before fix:** `NO`.
**After fix:** `agent-review-panel: LOADED / plan-review-integrator: LOADED`.

## Changes

### 1. Plugin manifests — add `"skills": ["./"]`

- `plugins/agent-review-panel/.claude-plugin/plugin.json` — added `"skills": ["./"]`, bumped **2.16.1 → 2.16.2**
- `plugins/plan-review-integrator/.claude-plugin/plugin.json` — added `"skills": ["./"]`, bumped **2.0.0 → 2.0.1**, and fixed inherited upstream schema error (`author` was a string, schema requires object) that `claude plugin validate` was rejecting

### 2. Cross-version sync (to keep PR #21 drift-detection tests green)

| File | Before | After |
|---|---|---|
| `plugins/agent-review-panel/eval-suite.json` | 2.16.1 | **2.16.2** |
| `package.json` | 2.16.1 | **2.16.2** |
| `plugins/plan-review-integrator/eval-suite.json` | 2.0.0 | **2.0.1** |
| `.claude-plugin/marketplace.json` (both entries) | 2.16.1 / 2.0.0 | **2.16.2 / 2.0.1** |

### 3. README slash-command fix

The README had `/agent-review-panel` (bare) in three places. Plugin skills are namespaced as `/<plugin>:<skill>`, so the actual working form is `/agent-review-panel:agent-review-panel`. Updated all three occurrences and added a callout block explaining the namespacing convention, plus a note that natural-language invocation works either way because it triggers by description match rather than exact slash command.

### 4. CHANGELOG `[2.16.2]` entry

Full diagnosis, why nobody noticed for two weeks, the empirical verification method, and a note that structural tests don't catch loader behavior (leaves a future-PR nudge to add an empirical plugin-load test).

## Verification

- [x] `claude plugin validate plugins/agent-review-panel` — **PASS**
- [x] `claude plugin validate plugins/plan-review-integrator` — **PASS** (was FAILING on main due to `author` schema bug)
- [x] `claude --plugin-dir ./plugins/agent-review-panel --plugin-dir ./plugins/plan-review-integrator --print "which skills are loaded?"` — **both report LOADED**
- [x] `npm test` — **352/352 pass**
- [ ] Post-merge: user runs the README install commands against main from a fully cleaned state (no old marketplace, no orphaned plugin cache, no stale `~/.claude/skills/agent-review-panel/`), confirms plugin loads and both slash + natural-language invocation work in a fresh Claude Code session

## What this PR does NOT fix

- **`causal-impact-campaign` has the same bug.** Same author, same repo structure (`SKILL.md` at plugin root, no `"skills"` field). User confirmed they never actually empirically tested the slash command after installing — they assumed it worked. It almost certainly doesn't. That's a separate repo and a separate PR.
- **Structural tests don't simulate the loader.** `manifest-consistency.test.mjs` happily validated a plugin.json that causes zero skills to load. An empirical load test (running `claude --plugin-dir` and grepping for skill registration) would have caught this in PR #18's CI. Leaving as a follow-up because it needs a non-trivial test harness.
- **PR #23 (docs cleanup) is still open separately.** This hotfix and that PR are independent. Merge order doesn't matter.

## Notes for future sessions

Added to global `~/.claude/lessons.md` as a follow-up: **structural validation of a plugin manifest (schema, JSON, cross-file version consistency) does not prove the plugin's skills actually load. The only authoritative check is an empirical `claude --debug --plugin-dir` invocation that asks the loaded model to list its registered skills.** The entire chain of PRs #18 → #19 → #20 → #21 → #22 each added more structural tests and more schema guards without ever asking Claude Code "did the skill actually load?" — and the answer was NO the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)