### PR TITLE
fix(phase-15.3): reliable HTML report generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "agent-review-panel",
       "source": "./plugins/agent-review-panel",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research."
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Phase 15.3 (Interactive HTML Report) silently failed in most runs because the or
 - **Manual recovery path:** "generate the HTML review report" launches the Phase 15.3 agent with the same disk-reading prompt, following the authoritative spec.
 - **Path resolution:** Orchestrator resolves `{output_dir}` and `{skill_dir}` to absolute paths. Custom filenames handled.
 - **Legacy language fix:** Updated `prompt-templates.md` Reference Inputs section to align with disk-reading strategy.
+- **Version unification:** SKILL.md heading and HTML footer instruction now show the full semver (`v2.16.4`) instead of the bare major version (`v2.16`). Single source of truth: `plugin.json` version is the canonical version; SKILL.md heading and footer instruction must match it on every bump.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Agent Review Panel.
 
+## [2.16.4] — 2026-04-15
+
+### Fixed — Phase 15.3 Reliability (HTML Report Generation)
+
+Phase 15.3 (Interactive HTML Report) silently failed in most runs because the orchestrator's context window was near capacity after 14 phases, causing the subagent launch to fail.
+
+- **Sequential Phase 15:** 15.1 → 15.2 → 15.3 (no longer parallel). Latency impact: ~2s.
+- **Disk-reading data strategy:** Phase 15.3 agent reads `review_panel_report.md`, `review_panel_process.md`, and the rendering spec from `references/prompt-templates.md` directly. Orchestrator prompt drops from 700+ lines to ~10 lines.
+- **Verification gate:** Mandatory file-existence check for all 3 output files before reporting completion. Auto-retry once if HTML is missing.
+- **Manual recovery path:** "generate the HTML review report" launches the Phase 15.3 agent with the same disk-reading prompt, following the authoritative spec.
+- **Path resolution:** Orchestrator resolves `{output_dir}` and `{skill_dir}` to absolute paths. Custom filenames handled.
+- **Legacy language fix:** Updated `prompt-templates.md` Reference Inputs section to align with disk-reading strategy.
+
+---
+
 ## [2.16.3] — 2026-04-09
 
 ### Added — External Domain Claim Web Verification in Phase 11

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -277,6 +277,9 @@ Techniques evaluated and rejected for our use case.
 | v2.15 | 2026-04-07 | **Expandable 10-section issue cards** in Phase 15.3 HTML dashboard (narrative, code evidence, debate, judge ruling, fix recommendation, cross-references, prior runs), deep-linking, keyboard nav, expand all/collapse all, print-friendly CSS, Prism.js syntax highlighting (CDN) |
 | v2.16 | 2026-04-07 | **Canonical plugin layout** — restructured to `plugins/<name>/SKILL.md` + `plugins/<name>/.claude-plugin/plugin.json` for Claude Code plugin marketplace compliance (PR #18). Marketplace manifest moved to `.claude-plugin/marketplace.json` with owner-prefixed name. Follow-ups: install-command fix + stale-clone diagnosis docs (PR #19), README dedupe + plugin rebrand + version drift cleanup (PR #20), 4 cross-version consistency assertions (PR #21). |
 | v2.16.1 | 2026-04-08 | **Multi-plugin marketplace bundle** (PR #22) — renamed marketplace to `plugin`; bundled `plan-review-integrator` v2.0.0 as a second plugin in the same repo; moved `eval-suite.json` to per-plugin location; refactored `manifest-consistency` and `trigger-classification` tests to iterate all plugins with independent per-plugin cross-version checks. Test count: 308 → 352. |
+| v2.16.2 | 2026-04-08 | **README unification** (PR #25) — unified shell-form and REPL-form install instructions with shell-form as primary. |
+| v2.16.3 | 2026-04-09 | **External domain claim web verification in Phase 11** — P0/P1 findings with external domain claims (product limits, API behavior, regulatory jurisdiction) auto-verified via web search. New labels: `[WEB-VERIFIED]`, `[WEB-CONTRADICTED]`, `[WEB-INCONCLUSIVE]`. |
+| v2.16.4 | 2026-04-15 | **Phase 15.3 reliability fix** (PR #26) — sequential Phase 15 execution (15.1→15.2→15.3), disk-reading data strategy (agent reads files instead of orchestrator injection), mandatory verification gate, manual recovery path. Fixes silent HTML report generation failure. |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "private": true,
   "description": "Multi-agent adversarial review panel for Claude Code",
   "scripts": {

--- a/plugins/agent-review-panel/.claude-plugin/plugin.json
+++ b/plugins/agent-review-panel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-review-panel",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "description": "Multi-agent adversarial review panel — 4-6 AI reviewers debate your code/plans, then a judge delivers a structured verdict with epistemic labels",
   "author": {
     "name": "wan-huiyan",

--- a/plugins/agent-review-panel/SKILL.md
+++ b/plugins/agent-review-panel/SKILL.md
@@ -909,8 +909,12 @@ See `references/prompt-templates.md` for the full judge prompt.
 
 ## Phase 15: Output Generation
 
-Three output files are written at the end of every review. All three are produced
-sequentially; Phases 15.2 and 15.3 run in parallel once Phase 15.1 is complete.
+Three output files are written at the end of every review. They are produced
+in strict sequence: Phase 15.1 first, then Phase 15.2, then Phase 15.3.
+Phase 15.3 runs AFTER Phase 15.2 (not in parallel) so that the Phase 15.3
+agent can read the already-written Phase 15.1 and 15.2 files from disk,
+avoiding the need for the orchestrator to inject all structured data and
+process history into the agent prompt from its own context window.
 
 ---
 
@@ -1069,8 +1073,46 @@ See `references/prompt-templates.md` for the Phase 15.2 assembly spec.
 
 Launch a single Opus agent to write `review_panel_report.html` — a polished,
 self-contained single-file interactive dashboard with **expandable issue
-cards** (v2.15). The agent receives the full structured data from all prior
-phases AND the Phase 15.2 process history as reference context.
+cards** (v2.15).
+
+**CRITICAL — Data passing strategy (v2.16.4 context-pressure fix):** Do NOT
+inject the structured data or process history into the agent prompt from the
+orchestrator's context. Instead, the agent prompt MUST instruct the agent to
+read from disk:
+1. Read `review_panel_report.md` (already written by Phase 15.1) for all
+   structured summary data (verdict, scores, action items, consensus, etc.)
+2. Read `review_panel_process.md` (already written by Phase 15.2) for
+   verbatim reviewer narratives, debate transcripts, judge rulings, and
+   verification agent trails — extracting per-finding content for the
+   10-section accordion
+3. Read `references/prompt-templates.md` starting from the line
+   `## Phase 15.3: HTML Report Generation Prompt` for the full rendering
+   spec (HTML structure, CSS, JS, expandable card schema, filter logic,
+   Prism.js setup, print styles)
+
+**Path resolution (CRITICAL):** The orchestrator MUST resolve all paths to
+absolute paths before including them in the Phase 15.3 agent prompt. The
+subagent has no knowledge of the skill installation directory or the user's
+output directory. Substitute:
+- `{output_dir}` → the actual resolved output directory (where Phase 15.1
+  wrote `review_panel_report.md`)
+- `{skill_dir}` → the absolute path to the skill's `references/` directory
+- If the user specified a custom output name (e.g., `--output my_review.md`),
+  use the actual filenames, not the defaults
+
+The orchestrator's Phase 15.3 launch prompt should be SHORT (~10 lines):
+```
+You are the Phase 15.3 HTML Report Agent. Generate `{output_dir}/{html_filename}`
+by reading these files:
+1. {output_dir}/{report_filename} — structured review data
+2. {output_dir}/{process_filename} — verbatim narratives and transcripts
+3. {skill_dir}/references/prompt-templates.md (search for "Phase 15.3: HTML
+   Report Generation Prompt") — the authoritative rendering spec
+Follow the rendering spec exactly. Write the complete HTML file.
+```
+
+This keeps the orchestrator's launch prompt under 200 tokens instead of
+700+ lines, eliminating the context-pressure failure mode.
 
 **Features:**
 - Dashboard overview: verdict, score, panel composition at a glance
@@ -1112,13 +1154,53 @@ full 10-section schema and rendering spec.
 
 ---
 
-After all three files are written, tell user:
-- Paths to all three output files
+### Phase 15 Verification Gate (MANDATORY — v2.16.4)
+
+Before reporting completion, verify ALL THREE output files exist by checking
+that each file was successfully written (e.g., `ls -la review_panel_report.md
+review_panel_process.md review_panel_report.html`).
+
+**If all three files exist:** proceed to the completion message below.
+
+**If `review_panel_report.html` is missing (Phase 15.3 failed):**
+1. Log: "Phase 15.3 HTML report generation failed. Retrying..."
+2. Retry Phase 15.3 ONCE with the same disk-reading prompt (the agent reads
+   from disk, so no orchestrator context re-assembly is needed)
+3. After retry, verify again
+4. If the file now exists: proceed to completion message
+5. If still missing after retry: report the two files that DO exist, and
+   tell the user: "The HTML report could not be generated automatically.
+   To generate it manually, say: **generate the HTML review report**"
+
+**Completion message (only after verification passes):**
+Tell user:
+- Paths to all output files that were successfully written
 - Verdict + score (from primary report)
 - Counts: consensus points, disagreements, action items, verification verdicts
 - Top P0 action item (if any)
 - Note: HTML report requires internet connection for Tailwind CSS, Chart.js, and Prism.js CDNs
 - HTML footer should read "Agent Review Panel v2.16" (match the current product version from `plugin.json`, not the version that introduced the HTML features)
+
+---
+
+### Manual HTML Report Recovery (v2.16.4)
+
+If the user asks to "generate the HTML report" or "generate the HTML review
+report" after a review has completed (whether Phase 15.3 failed or the user
+wants to regenerate), launch the Phase 15.3 agent with the same disk-reading
+prompt described above. Resolve all paths to absolute paths. The agent MUST:
+1. Read the Phase 15.1 output file (e.g., `review_panel_report.md`) for
+   structured data — use the actual filename from the completed review
+2. Read the Phase 15.2 output file (e.g., `review_panel_process.md`) for
+   verbatim content
+3. Read the skill's `references/prompt-templates.md` (absolute path) starting
+   from "Phase 15.3: HTML Report Generation Prompt" for the rendering spec
+
+Do NOT write a generic styled HTML page from the orchestrator's memory of the
+review. The spec in `references/prompt-templates.md` is authoritative — it
+specifies Tailwind CSS, Chart.js, Prism.js, the 10-section expandable accordion,
+Panel Gallery, filter logic, keyboard navigation, deep-linking, and print styles.
+Any HTML report that does not follow this spec is non-compliant.
 
 ---
 
@@ -1249,13 +1331,16 @@ See `references/prompt-templates.md` for the full Phase 16 Merge Agent prompt.
   Agent tool calls. Phases 2, 8, 9, 10, 11, 12, 13, 14 are sequential (Phase 9 is
   orchestrator-driven via Bash, not a subagent). Phase 12a is orchestrator
   logic (no agent). Phase 12b is a single Opus agent. Phase 13 agents launch
-  in parallel (single message with one Agent call per dispute point). Phase 15.1
-  runs first; Phases 15.2 (orchestrator-assembled, no agent) and 15.3 (single
-  Opus agent) run in parallel after Phase 15.1 completes.
+  in parallel (single message with one Agent call per dispute point). Phases
+  15.1, 15.2, and 15.3 run in strict sequence (15.1 → 15.2 → 15.3). Phase
+  15.3 runs AFTER 15.2 so its agent can read the already-written files from
+  disk instead of requiring the orchestrator to inject all data in-context.
 - **Context management:** Full content in Phases 2, 3, 8, 14. Phase 6 summaries
   with source excerpts in debate rounds for long works (>500 lines).
 - **Error handling:** Retry failed agents once. Proceed with minimum 2 reviewers.
-  Note gaps in report.
+  Note gaps in report. Phase 15.3 has an explicit verification gate (v2.16.4):
+  if the HTML file is missing after the agent returns, retry once before
+  degrading to 2-file output with a manual recovery instruction for the user.
 - **Idempotent:** Safe to re-run on the same content — each invocation produces
   an independent panel with no side effects from previous runs.
 - **Auto-persona algorithm:** Classify → base set → signal scan → add up to 6 →

--- a/plugins/agent-review-panel/SKILL.md
+++ b/plugins/agent-review-panel/SKILL.md
@@ -31,7 +31,7 @@ description: >
   composition/seam bugs.
 ---
 
-# Agent Review Panel v2.16
+# Agent Review Panel v2.16.4
 
 A multi-agent adversarial review system based on nine research foundations:
 ChatEval (ICLR 2024), AutoGen, Du et al. (ICML 2024), MachineSoM (ACL 2024),
@@ -1179,7 +1179,7 @@ Tell user:
 - Counts: consensus points, disagreements, action items, verification verdicts
 - Top P0 action item (if any)
 - Note: HTML report requires internet connection for Tailwind CSS, Chart.js, and Prism.js CDNs
-- HTML footer should read "Agent Review Panel v2.16" (match the current product version from `plugin.json`, not the version that introduced the HTML features)
+- HTML footer should read "Agent Review Panel v2.16.4" (MUST match the full semver from `plugin.json` — update this line whenever the version is bumped)
 
 ---
 

--- a/plugins/agent-review-panel/eval-suite.json
+++ b/plugins/agent-review-panel/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "agent-review-panel",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "created_by": "manual",
   "updated": "2026-04-07",
   "triggers": [

--- a/plugins/agent-review-panel/references/changelog.md
+++ b/plugins/agent-review-panel/references/changelog.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## v2.16.4 (2026-04-15) — Phase 15.3 Reliability Fix
+
+Fixes a reliability bug where Phase 15.3 (Interactive HTML Report) silently
+fails to execute when the orchestrator's context window is near capacity
+after 14 prior phases.
+
+### Root Cause
+
+Phase 15.3 ran in parallel with 15.2, requiring the orchestrator to inject
+~700 lines of structured data + the full process history into the subagent
+prompt from its own context. By Phase 15, the orchestrator's context is
+near capacity, causing the agent launch to silently fail or produce a
+degraded prompt that generates a generic HTML page instead of the spec-
+compliant interactive dashboard.
+
+### Fixes
+
+1. **Sequential Phase 15**: 15.1 → 15.2 → 15.3 (no longer parallel).
+   Phase 15.3 runs AFTER 15.2 so the agent can read completed files from
+   disk. Latency impact: negligible (15.2 is orchestrator-assembled, ~2s).
+
+2. **Disk-reading data strategy**: Phase 15.3 agent reads
+   `review_panel_report.md`, `review_panel_process.md`, and the rendering
+   spec from `references/prompt-templates.md` directly. Orchestrator prompt
+   drops from 700+ lines to ~10 lines.
+
+3. **Verification gate**: Mandatory file-existence check for all 3 output
+   files before reporting completion. If HTML is missing, retry once
+   automatically before degrading to 2-file output.
+
+4. **Manual recovery path**: "generate the HTML review report" launches
+   the Phase 15.3 agent with the same disk-reading prompt, following the
+   authoritative spec in `prompt-templates.md` — not a generic HTML page.
+
+### Files Changed
+
+- `SKILL.md` — Phase 15 sequencing, data passing strategy, verification
+  gate, manual recovery section, implementation notes, error handling
+- `references/prompt-templates.md` — data injection placeholders updated
+  to reference disk-reading instead of orchestrator injection
+- `references/changelog.md` — this entry
+
+### Backward Compatibility
+
+No schema changes. No new dependencies. Multi-run mode unaffected (Phase 15
+ordering is internal to each run and doesn't interact with the multi-run
+protocol).
+
+---
+
 ## v2.16.3 (2026-04-09) — External Domain Claim Web Verification in Phase 11
 
 Motivated by a real gap in the PUMA GA4 audit: all 4 reviewers unanimously

--- a/plugins/agent-review-panel/references/changelog.md
+++ b/plugins/agent-review-panel/references/changelog.md
@@ -41,6 +41,8 @@ compliant interactive dashboard.
 - `references/prompt-templates.md` — data injection placeholders updated
   to reference disk-reading instead of orchestrator injection
 - `references/changelog.md` — this entry
+- `SKILL.md` line 34 header: `v2.16` → `v2.16.4` (full semver unification)
+- `SKILL.md` line 1182 footer instruction: `v2.16` → `v2.16.4` with note to keep in sync with `plugin.json`
 
 ### Backward Compatibility
 

--- a/plugins/agent-review-panel/references/prompt-templates.md
+++ b/plugins/agent-review-panel/references/prompt-templates.md
@@ -839,22 +839,29 @@ The HTML file must work when opened directly in a browser. Use:
 
 The file must be fully functional offline except for those three CDN dependencies.
 
-## Reference Inputs (v2.15)
+## Reference Inputs (v2.15, updated v2.16.4)
 
-In addition to the structured review data below, you receive the full Phase 15.2
-process history as reference context. Use it to extract verbatim reviewer
-narratives, debate exchanges, and judge rulings when populating the per-finding
-schema fields (`narrative`, `debateTranscript`, `judgeRuling`). Do NOT copy the
-entire process history into the HTML — extract only the relevant passages per
-finding. The process history is the authoritative source for the verbatim
-content; the Phase 15.1 summary report is a condensed view.
+Read the Phase 15.2 process history from disk (see data source files below).
+Use it to extract verbatim reviewer narratives, debate exchanges, and judge
+rulings when populating the per-finding schema fields (`narrative`,
+`debateTranscript`, `judgeRuling`). Do NOT copy the entire process history
+into the HTML — extract only the relevant passages per finding. The process
+history is the authoritative source for the verbatim content; the Phase 15.1
+summary report is a condensed view.
 
-{Phase 15.2 process history content, injected by orchestrator — the full
-contents of `review_panel_process.md`}
+**Data source files (v2.16.4 — read from disk, do NOT rely on orchestrator
+injection):**
+1. Read `review_panel_report.md` for all structured summary data below
+2. Read `review_panel_process.md` for verbatim narratives, debate transcripts,
+   judge rulings, and verification agent trails
+3. This prompt template (starting from "Phase 15.3: HTML Report Generation
+   Prompt") contains the full rendering spec
+
+Extract the following structured data from those files:
 
 ## Structured Review Data
 
-{Provide all data in a clear structured format:}
+{The agent extracts this from the Phase 15.1 and 15.2 files on disk:}
 
 ### Panel Summary
 - Work reviewed: {title/path}


### PR DESCRIPTION
## Summary

- **Fixes Phase 15.3 (HTML report) silently failing** in most runs due to orchestrator context exhaustion after 14 phases
- **Root cause:** Phase 15.3 ran in parallel with 15.2, requiring the orchestrator to inject ~700 lines of structured data into the subagent prompt from its near-exhausted context window
- **3 P1 findings from self-review** also addressed (contradictory legacy language, relative path resolution, custom filename handling)

## Changes

| Fix | Description |
|-----|-------------|
| Sequential Phase 15 | 15.1 to 15.2 to 15.3 (no longer parallel). Negligible latency impact (~2s). |
| Disk-reading data strategy | Phase 15.3 agent reads .md + _process.md + prompt-templates.md from disk. Orchestrator prompt drops from 700+ lines to ~10 lines. |
| Verification gate | Mandatory file-existence check for all 3 outputs before completion. Auto-retry once if HTML missing. |
| Manual recovery path | "generate the HTML review report" launches Phase 15.3 with disk-reading prompt following the authoritative spec. |
| Path resolution | Orchestrator must resolve output_dir and skill_dir to absolute paths. Custom filenames handled. |
| Legacy language fix | Updated prompt-templates.md Reference Inputs section to align with disk-reading strategy. |

## Meta-test

Ran the review panel **on its own fix** (4 reviewers + judge). Result:
- **Verdict:** CONDITIONAL APPROVE (7.5/10)
- **All 3 output files generated:** .md (6KB) + _process.md (18KB) + .html (56KB)
- **HTML report confirmed spec-compliant:** Tailwind CSS, Chart.js, Prism.js, details expandable cards, Panel Gallery, filter bar, keyboard navigation, print styles
- **3 P1 findings** surfaced by review panel and fixed in same commit
- 352/352 tests pass

## Test plan

- [x] npm test - 352/352 pass
- [x] Meta-test: review panel on own changes produces all 3 files
- [x] HTML report opens in browser with CDN dependencies loading
- [ ] Run panel on a real code review in a separate project to validate end-to-end

Generated with [Claude Code](https://claude.com/claude-code)
