### PR TITLE
fix(plugins): resolve path escape error in plugin.json skills field

### DIFF
--- a/plugins/agent-review-panel/.claude-plugin/plugin.json
+++ b/plugins/agent-review-panel/.claude-plugin/plugin.json
@@ -16,5 +16,5 @@
     "adversarial",
     "evaluation"
   ],
-  "skills": ["./"]
+  "skills": ["SKILL.md"]
 }

--- a/plugins/plan-review-integrator/.claude-plugin/plugin.json
+++ b/plugins/plan-review-integrator/.claude-plugin/plugin.json
@@ -15,5 +15,5 @@
     "multi-agent",
     "voltagent-integration"
   ],
-  "skills": ["./"]
+  "skills": ["SKILL.md"]
 }


### PR DESCRIPTION
## Summary

- Fixes `plan-review-integrator@plugin: Path escapes plugin directory: ./ (skills)` error that prevents both plugins from loading
- Changes `"skills": ["./"]` to `"skills": ["SKILL.md"]` in both plugin.json files
- Root cause: Claude Code's plugin loader rejects `./` as a path escape in multi-plugin marketplaces

## Test plan

- [x] `/reload-plugins` shows 0 errors after applying fix to installed copy
- [ ] Merge, run `/plugin update agent-review-panel@plugin`, verify `/doctor` clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>