### PR TITLE
release: v2.16.5 — credit @okuuva, clarify supported surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "roundtable",
       "source": "./plugins/agent-review-panel",
-      "version": "2.16.4",
+      "version": "2.16.5",
       "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research."
     },
     {

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Fixed
+      labels:
+        - bug
+        - fix
+    - title: Added
+      labels:
+        - feature
+        - enhancement
+    - title: Changed
+      labels:
+        - refactor
+        - chore
+    - title: Documentation
+      labels:
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Agent Review Panel.
 
-## [Unreleased]
+## [2.16.5] — 2026-04-19
 
 ### Fixed — Plugin skills layout for Claude Code ≥2.1.112 manifest validation (PR #30)
 
@@ -14,6 +14,14 @@ Claude Code 2.1.112 rejected both `skills` field values the plugin had historica
 ### Thanks
 
 - [@okuuva](https://github.com/okuuva) — first external contribution, via [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30).
+
+### Bumped
+
+- `package.json`: 2.16.4 → 2.16.5
+- `plugins/agent-review-panel/.claude-plugin/plugin.json`: 2.16.4 → 2.16.5
+- `plugins/agent-review-panel/eval-suite.json`: 2.16.4 → 2.16.5
+- `.claude-plugin/marketplace.json` (roundtable entry): 2.16.4 → 2.16.5
+- `plugins/agent-review-panel/skills/agent-review-panel/SKILL.md`: header `v2.16.4` → `v2.16.5`; HTML footer instruction updated to match
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Agent Review Panel.
 
+## [Unreleased]
+
+### Fixed — Plugin skills layout for Claude Code ≥2.1.112 manifest validation (PR #30)
+
+Claude Code 2.1.112 rejected both `skills` field values the plugin had historically used: `["./"]` failed with *"Path escapes plugin directory"*, and `["SKILL.md"]` failed with *"Validation errors: skills: Invalid input"*. Neither value was portable across versions.
+
+- **Restructured to canonical nested layout.** `SKILL.md` now lives at `plugins/<name>/skills/<name>/SKILL.md` and the `skills` field has been dropped from `plugin.json` entirely. Claude Code's default skill auto-discovery loads the skill without any manifest path declaration, sidestepping both validation bugs.
+- Resolves #28.
+
+### Thanks
+
+- [@okuuva](https://github.com/okuuva) — first external contribution, via [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30).
+
+---
+
 ## [2.16.4] — 2026-04-15
 
 ### Fixed — Phase 15.3 Reliability (HTML Report Generation)

--- a/README.md
+++ b/README.md
@@ -489,3 +489,9 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history. See [ROADMAP.md](
 - Inspired by [MiroFish](https://github.com/666ghj/MiroFish) — multi-agent prediction engine with heterogeneous agent personalities and memory; influenced auto-persona detection and persona-matched verification agents
 - Eval suite improved using [schliff](https://github.com/Zandereins/schliff)
 - See [HOW_WE_BUILT_THIS.md](HOW_WE_BUILT_THIS.md) for the design journey
+
+### Contributors
+
+External contributions — thank you!
+
+- [@okuuva](https://github.com/okuuva) — [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30) restructured the plugin to the canonical nested skills layout for Claude Code ≥2.1.112 manifest validation (resolves [#28](https://github.com/wan-huiyan/agent-review-panel/issues/28))

--- a/README.md
+++ b/README.md
@@ -95,18 +95,19 @@ timeout. [VERIFIED] against actual code.
 
 ### Requires Claude Code
 
-This plugin **only works inside [Claude Code](https://claude.ai/code)** — the agentic-coding surface that ships the `Agent` tool, subagent spawning, local-filesystem access, and the `/plugin` marketplace machinery. Claude Code is available in several forms:
+This plugin **only works on Claude Code surfaces** — or on the **[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/plugins)** — because it needs the `Agent` tool for subagent spawning, local-filesystem access for output files, and a plugin-loader. Supported surfaces:
 
 **Works ✅**
 - ✅ **CLI** — `claude` command in your terminal
 - ✅ **VS Code extension** — Claude Code extension from the VS Code marketplace
 - ✅ **JetBrains IDE extension** — IntelliJ, PyCharm, WebStorm, GoLand, Rider, etc.
-- ✅ **Claude Desktop app → Code tab** — the Desktop app bundles a Claude Code surface in its dedicated "Code" tab; the plugin installs and runs there the same way it does in the CLI.
+- ✅ **Claude Desktop app → Code tab** — the Desktop app bundles a Claude Code surface in its dedicated "Code" tab; the plugin installs and runs there the same way it does in the CLI. ([official docs](https://code.claude.com/docs/en/desktop))
+- ✅ **Claude Agent SDK** — programmatic agent-building library on top of the Anthropic API. Load this plugin with `options.plugins: [{ type: "local", path: "./agent-review-panel" }]` in TypeScript or Python; subagents, skills, slash commands, and filesystem tools all work. See [Plugins in the SDK](https://code.claude.com/docs/en/agent-sdk/plugins).
 
 **Does not work ❌**
-- ❌ **Claude Desktop app → regular chat tabs** — general chat in Desktop has no `Agent` tool and no `/plugin` marketplace, so the plugin can't load there. Use the Code tab instead.
-- ❌ **claude.ai web chat** — same reason: no `Agent` tool, no subagent spawning, no local-filesystem access, no `/plugin` surface.
-- ❌ **Claude API direct** — same reason.
+- ❌ **Claude Desktop app → regular chat tabs** — the chat surface has no `/plugin` marketplace; and although [Agent Skills](https://www.anthropic.com/news/skills) can run there, this plugin's 4–6 parallel reviewers plus three local-file outputs need Claude Code's subagent + filesystem infrastructure. Use the Code tab instead.
+- ❌ **claude.ai web chat** — same reason: no `/plugin` marketplace, and Skills on the web surface can't spawn the parallel subagents or write the `review_panel_*.md`/`.html` files the plugin produces.
+- ❌ **Anthropic Messages API called directly (without the Agent SDK)** — the raw API is a prompt→response interface; it has no plugin loader, no subagent orchestration, and no filesystem. If you want to run the plugin against the API, use the **Claude Agent SDK** entry above.
 
 **Why:** the panel spawns 4–6 reviewer subagents in parallel via Claude Code's `Agent` tool, reads/writes files on your local filesystem to generate the three output reports, and responds to the `/agent-review-panel:agent-review-panel` slash command (or any natural-language "review panel" request). Only Claude Code surfaces expose those capabilities.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "private": true,
   "description": "Multi-agent adversarial review panel for Claude Code",
   "scripts": {

--- a/plugins/agent-review-panel/.claude-plugin/plugin.json
+++ b/plugins/agent-review-panel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "description": "Multi-agent adversarial review panel — 4-6 AI reviewers debate your code/plans, then a judge delivers a structured verdict with epistemic labels",
   "author": {
     "name": "wan-huiyan",

--- a/plugins/agent-review-panel/eval-suite.json
+++ b/plugins/agent-review-panel/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "agent-review-panel",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "created_by": "manual",
   "updated": "2026-04-07",
   "triggers": [

--- a/plugins/agent-review-panel/skills/agent-review-panel/SKILL.md
+++ b/plugins/agent-review-panel/skills/agent-review-panel/SKILL.md
@@ -31,7 +31,7 @@ description: >
   composition/seam bugs.
 ---
 
-# Agent Review Panel v2.16.4
+# Agent Review Panel v2.16.5
 
 A multi-agent adversarial review system based on nine research foundations:
 ChatEval (ICLR 2024), AutoGen, Du et al. (ICML 2024), MachineSoM (ACL 2024),
@@ -1179,7 +1179,7 @@ Tell user:
 - Counts: consensus points, disagreements, action items, verification verdicts
 - Top P0 action item (if any)
 - Note: HTML report requires internet connection for Tailwind CSS, Chart.js, and Prism.js CDNs
-- HTML footer should read "Agent Review Panel v2.16.4" (MUST match the full semver from `plugin.json` — update this line whenever the version is bumped)
+- HTML footer should read "Agent Review Panel v2.16.5" (MUST match the full semver from `plugin.json` — update this line whenever the version is bumped)
 
 ---
 

--- a/plugins/agent-review-panel/skills/agent-review-panel/references/changelog.md
+++ b/plugins/agent-review-panel/skills/agent-review-panel/references/changelog.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v2.16.5 (2026-04-19) — Plugin Skills Layout Fix (Claude Code ≥2.1.112)
+
+Fixes plugin loading on Claude Code 2.1.112, which tightened `skills` field
+validation in a way that rejected both historical values the plugin had used:
+
+- `["./"]`       → *"Path escapes plugin directory: ./ (skills)"*
+- `["SKILL.md"]` → *"Validation errors: skills: Invalid input"*
+
+### Root Cause
+
+Manifest validation in current Claude Code requires component paths to resolve
+strictly inside the plugin directory and rejects bare-file paths missing the
+`./` prefix. The `./` form, while matching the documented spec, also fails the
+path-escape check on this version. Neither value is portable across versions.
+
+### Fix
+
+Adopted the canonical nested skill layout and removed the `skills` field from
+`plugin.json` entirely:
+
+- `SKILL.md` moved from `plugins/<name>/SKILL.md` to
+  `plugins/<name>/skills/<name>/SKILL.md`.
+- Claude Code's default skill auto-discovery now loads the skill without any
+  manifest path declaration, sidestepping both validation bugs.
+
+Resolves [#28](https://github.com/wan-huiyan/agent-review-panel/issues/28)
+via PR [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30).
+
+### Contributor
+
+First external contribution: [@okuuva](https://github.com/okuuva). Thank you.
+
+### Files Changed
+
+- Moved `plugins/agent-review-panel/SKILL.md` → `plugins/agent-review-panel/skills/agent-review-panel/SKILL.md` (and sibling `references/` + `tests/` subdirs)
+- `plugins/agent-review-panel/.claude-plugin/plugin.json` — dropped `skills` field
+- Version bumps across `package.json`, `plugin.json`, `eval-suite.json`,
+  `.claude-plugin/marketplace.json`, SKILL.md header, and HTML footer
+  instruction (2.16.4 → 2.16.5)
+
+### Backward Compatibility
+
+No schema or runtime behavior changes. Purely a plugin-packaging fix.
+
+---
+
 ## v2.16.4 (2026-04-15) — Phase 15.3 Reliability Fix
 
 Fixes a reliability bug where Phase 15.3 (Interactive HTML Report) silently


### PR DESCRIPTION
## Summary

Cuts **v2.16.5** and credits [@okuuva](https://github.com/okuuva) for the first external contribution (#30, which fixed plugin loading on Claude Code ≥2.1.112). Also tightens a couple of stale claims in the README after verifying current docs.

### Contents

1. **Credit @okuuva**
   - New **Contributors** subsection under `README.md` → Acknowledgements.
   - `CHANGELOG.md` `[2.16.5]` entry with a `Thanks` line.
   - Per-skill `references/changelog.md` entry.

2. **v2.16.5 release prep** (PR #30 is unreleased; bumping across the usual version files)
   - `package.json`, `plugins/agent-review-panel/.claude-plugin/plugin.json`, `plugins/agent-review-panel/eval-suite.json`, `.claude-plugin/marketplace.json` (roundtable entry)
   - `SKILL.md` header (line 34) + HTML footer instruction (line 1182), per the 2.16.4 version-unification rule
   - Promoted `[Unreleased]` → `[2.16.5] — 2026-04-19` in `CHANGELOG.md` with a Bumped list

3. **GitHub Release auto-notes config**
   - New `.github/release.yml` with category buckets (Fixed / Added / Changed / Documentation / Other) so auto-generated release notes look clean going forward.

4. **README accuracy — "Requires Claude Code" section** (verified against `code.claude.com/docs` and `anthropic.com/news/skills`)
   - **Added ✅ Claude Agent SDK** as a supported surface — the `@anthropic-ai/claude-agent-sdk` (TS) and `claude_agent_sdk` (Python) packages can load this plugin via `options.plugins: [{ type: "local", path: "..." }]`. The previous implication of "API = no plugins" was too broad.
   - **Split the "❌ Claude API direct" bullet** into "❌ Anthropic Messages API called directly (without the Agent SDK)", pointing readers to the Agent SDK entry.
   - **Softened** the "no Agent tool" phrasing on the claude.ai web chat and Desktop regular-chat bullets — Agent Skills do exist on those surfaces now, but this plugin's parallel subagents + three local-file outputs still require Claude Code infrastructure. Practical conclusion unchanged; just more precisely stated.

## Test plan

- [x] `npm test` — all 354 tests pass (manifest consistency, trigger classification, eval-suite integrity, report structure, behavioral assertions, golden files)
- [x] Version string is consistent across all 6 locations (4 manifests + SKILL.md header + HTML footer instruction)
- [ ] After merge, cut GitHub Release `v2.16.5` from `main` targeting the merge commit; release body reuses the `[2.16.5]` section from `CHANGELOG.md`; auto-generated "New Contributors" should surface @okuuva
- [ ] Verify the README stale `v2.10.0` release badge updates to `v2.16.5` once the release is live

---

Once you merge this, say the word and I'll cut the `v2.16.5` GitHub Release.
