### PR TITLE
fix(phase-15.3): Process Overview "15.2/15.3 parallel" contradicted Phase 15 implementation

### DIFF
--- a/plugins/agent-review-panel/SKILL.md
+++ b/plugins/agent-review-panel/SKILL.md
@@ -114,7 +114,7 @@ Phase 11:   Severity Verification     → Read actual code for every P0/P1, down
 Phase 12:   Verification Tier Assign  → Confidence draft (12a) + judge-advised refinement (12b)
 Phase 13:   Targeted Verification     → Persona-matched agents dispatched per dispute point
 Phase 14:   Supreme Judge             → Opus arbitrates everything including verification round
-Phase 15:   Output Generation         → (parent) Three output files (15.1 sequential, 15.2/15.3 parallel)
+Phase 15:   Output Generation         → (parent) Three output files (all sequential: 15.1 → 15.2 → 15.3)
   Phase 15.1: Primary Markdown Report → Structured markdown summary (review_panel_report.md)
   Phase 15.2: Process History         → Full director's-cut log (review_panel_process.md)
   Phase 15.3: HTML Report             → Interactive dashboard (review_panel_report.html)
@@ -414,7 +414,7 @@ All launches below MUST pass `model: "opus"` explicitly (v2.14).
 | Tier Refinement Advisor (Phase 12b) | Generic, `model: "opus"` | (must be domain-neutral to refine tiers) |
 | Verification Agents (Phase 13) | Persona-matched — see Phase 13 table, `model: "opus"` | Each agent matched to claim type |
 | Supreme Judge (Phase 14) | Generic, `model: "opus"` | (judge must be domain-neutral) |
-| HTML Report Agent (Phase 15.3) | `voltagent-lang:javascript-pro`, `model: "opus"` | Generate interactive HTML dashboard with expandable issue cards (v2.15). Receives structured data + Phase 15.2 process history. Loads Tailwind, Chart.js, and Prism.js via CDN. |
+| HTML Report Agent (Phase 15.3) | `voltagent-lang:javascript-pro`, `model: "opus"` | Generate interactive HTML dashboard with expandable issue cards (v2.15). Reads from disk: Phase 15.1 report + Phase 15.2 process history + rendering spec from prompt-templates.md (v2.16.4). Loads Tailwind, Chart.js, and Prism.js via CDN. |
 | Merge Agent (Phase 16) | `voltagent-meta:knowledge-synthesizer`, `model: "opus"` | Deduplicate + score stability in multi-run mode (v2.14) |
 
 **Step 3: Suggest installation when beneficial.** If a selected persona would


### PR DESCRIPTION
## Summary

PR #26 updated the Phase 15 implementation section to enforce strict sequential execution (15.1 → 15.2 → 15.3) but left the **Process Overview table** unchanged. That table remained the primary execution signal for orchestrating agents.

**Root cause:** Line 117 in `SKILL.md` still read:
```
(parent) Three output files (15.1 sequential, 15.2/15.3 parallel)
```

With the v2.16.4 disk-reading strategy, Phase 15.3 reads `review_panel_process.md` from disk — a file that Phase 15.2 writes. Running them in parallel meant Phase 15.3 would read a file that didn't exist yet, silently failing or producing an empty report. In practice, orchestrators that treat the overview table as the canonical execution plan simply never triggered Phase 15.3.

## Changes

- **Line 117** (`SKILL.md`): `"15.1 sequential, 15.2/15.3 parallel"` → `"all sequential: 15.1 → 15.2 → 15.3"`
- **Line 417** (`SKILL.md`): VoltAgent integration table row for Phase 15.3 updated to reflect disk-reading strategy — previously still said "Receives structured data + Phase 15.2 process history" (the old context-injection approach)

`SKILL.md` only — no plugin.json, no prompt-templates.md.

## Test plan

- [x] 352/352 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)