### PR TITLE
docs(README): add Path A (Claude-Code-assisted install) for upgrade UX

### DIFF
--- a/HOW_WE_BUILT_THIS.md
+++ b/HOW_WE_BUILT_THIS.md
@@ -796,30 +796,66 @@ Each plugin's drift was caught **independently** — the refactor did not silent
 
 ---
 
+## Step 21: Single-Plugin Layout + Release-Check (v3.0, 2026-04-27)
+
+### Motivation
+
+Two months after Step 20 bundled `plan-review-integrator` as a second plugin, a real install-failure debug session surfaced that the multi-plugin layout was ceremony, not value. The user reported "my plugin install doesn't work" and asked to mirror [obra/superpowers](https://github.com/obra/superpowers) — a single-plugin repo. Inspecting superpowers vs. this repo revealed: when a marketplace ships exactly one plugin and that plugin bundles its skills, the extra `plugins/<plugin-name>/` nesting layer adds nothing. Both skills load the same way; users still install one plugin; tests still validate the same invariants. The nesting was there because Step 20 anticipated more plugins arriving — but six weeks in, only the two existed and they were tightly producer/consumer-coupled.
+
+PR #33 collapsed the layout. PR #34 added an upgrade-friendly install path after a real upgrade hiccup (cached marketplace name from pre-v2.16.1 short-circuited `marketplace add`). PR #32 was opened in parallel with a plugin-name revert (`roundtable` → `agent-review-panel`); the revert was considered and rejected — see Lesson 44 below.
+
+### Implementation
+
+**PR #33 — Single-plugin collapse.** Moved `plugins/<plugin>/skills/<skill>/SKILL.md` → `skills/<skill>/SKILL.md`. Created `.claude-plugin/plugin.json` at the repo root (was at `plugins/agent-review-panel/.claude-plugin/plugin.json`). Marketplace source path changed from `./plugins/agent-review-panel` to `./`. The `plugins/` directory was deleted entirely.
+
+**PR #30's auto-discovery fix preserved.** The convention from Step 19's PR #30 (skills live at `<plugin-root>/skills/<skill-name>/SKILL.md` with no `skills` field declared in `plugin.json`) is intact. Only the plugin root location changed, not the relative path from plugin root to SKILL.md.
+
+**Test discovery rewritten.** `manifest-consistency.test.mjs` now walks `skills/<name>/` under one root `plugin.json` instead of iterating `plugins/<name>/`. Introduced a "marquee skill" concept: when a skill's directory name matches the plugin's name, that skill's eval-suite tracks `plugin.json` version exactly; other bundled skills version independently. `trigger-classification.test.mjs` got the same skills/-walking refactor. `eval-suite-integrity.test.mjs` and `behavioral-assertions.test.mjs` only needed hardcoded path updates (still agent-review-panel-specific).
+
+**`scripts/release-check.sh`** (folded in from PR #32). Pre-release doc-drift detector. Asserts slash-command consistency, marketplace-name consistency, test-count accuracy, canonical-version match across 5 files, ROADMAP row presence, CHANGELOG section presence. Auto-detects plugin name from `plugin.json` so future renames don't break it. Caught real drift items multiple times during this PR's development.
+
+**PR #34 — Path A install instructions.** Added a new install path to README's Quick Start that uses Claude Code itself to run the cleanup-and-install flow. Motivated by a real v3.0 upgrade hiccup: the installer's `~/.claude/plugins/known_marketplaces.json` had the marketplace registered under its pre-v2.16.1 name `"plugin"` (Step 19 renamed the marketplace, but the user's local cache predated that). `claude plugin marketplace add` saw the repo was already registered and short-circuited without re-reading the new name. The install command then looked for marketplace `agent-review-panel`, didn't find it, and failed. Path A's prompt scans `known_marketplaces.json`, removes stale registrations, scans for orphan marketplace dirs and loose-clone shadows, and reinstalls — all inside a Claude Code session, so the user just confirms the destructive `rm`s.
+
+### Lessons
+
+43. **Layout decisions that "anticipate future scale" age into ceremony.** Step 20's `plugins/<plugin-name>/` nesting was correct *if* a third or fourth plugin landed. Six weeks later, only two existed and they were so tightly coupled that a third was never going to be a sibling — it would either fold into one of them or split into a separate marketplace. Anticipatory nesting is fine when it's free, but it stops being free as soon as it shows up in test code, doc paths, install commands, and CI scripts. The cost of carrying it should be evaluated against the probability the anticipated scale arrives. When in doubt, ship the simpler layout and add nesting when the third entity actually shows up.
+
+44. **The right naming changes when the layout changes.** PR #32 proposed reverting `roundtable` → `agent-review-panel` to eliminate the three-layer plugin/skill/marketplace name divergence. Under the multi-plugin layout (where `roundtable` was one of two plugin names) the divergence created friction. Under the single-plugin bundle layout the calculus inverts: a distinct collective bundle name *helps* — `roundtable` works as a collective noun, `/roundtable:agent-review-panel` reads as "the agent-review-panel skill of the roundtable," and `/roundtable:plan-review-integrator` reads naturally for the second skill. The alternative `/agent-review-panel:agent-review-panel` is stutter; `/agent-review-panel:plan-review-integrator` falsely implies plan-review-integrator is a sub-component of agent-review-panel rather than a peer. CHANGELOG documents the decision in a "Considered but rejected" section so the reasoning isn't lost when someone proposes the rename again.
+
+45. **A failed `marketplace add` can leave silent traps.** Three classes of stale state on the user machine can break a fresh install with no error from the installer:
+    - **Old marketplace name in `~/.claude/plugins/known_marketplaces.json`** — `marketplace add` short-circuits if the repo URL matches an existing registration, regardless of name. Renames in the marketplace.json don't propagate to existing registrations.
+    - **Orphan directories under `~/.claude/plugins/marketplaces/`** with weird names like a literal trailing space (e.g. `wan-huiyan-agent-review-panel `).
+    - **Loose-clone shadows under `~/.claude/skills/`** from pre-marketplace-era manual clones — these load *before* and shadow marketplace-installed skills.
+
+    All three coexisted on the v3.0 test machine. None of them produced an error message during the failed install. The reusable diagnostic recipe is now captured in the user-level skill `claude-code-plugin-install-shadow-diagnosis` and in README Path A.
+
+46. **Self-pacing the rename decision.** In one session: shipped the layout collapse (PR #33), folded in PR #32's rename revert, then reversed course on the rename after the user asked which I preferred and gave permission to push back. The reversal felt like wasted work but wasn't — the round-trip surfaced Lesson 44, which wouldn't have been articulated if the rename had stayed shipped. When you have permission to argue against a proposed change, take it; the disagreement extracts more reasoning than agreement does.
+
+---
+
 ## File Inventory
 
 ```
 ├── .claude-plugin/
-│   └── marketplace.json                # Marketplace manifest (name: "plugin", 2 bundled plugins)
-├── plugins/
-│   ├── agent-review-panel/             # This plugin — the multi-agent review panel
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json             # Plugin metadata (v2.16.1)
+│   ├── marketplace.json                # Marketplace manifest (name: "agent-review-panel", 1 plugin entry, source "./")
+│   └── plugin.json                     # Plugin manifest at repo root (v3.0+ single-plugin layout, name: "roundtable")
+├── skills/
+│   ├── agent-review-panel/             # The marquee skill — multi-agent review panel
 │   │   ├── SKILL.md                    # The skill itself (~1220 lines — 16 phases + sub-phases)
-│   │   └── eval-suite.json             # Schliff eval suite (triggers + assertions)
-│   └── plan-review-integrator/         # Bundled companion plugin (v2.16.1+)
-│       ├── .claude-plugin/
-│       │   └── plugin.json             # Plugin metadata (v2.0.0)
+│   │   ├── eval-suite.json             # Schliff eval suite (triggers + assertions)
+│   │   └── references/
+│   │       ├── signals-and-checklists.md  # 11 signal groups + domain checklists (incl. v2.14 Transform + Data Flow Invariants)
+│   │       ├── prompt-templates.md        # All phase prompt templates (incl. Phase 2 Data Flow Tracer + Phase 16 Merge + Phase 15.3 expandable cards)
+│   │       ├── changelog.md               # Version history (v2–v3.0)
+│   │       └── research-v28.md            # 19-source v2.8 research compilation
+│   └── plan-review-integrator/         # Bundled companion skill (v2.0.1, integrates panel findings into plans)
 │       ├── SKILL.md                    # The integrator skill
-│       └── eval-suite.json             # Per-plugin eval suite
-├── references/
-│   ├── signals-and-checklists.md       # 11 signal groups + domain checklists (includes v2.14 Transform + Data Flow Invariants checklists)
-│   ├── prompt-templates.md             # All phase prompt templates (incl. Phase 2 Data Flow Tracer + Phase 16 Merge + Phase 15.3 10-section expandable cards)
-│   ├── changelog.md                    # Version history (v2–v2.15)
-│   └── research-v28.md                 # 19-source v2.8 research compilation
+│       └── eval-suite.json             # Per-skill eval suite
+├── scripts/
+│   └── release-check.sh                # Pre-release doc-drift detector (v3.0+, folded in from PR #32)
 ├── tests/
-│   ├── trigger-classification.test.mjs   # Multi-plugin — iterates every plugins/<name>/eval-suite.json
-│   ├── manifest-consistency.test.mjs     # Multi-plugin — per-plugin cross-version assertions (PR #21+PR #22)
+│   ├── trigger-classification.test.mjs   # Walks skills/<name>/eval-suite.json (one plugin, N skills)
+│   ├── manifest-consistency.test.mjs     # Single-plugin manifest validation + per-skill cross-version checks
 │   ├── eval-suite-integrity.test.mjs     # agent-review-panel-specific — v2.9/v2.14/v2.15 coverage blocks
 │   ├── behavioral-assertions.test.mjs    # agent-review-panel-specific — fixture-based behavioral assertions
 │   ├── report-structure.test.mjs         # agent-review-panel-specific — report format validation
@@ -838,9 +874,9 @@ Each plugin's drift was caught **independently** — the refactor did not silent
 ├── .github/workflows/
 │   └── test.yml                        # GitHub Actions — runs `npm test` on every push/PR
 ├── README.md                           # User-facing documentation (install via /plugin marketplace add)
-├── HOW_WE_BUILT_THIS.md                # This file (Steps 1–20 chronicling v1–v2.16.1)
+├── HOW_WE_BUILT_THIS.md                # This file (Steps 1–21 chronicling v1–v3.0)
 ├── ROADMAP.md                          # Unified research + trust roadmap (22+ papers, 14 projects)
-├── CHANGELOG.md                        # Top-level changelog (v1.0 → v2.16.1)
-├── package.json                        # Node.js test runner config (v2.16.1, locked to agent-review-panel)
+├── CHANGELOG.md                        # Top-level changelog (v1.0 → v3.0.0)
+├── package.json                        # Node.js test runner config (v3.0.0, name "roundtable")
 └── LICENSE                             # MIT
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,19 @@ A [Claude Code](https://claude.ai/code) **plugin** that orchestrates multi-agent
 
 ## Quick Start
 
-**Install (recommended — Claude Code marketplace).** Run these **in your terminal** (bash/zsh):
+Pick the install path that matches where you are. **Path A is the easiest if you already have a Claude Code session open** — Claude does the cleanup, install, and verification for you, which sidesteps the most common upgrade gotchas (stale marketplace cache from old names, loose-clone shadows in `~/.claude/skills/`).
+
+### Path A — Ask Claude Code to install it (easiest, recommended for upgrades)
+
+Open any Claude Code session and paste this prompt:
+
+> Install the `agent-review-panel` plugin from `wan-huiyan/agent-review-panel`. Before installing, check `~/.claude/plugins/known_marketplaces.json` for any existing registration of this repo (it may be cached under an old name like `plugin` from pre-v2.16.1) — if found, run `claude plugin marketplace remove <old-name>` first. Also check `~/.claude/plugins/marketplaces/` for orphan directories with trailing whitespace and `~/.claude/skills/` for loose-clone shadows of `agent-review-panel`, `agent-review-panel-workspace`, `plan-review-integrator`, or `roundtable` — remove any found. Then run `claude plugin marketplace add wan-huiyan/agent-review-panel` and `claude plugin install roundtable@agent-review-panel`. Verify the install by listing `~/.claude/plugins/cache/agent-review-panel/roundtable/3.0.0/skills/` and confirming both `agent-review-panel/SKILL.md` and `plan-review-integrator/SKILL.md` are present. Restart-required reminder at the end. Report each step's outcome.
+
+Claude Code reads this prompt, runs the bash itself (you'll be asked to confirm the destructive `rm`s), and reports back. Restart your Claude Code session afterward — skills load at session start.
+
+### Path B — Run the commands yourself (fresh installs)
+
+**In your terminal** (bash/zsh):
 
 ```bash
 claude plugin marketplace add wan-huiyan/agent-review-panel
@@ -38,6 +50,37 @@ Type these at the REPL prompt (note the leading `/` and no `claude` prefix):
 ```
 
 Both forms do the same thing. Pick whichever matches where you are: shell-form `claude plugin …` for terminal, REPL-form `/plugin …` for inside Claude Code.
+</details>
+
+<details>
+<summary><strong>Upgrading from v2.x?</strong> The marketplace name and plugin layout changed — bash recipe to clean up</summary>
+
+If you installed before v3.0, your `~/.claude/` directory likely has stale state that will silently break or shadow the new install. Path A handles this automatically; if you'd rather run it manually:
+
+```bash
+# Old marketplace name (pre-v2.16.1 was "plugin")
+claude plugin marketplace remove plugin 2>/dev/null
+
+# Orphan marketplace dirs (sometimes have trailing whitespace in the name)
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel "  # note trailing space
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel"   # no space (also possible)
+
+# Loose-clone shadows from pre-marketplace-era manual clones
+rm -rf "$HOME/.claude/skills/agent-review-panel" \
+       "$HOME/.claude/skills/agent-review-panel-workspace" \
+       "$HOME/.claude/skills/plan-review-integrator" \
+       "$HOME/.claude/skills/roundtable"
+
+# Fresh install
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+
+# Verify
+ls ~/.claude/plugins/cache/agent-review-panel/roundtable/*/skills/
+# expected: agent-review-panel/  plan-review-integrator/
+```
+
+Restart your Claude Code session after install.
 </details>
 
 > The `roundtable` plugin bundles **two skills**: `agent-review-panel` (the review panel) and `plan-review-integrator` (the review→integrate companion). One install gets you both. See [Bundled skills](#bundled-skills) below.


### PR DESCRIPTION
## Summary

v3.0 documentation completion. Two related additions to follow up the PR #33 layout collapse:

1. **README Path A** — new install path that uses Claude Code itself to run the cleanup-and-install flow. Sidesteps the most common upgrade gotchas (stale marketplace cache from old names, loose-clone shadows in \`~/.claude/skills/\`).
2. **HOW_WE_BUILT_THIS Step 21** — chronicles the v3.0 layout collapse, the rejected rename revert (PR #32), and the upgrade-friendly install flow. Adds 4 new lessons (43-46). Refreshes the file inventory section to v3.0 paths.

Both are pure docs — no code changes.

## What we hit testing v3.0 install (motivating Path A)

After PR #33 merged, @wan-huiyan ran the documented install commands and got:

\`\`\`
✔ Marketplace 'plugin' already on disk — declared in user settings
✘ Failed to install plugin \"roundtable@agent-review-panel\":
  Plugin \"roundtable\" not found in marketplace \"agent-review-panel\"
\`\`\`

Diagnosis: \`~/.claude/plugins/known_marketplaces.json\` had the marketplace registered under its **pre-v2.16.1 name** \`\"plugin\"\` (the marketplace was renamed to \`agent-review-panel\` in commit 00e2149, but the user's local registration was cached from before that). \`claude plugin marketplace add\` matches on the **repo URL**, not the name, so it sees the repo is already registered (just under the old name) and short-circuits — without re-reading the current \`marketplace.json\`. The subsequent \`plugin install <plugin>@<new-marketplace-name>\` then fails with \"marketplace not found\" / \"plugin not found in marketplace.\"

This is artifact #4 in a class of four (the others — install-not-completed, orphan marketplace dirs, loose-clone shadows — were already documented). Manual recovery requires inspecting \`known_marketplaces.json\`, identifying the old name, running \`claude plugin marketplace remove <old-name>\`, then re-adding. That's a lot of v3.0-upgrade overhead just to install — Path A handles it inline.

## What this PR adds

### Path A (new) — README Quick Start

Paste a self-contained prompt into any Claude Code session. Claude reads \`known_marketplaces.json\`, scans \`marketplaces/\` for orphans, scans \`skills/\` for loose-clone shadows, removes anything stale, runs the install, verifies cache layout. User just confirms the destructive \`rm\` prompts.

### Path B (existing, expanded) — README Quick Start

Manual terminal commands plus a new collapsible **\"Upgrading from v2.x?\"** section with the full cleanup recipe covering all four classes of stale state:
1. Old marketplace name (e.g. \`\"plugin\"\`) registered in \`known_marketplaces.json\`
2. Trailing-whitespace orphan directories under \`marketplaces/\`
3. Loose-clone shadows under \`~/.claude/skills/\`
4. Old \`plan-review-integrator\` skill dir (no longer needed; bundled into \`roundtable\`)

### HOW_WE_BUILT_THIS Step 21 (new)

Chronicles three v3.0 PRs in one section:
- **PR #33**: collapse \`plugins/<plugin>/skills/<skill>/\` → \`skills/<skill>/\`
- **PR #32**: rename revert (considered + rejected, with documented reasoning)
- **PR #34** (this PR): Path A install instructions + Step 21 itself

**4 new lessons (43–46):**
43. Anticipatory layout nesting ages into ceremony
44. The right naming changes when the layout changes
45. Failed marketplace add leaves four classes of silent traps (cache miss, orphan dirs, loose-clone shadows, **stale-name registration**)
46. When given permission to push back on a proposed change, take it

**File inventory section updated for v3.0:** \`skills/\` at root, no \`plugins/\`, new \`scripts/release-check.sh\`, no per-plugin \`.claude-plugin/\` dirs. Footer: \"Steps 1–21 chronicling v1–v3.0\".

## Why this matters beyond v3.0

Future plugin layout/naming changes will hit the same four-artifact trap. Path A scales — the prompt is generic enough that the next breaking change just updates the prompt, not the user's mental model. Path B's cleanup recipe is also reusable. Lesson 45's four-artifact taxonomy is the most reusable — captured in the user-level skill \`claude-code-plugin-install-shadow-diagnosis\` (now at v1.1.0 with the stale-name registration class added).

## Verification

- [x] \`bash scripts/release-check.sh\` → 9/9 green (no version/slash/marketplace drift)
- [x] No code changes, README + HOW_WE_BUILT_THIS only
- [x] @wan-huiyan tested the actual install on Claude Code Desktop after the cleanup commands ran — both \`/roundtable:agent-review-panel\` and \`/roundtable:plan-review-integrator\` slash commands fire ✅
- [ ] Reviewer: skim Step 21 for accuracy + tone consistency with Steps 1–20

## Release plan

After this merges, tag \`v3.0.0\` from main and create a GitHub release (CHANGELOG \`[3.0.0]\` section copy-pastes into the release body). The release semantically covers PRs #33 + #34; PR #32's contributions (release-check.sh) and rejection (rename revert) are documented in CHANGELOG \"Considered but rejected.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)