### PR TITLE
docs(README): unify shell-form and REPL-form install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,27 @@ A [Claude Code](https://claude.ai/code) **plugin** that orchestrates multi-agent
 
 ## Quick Start
 
-**Install (recommended — Claude Code marketplace):**
+**Install (recommended — Claude Code marketplace).** Run these **in your terminal** (bash/zsh):
+
+```bash
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install agent-review-panel@plugin
+claude plugin install plan-review-integrator@plugin    # optional companion: integrate review findings into plans
+```
+
+<details>
+<summary>Already inside a Claude Code session? Use the slash-command form instead</summary>
+
+Type these at the REPL prompt (note the leading `/` and no `claude` prefix):
+
 ```
 /plugin marketplace add wan-huiyan/agent-review-panel
 /plugin install agent-review-panel@plugin
-/plugin install plan-review-integrator@plugin    # optional companion: integrate review findings into plans
+/plugin install plan-review-integrator@plugin
 ```
+
+Both forms do the same thing. Pick whichever matches where you are: shell-form `claude plugin …` for terminal, REPL-form `/plugin …` for inside Claude Code.
+</details>
 
 > The marketplace bundles **two plugins**: `agent-review-panel` (this project) and `plan-review-integrator` (the review→integrate companion). See [Bundled plugins](#bundled-plugins) below.
 
@@ -116,19 +131,22 @@ Claude Code downloads the plugin to its cache, loads the `agent-review-panel` sk
 
 ### Updating to the latest version
 
-New releases land on `main`; Claude Code does not auto-pull. Run the update flow after each release (or any time you want the newest features):
+New releases land on `main`; Claude Code does not auto-pull. Run the update flow after each release (or any time you want the newest features) **in your terminal**:
+
+```bash
+claude plugin marketplace update plugin
+claude plugin update agent-review-panel@plugin
+```
+
+<details>
+<summary>Or, if you're already in a Claude Code session, use the slash-command form</summary>
 
 ```
 /plugin marketplace update plugin
 /plugin update agent-review-panel@plugin
 ```
 
-CLI equivalent:
-
-```bash
-claude plugin marketplace update plugin
-claude plugin update agent-review-panel@plugin
-```
+</details>
 
 **Verify the update worked:**
 ```bash
@@ -150,7 +168,17 @@ rm -rf ~/.claude/skills/agent-review-panel
 
 Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/plugin/` will take over.
 
-**Fallback — clean reinstall:** If the update commands misbehave, uninstall and reinstall from scratch:
+**Fallback — clean reinstall:** If the update commands misbehave, uninstall and reinstall from scratch. From your terminal:
+
+```bash
+claude plugin uninstall agent-review-panel@plugin
+claude plugin marketplace remove plugin
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install agent-review-panel@plugin
+```
+
+<details>
+<summary>REPL-form equivalent (inside a Claude Code session)</summary>
 
 ```
 /plugin uninstall agent-review-panel@plugin
@@ -158,6 +186,8 @@ Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/pl
 /plugin marketplace add wan-huiyan/agent-review-panel
 /plugin install agent-review-panel@plugin
 ```
+
+</details>
 
 ### Manual clone (development / custom setup)
 
@@ -350,32 +380,50 @@ This marketplace ships **two plugins** in one repository. They are independently
 | `agent-review-panel` | [`plugins/agent-review-panel/`](plugins/agent-review-panel/) | Multi-agent adversarial review panel — 4–6 reviewers debate, judge renders final verdict (this project, v2.16.1) | When you need a structured review of code, plans, docs, or configs |
 | `plan-review-integrator` | [`plugins/plan-review-integrator/`](plugins/plan-review-integrator/) | Takes review panel output and integrates findings into an implementation plan — classifies each finding, applies concrete edits, produces a traceability summary (v2.0.0) | After a panel review of a plan document, when you need findings reflected in the plan with traceability |
 
-Install both for the full review→integrate pipeline:
+Install both for the full review→integrate pipeline. From your terminal:
+
+```bash
+claude plugin install agent-review-panel@plugin
+claude plugin install plan-review-integrator@plugin
 ```
-/plugin install agent-review-panel@plugin
-/plugin install plan-review-integrator@plugin
-```
+
+(Or, inside a Claude Code session, use the REPL form: `/plugin install agent-review-panel@plugin` and `/plugin install plan-review-integrator@plugin`.)
 
 `plan-review-integrator` was previously published as a standalone repo at `wan-huiyan/plan-review-integrator`. That repo is now **archived** in favor of the bundled distribution here. See [Migration](#migration-from-previous-marketplaces) for upgrade instructions.
 
 ## Migration from previous marketplaces
 
-If you installed before v2.16.1, you used one of the old marketplace names. Migrate with:
+If you installed before v2.16.1, you used one of the old marketplace names. Migrate from your terminal:
 
-```
+```bash
 # Old agent-review-panel install
-/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
-/plugin marketplace remove wan-huiyan-agent-review-panel
+claude plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+claude plugin marketplace remove wan-huiyan-agent-review-panel
 
 # Old plan-review-integrator standalone install (if applicable)
-/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
-/plugin marketplace remove wan-huiyan-plan-review-integrator
+claude plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
+claude plugin marketplace remove wan-huiyan-plan-review-integrator
 
 # New bundled install
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install agent-review-panel@plugin
+claude plugin install plan-review-integrator@plugin
+```
+
+<details>
+<summary>REPL-form equivalent (inside a Claude Code session)</summary>
+
+```
+/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace remove wan-huiyan-agent-review-panel
+/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
+/plugin marketplace remove wan-huiyan-plan-review-integrator
 /plugin marketplace add wan-huiyan/agent-review-panel
 /plugin install agent-review-panel@plugin
 /plugin install plan-review-integrator@plugin
 ```
+
+</details>
 
 Verify both are loaded under the new marketplace:
 ```
@@ -395,11 +443,13 @@ Please open an issue to discuss before submitting large PRs.
 
 ## Uninstalling
 
-**If installed via marketplace:**
+**If installed via marketplace**, from your terminal:
+```bash
+claude plugin uninstall agent-review-panel@plugin
+claude plugin marketplace remove plugin
 ```
-/plugin uninstall agent-review-panel@plugin
-/plugin marketplace remove plugin
-```
+
+(REPL-form equivalent: `/plugin uninstall agent-review-panel@plugin` and `/plugin marketplace remove plugin`.)
 
 **If installed via manual clone:**
 ```bash


### PR DESCRIPTION
## Problem

Post-PR-#24 dogfood exposed a real UX issue: the README's Quick Start shows the REPL-form install commands (`/plugin marketplace add ...`), but any terminal-based walkthrough uses the shell form (`claude plugin marketplace add ...`). Both forms do the same thing, but they work in different places:

- **REPL form** (`/plugin ...`) — typed at the prompt inside a running Claude Code session
- **Shell form** (`claude plugin ...`) — typed in your OS terminal (bash/zsh)

New users reading the README on GitHub haven't started a Claude Code session yet — they're at their shell. Pasting `/plugin marketplace add ...` into bash/zsh fails silently with `zsh: no matches found`. The later "Claude Code marketplace (recommended)" section eventually shows the shell equivalent, but by then the user has already been confused and possibly given up.

## Fix

Make **shell form the primary** everywhere, with REPL form as a collapsible `<details>` alternative. Rationale: every other CLI tool install instruction (`npm install`, `pip install`, `brew install`) shows shell form by default. That matches where a first-time user actually is when reading install instructions.

## Sections updated

| Section | Before | After |
|---|---|---|
| Quick Start (install block) | REPL form only | Shell primary, REPL in `<details>`, explicit "Run these in your terminal" heading |
| Bundled plugins install-both | REPL form only | Shell primary with parenthetical REPL alternative |
| Updating to the latest version | REPL form primary + "CLI equivalent" block | Shell primary, REPL in `<details>` |
| Fallback clean reinstall | REPL form only | Shell primary, REPL in `<details>` |
| Migration from previous marketplaces | REPL form only | Shell primary, REPL in `<details>` |
| Uninstalling | REPL form only | Shell primary with parenthetical REPL note |

## What this does NOT change

- Install command semantics (marketplace name still `plugin`, plugin names unchanged, slash command still `/agent-review-panel:agent-review-panel`)
- Any non-install content
- Any file other than README.md

## Test plan

- [x] `npm test` — 352/352 pass
- [x] `grep '^claude plugin\|^/plugin' README.md` — every install/update/uninstall command now has both forms, shell primary
- [ ] Post-merge: user copies Quick Start block directly into terminal — should work without pasting slash commands into a non-REPL shell

## Related

- **PR #24** (merged) — fixed the underlying plugin layout bug so the install commands actually work at all
- **Lesson #146** (global `~/.claude/lessons.md`) — captures the plugin-layout bug for future sessions
- **Lesson #134** (global `~/.claude/lessons.md`) — "README install instructions silently drift from marketplace manifests"; this PR is the inverse case (form drift within README itself, not drift from manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)