### PR TITLE
fix(#35): silent phase compression — v3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "roundtable",
       "source": "./",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "description": "Orchestrate a multi-agent adversarial review panel. 4-6 reviewers with distinct personas independently evaluate work, debate findings across 1-3 rounds, then a supreme judge renders the final verdict. Bundles plan-review-integrator for applying findings back into implementation plans. Auto-detected Precise/Exhaustive mode, severity verification, tiered L0/L1/L2 knowledge mining, 10 signal groups with domain checklists. Based on ChatEval, AutoGen, DMAD, CONSENSAGENT, and Trust or Escalate research."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Multi-agent adversarial review panel — 4-6 AI reviewers debate your code/plans, then a judge delivers a structured verdict with epistemic labels. Bundles plan-review-integrator for applying review findings back into implementation plans.",
   "author": {
     "name": "wan-huiyan",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Agent Review Panel.
 
+## [3.1.0] — 2026-04-27 — silent-phase-compression fix (#35)
+
+### Fixed — silent compression of mandatory Phases 4 / 5 / 7
+
+Under context-budget pressure, the v3.0.0 orchestrator silently inlined Phases 4 (private reflection), 5 (debate rounds), 6 (round summaries), and 7 (blind final assessments) into the Supreme Judge step, producing deliverables indistinguishable from full runs. Empirical cost measured at 6 net-new findings (including 1 P0 FERPA / Anthropic-DPA gap) missed by a compressed run versus the corrective full-run review on the same input. Fixes [#35](https://github.com/wan-huiyan/agent-review-panel/issues/35).
+
+### Architectural changes
+
+- **File-based subagent state.** All Phase 3 / 4 / 5 / 7 / 8 / 10 / 11 / 14 outputs now write to `state/<file>.md` under the review output directory; subagents return only `{path, 100-word summary}` rather than verbatim review content. Eliminates the orchestrator-context bloat (~75k tokens per phase × 6 phases) that drove silent compression. Multi-run mode namespaces under `state/run_<N>/`.
+- **Phase 13.5 — Pre-Judge Verification Gate (NEW).** Before launching the Supreme Judge, the orchestrator verifies all mandatory phase outputs exist on disk + meet a minimum-bytes threshold (≥500 B) + contain required schema headers. Single retry on failure; persistent miss triggers the COMPRESSED RUN warning rather than a silently incomplete report.
+- **Phase 14 reads state on demand.** Launch prompt is ~200 tokens of paths; the judge uses the Read tool to load specific state files. Mirrors the v2.16.4 Phase 15.3 HTML-agent pattern. The judge's ruling materializes to `state/phase_14_judge_ruling.md` so Phase 15.1 can later consume it from disk.
+- **`⚠️ COMPRESSED RUN` header in Phase 15.1.** When the gate detects unrecoverable phase loss, the markdown report begins with a fail-loud blockquote listing the skipped phases; every action item gains a `[COMPRESSED]` epistemic-label suffix. Phase 15.3 renders the same warning as a red HTML banner above the summary card.
+
+### Tests
+
+- New fixture: `tests/fixtures/sample-report-compressed-run.md` and golden snapshot `tests/golden/sample-report-compressed-run.golden.json`.
+- `tests/report-structure.test.mjs` parser extended to extract `report.compressedRun.{detected, phasesSkipped}`.
+- `tests/behavioral-assertions.test.mjs` gains a `v3.1.0 file-based state convention` describe block validating SKILL.md documents the new architecture.
+- 379 / 379 tests pass.
+
+### Breaking changes
+
+None. The `state/` directory is net-new and may be `.gitignore`d if not desired in commits. Existing report consumers see unchanged report files for full runs and a leading warning blockquote for compressed runs.
+
+### Design references
+
+- Design doc: `docs/plans/2026-04-27-silent-phase-compression-fix-design.md`
+- Implementation plan: `docs/plans/2026-04-27-silent-phase-compression-fix-plan.md`
+
 ## [3.0.0] — 2026-04-27
 
 ### Changed — Single-plugin layout (BREAKING) (PR #33)

--- a/README.md
+++ b/README.md
@@ -52,38 +52,7 @@ Type these at the REPL prompt (note the leading `/` and no `claude` prefix):
 Both forms do the same thing. Pick whichever matches where you are: shell-form `claude plugin …` for terminal, REPL-form `/plugin …` for inside Claude Code.
 </details>
 
-<details>
-<summary><strong>Upgrading from v2.x?</strong> The marketplace name and plugin layout changed — bash recipe to clean up</summary>
-
-If you installed before v3.0, your `~/.claude/` directory likely has stale state that will silently break or shadow the new install. Path A handles this automatically; if you'd rather run it manually:
-
-```bash
-# Old marketplace name (pre-v2.16.1 was "plugin")
-claude plugin marketplace remove plugin 2>/dev/null
-
-# Orphan marketplace dirs (sometimes have trailing whitespace in the name)
-rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel "  # note trailing space
-rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel"   # no space (also possible)
-
-# Loose-clone shadows from pre-marketplace-era manual clones
-rm -rf "$HOME/.claude/skills/agent-review-panel" \
-       "$HOME/.claude/skills/agent-review-panel-workspace" \
-       "$HOME/.claude/skills/plan-review-integrator" \
-       "$HOME/.claude/skills/roundtable"
-
-# Fresh install
-claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install roundtable@agent-review-panel
-
-# Verify
-ls ~/.claude/plugins/cache/agent-review-panel/roundtable/*/skills/
-# expected: agent-review-panel/  plan-review-integrator/
-```
-
-Restart your Claude Code session after install.
-</details>
-
-> The `roundtable` plugin bundles **two skills**: `agent-review-panel` (the review panel) and `plan-review-integrator` (the review→integrate companion). One install gets you both. See [Bundled skills](#bundled-skills) below.
+> The `roundtable` plugin bundles **two skills**: `agent-review-panel` (the review panel) and `plan-review-integrator` (the review→integrate companion). One install gets you both. See [Bundled skills](#bundled-skills) below. Upgrading from v2.x? See [Migration](#migration-from-previous-marketplaces).
 
 **Use:**
 ```
@@ -99,38 +68,7 @@ Restart your Claude Code session after install.
 - `review_panel_process.md` — full "director's cut" log of every agent's verbatim output with persona profiles
 - `review_panel_report.html` — interactive dashboard with **expandable 10-section issue cards** (Narrative, Code Evidence, Debate, Judge Ruling, Fix Recommendation, and more — new in v2.15), filterable issue cards, charts, and a Panel Gallery
 
-<details>
-<summary><strong>Example report output (truncated)</strong></summary>
-
-```markdown
-# Review Panel Report
-**Work reviewed:** src/auth/middleware.ts  |  **Date:** 2026-03-28
-**Panel:** 4 reviewers + Auditor + Judge
-**Verdict:** Approve with Revisions  |  **Confidence:** High
-**Review mode:** Precise (auto-detected from content type: code)
-
-## Executive Summary
-The authentication middleware is well-structured with proper token validation
-and rate limiting. Two substantive issues emerged: the session store lacks
-TTL enforcement (P1, [VERIFIED]) and the CORS configuration is overly
-permissive for production (P1, [CONSENSUS]). Score: 7/10.
-
-## Consensus Points
-- Token rotation logic is correct and handles edge cases well
-- Error responses follow RFC 7807 format consistently
-
-## Disagreement Points
-**Session store TTL:** Security Auditor (P0) vs Architecture Critic (P2)
-Judge ruling: P1 — the risk is real but mitigated by the upstream API gateway
-timeout. [VERIFIED] against actual code.
-
-## Action Items
-- [P1] [VERIFIED] Add TTL to session store entries (src/auth/session.ts:47)
-- [P1] [CONSENSUS] Restrict CORS origins in production config
-- [P2] [SINGLE-SOURCE] Consider adding request signing for internal APIs
-```
-
-</details>
+_See the [demo GIFs](#agent-review-panel) at the top of this README for what the markdown report and HTML dashboard look like._
 
 ## Installation
 
@@ -156,20 +94,13 @@ Don't have Claude Code yet? Install it from **[claude.ai/code](https://claude.ai
 
 ### Claude Code marketplace (recommended)
 
-Install commands appear in [Quick Start](#quick-start). The shell-form equivalent (for users running in a terminal rather than the Claude Code REPL):
-
-```bash
-claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install roundtable@agent-review-panel
-```
-
-Claude Code caches the plugin, loads its skills, and activates trigger phrases automatically.
+Install commands are in [Quick Start](#quick-start) above. Claude Code caches the plugin, loads its skills, and activates trigger phrases automatically. Two things worth knowing about the install handle:
 
 <!-- release-check:marketplace-name-callout — load-bearing for scripts/release-check.sh; do not delete without updating both -->
 > **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `agent-review-panel` (defined in `.claude-plugin/marketplace.json`); the plugin install name inside it is `roundtable`. Hence `roundtable@agent-review-panel`. Pre-v2.16.1 releases used `@wan-huiyan-agent-review-panel`; pre-v2.16 used `@agent-review-panel`. If you installed under an older marketplace name, see [Migration](#migration-from-previous-marketplaces).
 <!-- /release-check:marketplace-name-callout -->
 
-**Why the marketplace path?** The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests (v3.0+ single-plugin layout) that Claude Code reads to register the plugin — the marketplace install handles caching, version tracking, and activation in one step. Manual clone (below) works but bypasses the manifests.
+**Why the marketplace path?** The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests (v3.0+ single-plugin layout) that Claude Code reads to register the plugin — the marketplace install handles caching, version tracking, and activation in one step. [Manual clone](#manual-clone-development--custom-setup) works but bypasses the manifests.
 
 ### Updating to the latest version
 
@@ -465,6 +396,33 @@ Verify both are loaded under the new marketplace:
 ls ~/.claude/plugins/cache/agent-review-panel/
 # expected: roundtable  (one plugin dir; both skills live inside it)
 ```
+
+<details>
+<summary><strong>Plugin install isn't working after migration?</strong> Bash recipe to clear stale state</summary>
+
+If you installed before v3.0, your `~/.claude/` directory may have stale state that silently shadows the new install ([Path A](#path-a--ask-claude-code-to-install-it-easiest-recommended-for-upgrades) in Quick Start handles this automatically — this is the manual equivalent):
+
+```bash
+# Old marketplace name (pre-v2.16.1 was "plugin")
+claude plugin marketplace remove plugin 2>/dev/null
+
+# Orphan marketplace dirs (sometimes have trailing whitespace in the name)
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel "  # note trailing space
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel"   # no space (also possible)
+
+# Loose-clone shadows from pre-marketplace-era manual clones
+rm -rf "$HOME/.claude/skills/agent-review-panel" \
+       "$HOME/.claude/skills/agent-review-panel-workspace" \
+       "$HOME/.claude/skills/plan-review-integrator" \
+       "$HOME/.claude/skills/roundtable"
+
+# Fresh install
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+```
+
+Restart your Claude Code session after install.
+</details>
 
 ## Contributing
 

--- a/docs/plans/2026-04-27-silent-phase-compression-fix-plan.md
+++ b/docs/plans/2026-04-27-silent-phase-compression-fix-plan.md
@@ -37,6 +37,18 @@
 - "Commit:" steps use a per-task message; squash at the end is fine but not required.
 - For surgical edits, the plan shows a `Find:` block (the existing text to locate) and a `Replace with:` block (the new text). Use the Edit tool's exact-match behavior.
 
+### Prompt-template directive placement (Tasks 2-6, 8)
+
+When inserting an `**Output protocol (v3.1.0+):**` directive into a prompt
+template in `references/prompt-templates.md`, place it **INSIDE the prompt's
+code fence**, just before the closing triple-backtick. The orchestrator's
+subagent dispatch typically copies the literal fenced content into the Task()
+prompt, so directives outside the fence may not reach the subagent.
+
+Single-line directive sentences are required (test regexes use `.*` which
+does not span newlines without the `s` flag). If a directive sentence wraps
+naturally, keep the path-bearing sentence on one physical line in the file.
+
 ---
 
 ## Task 1: State directory convention in SKILL.md Implementation Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Multi-agent adversarial review panel for Claude Code",
   "scripts": {

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -680,6 +680,9 @@ See `references/prompt-templates.md` for full prompt.
   exclude BOTH Christmases. This is the #1 class of bug that reviewers miss
   because they focus on the method, not the temporal arithmetic.
 
+**Output (v3.1.0+):** Subagent writes full output to `state/phase_8_audit.md`
+and returns only path + 100-word summary.
+
 ---
 
 ## Phase 9: Verification Command Execution (v2.8)
@@ -697,6 +700,9 @@ Skip this phase if no verification commands were provided.
 Single agent (`model: "opus"`) checks all reviewer citations against source.
 Classifies each as [VERIFIED], [INACCURATE], [MISATTRIBUTED], [HALLUCINATED],
 or [UNVERIFIABLE]. Results feed into judge prompt.
+
+**Output (v3.1.0+):** Subagent writes full output to `state/phase_10_claim_verification.md`
+and returns only path + 100-word summary.
 
 ---
 
@@ -782,6 +788,9 @@ benchmark: 2/3 P0 findings were overstated after code investigation).
 
 Results feed into the Supreme Judge prompt. The judge MUST reference the
 verification table when ruling on disagreements.
+
+**Output (v3.1.0+):** Subagent writes full output to `state/phase_11_severity_verification.md`
+and returns only path + 100-word summary.
 
 ---
 

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -628,6 +628,11 @@ summary.
 Launch all reviewers **in parallel** each round. Each receives their own review
 + reflection, all others' feedback, and unresolved points from previous round.
 
+**Output (v3.1.0+):** Each reviewer's per-round debate response is written
+to `state/reviewer_<name>_phase_5_round<R>.md` (R = 1, 2, or 3). Round 1 is
+mandatory; rounds 2 and 3 follow the existing convergence-based skip rules.
+Subagent returns only path + 100-word summary.
+
 ### Phase 6: Round Summarization
 
 After each round, summarize (no agent needed):

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -605,6 +605,10 @@ brief, and the full work content inside injection boundaries.
 
 Collect all N independent reviews.
 
+**Output (v3.1.0+):** Each reviewer subagent writes its full review to
+`state/reviewer_<name>_phase_3.md` and returns only the path + a 100-word
+summary. The orchestrator does NOT hold verbatim reviews in its window.
+
 ---
 
 ## Phase 4: Private Reflection

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -617,6 +617,10 @@ Launch all reviewers **in parallel**, each receiving ONLY their own review.
 They re-read source, rate confidence per finding (High/Medium/Low), note new
 issues, identify most/least defensible findings. See `references/prompt-templates.md`.
 
+**Output (v3.1.0+):** Each reviewer's reflection is written to
+`state/reviewer_<name>_phase_4.md`. Subagent returns only path + 100-word
+summary.
+
 ---
 
 ## Phase 5: Debate (Rounds 1-3, adaptive)

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -1264,6 +1264,20 @@ This keeps the orchestrator's launch prompt under 200 tokens instead of
 See `references/prompt-templates.md` for the Phase 15.3 agent prompt with the
 full 10-section schema and rendering spec.
 
+**Compressed-run banner (v3.1.0+):** If the source Phase 15.1 markdown
+report begins with the `⚠️ COMPRESSED RUN` blockquote, Phase 15.3 MUST render
+a prominent red banner at the top of the HTML body containing the same
+warning text. Suggested CSS:
+
+```html
+<div role="alert" style="background:#FEE2E2; color:#991B1B; padding:1rem 1.25rem; margin:1rem 0; border:2px solid #DC2626; border-radius:6px;">
+  <strong>⚠️ COMPRESSED RUN — Phases skipped: <list></strong>
+  <p>This run did not complete the full panel protocol. ... Re-run the panel for a complete review.</p>
+</div>
+```
+
+The banner appears above the report header summary card.
+
 ---
 
 ### Phase 15 Verification Gate (MANDATORY — v2.16.4)

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -661,6 +661,10 @@ sycophancy alert into next round prompt for all reviewers.
 Launch all reviewers one final time in parallel. Each gives final score, top 3
 points, recommendation, one-line verdict. Others do NOT see these.
 
+**Output (v3.1.0+):** Each reviewer's blind final is written to
+`state/reviewer_<name>_phase_7.md`. Subagent returns only path + 100-word
+summary of new findings.
+
 ---
 
 ## Phase 8: Completeness Audit

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -1015,6 +1015,26 @@ process history into the agent prompt from its own context window.
 Write structured summary to `review_panel_report.md` (or user-specified name).
 This is the main deliverable — concise, structured, action-oriented.
 
+**Compressed-run warning (v3.1.0+):** If the Phase 13.5 verification gate
+detected any unrecoverable missing phase output, Phase 15.1 MUST emit this
+block as the FIRST content of the report (before any other section,
+including Executive Summary):
+
+```markdown
+> ⚠️ **COMPRESSED RUN — Phases skipped: <comma-separated list, e.g., "4 (security), 5 (security, devils-advocate)">**
+>
+> This run did not complete the full panel protocol. The Supreme Judge ruled
+> on partial input. Findings below should be treated as **lower confidence**
+> than a full-run report. Re-run the panel for a complete review.
+```
+
+Additionally, in compressed runs, every action item MUST have `[COMPRESSED]`
+appended to its epistemic label (e.g., `[CONSENSUS][COMPRESSED]`,
+`[VERIFIED][COMPRESSED]`).
+
+For full runs, the warning block is absent. Its absence is the green-light
+signal that the panel completed the full protocol.
+
 ```markdown
 # Review Panel Report
 **Work reviewed:** {title/path}  |  **Date:** {today}

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -916,6 +916,61 @@ This table is passed to Phase 14 as input item 8.
 
 ---
 
+## Phase 13.5: Pre-Judge Verification Gate (v3.1.0)
+
+Before launching the Supreme Judge (Phase 14), the orchestrator MUST verify
+that all mandatory phase outputs exist on disk. This gate is the load-bearing
+guardrail against silent compression of Phases 4 / 5 / 7.
+
+**Gate logic (orchestrator-executed, no subagent dispatch):**
+
+For each reviewer in the panel, verify these files exist under `state/`
+(or `state/run_<N>/` in multi-run mode):
+
+| Required file | Phase | Mandatory |
+|---|---|---|
+| `reviewer_<name>_phase_3.md` | Independent review | Always |
+| `reviewer_<name>_phase_4.md` | Private reflection | Always |
+| `reviewer_<name>_phase_5_round1.md` | Debate round 1 | Always (rounds 2/3 per existing skip rules) |
+| `reviewer_<name>_phase_7.md` | Blind final | Always |
+
+Plus panel-level files:
+- `phase_8_audit.md`
+- `phase_10_claim_verification.md`
+- `phase_11_severity_verification.md`
+
+**For each required file, run three checks:**
+
+1. **Existence check** — file is present on disk.
+2. **Minimum-bytes check** — file size ≥ 500 bytes. Below this is empirically
+   a stub (subagent crashed mid-write or returned a placeholder).
+3. **Required-headers check** — parse the file and confirm it contains the
+   required schema sections for that phase (e.g., a Phase 3 review must
+   contain a Score, a Findings section, and severity tags). The exact required
+   sections per phase are defined in `references/prompt-templates.md`.
+
+**On gate failure for any file:**
+
+1. Log loudly: `GATE FAIL: <file> missing | stub | malformed`
+2. Re-dispatch the subagent for the missing/malformed phase output.
+3. Re-run the gate after re-dispatch.
+4. **Single retry only.** If the second attempt also fails, do NOT block the
+   run. Mark the phase as unrecoverable, write the COMPRESSED RUN header in
+   Phase 15.1 (see Phase 15.1 spec), and proceed to Phase 14 with the
+   partial input. The deliverable is produced with explicit warning rather
+   than failing entirely — partial review with loud warning beats no review.
+
+**On full gate pass:** proceed to Phase 14. The COMPRESSED RUN header is NOT
+emitted (its absence is the green light).
+
+**Why bytes + headers, not just existence:** A subagent can write a stub and
+crash, leaving an empty/partial file. Existence alone passes the gate on a
+stub. Bytes + required-headers makes the check load-bearing. This mirrors
+how the Phase 15 verification gate (v2.16.4) validates HTML output
+structurally, not just by file presence.
+
+---
+
 ## Phase 14: Supreme Judge
 
 Single agent (`model: "opus"`). Receives all prior outputs (including the

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -1327,6 +1327,60 @@ See `references/prompt-templates.md` for the full Phase 16 Merge Agent prompt.
 
 ## Implementation Notes
 
+### State files (v3.1.0+)
+
+Subagent outputs for Phases 3, 4, 5, 7, 8, 10, 11, and 14 are written to disk
+under a `state/` subdirectory of the review output directory, then the
+subagent returns only the file path plus a 100-word summary. The orchestrator
+reads files on demand rather than holding verbatim subagent outputs in its
+context window.
+
+Reviewer state files use the naming convention
+`state/reviewer_<name>_phase_<N>.md` (where `<name>` is the persona slug and
+`<N>` is the phase number); orchestrator-level state files include
+`state/phase_8_audit.md`, `state/phase_10_claim_verification.md`,
+`state/phase_11_severity_verification.md`, and `state/phase_14_judge_ruling.md`.
+
+**Single-run layout:**
+
+```
+docs/reviews/<date>-<topic>/
+├── state/
+│   ├── reviewer_<name>_phase_3.md         # independent review
+│   ├── reviewer_<name>_phase_4.md         # private reflection
+│   ├── reviewer_<name>_phase_5_round1.md  # debate response
+│   ├── reviewer_<name>_phase_7.md         # blind final assessment
+│   ├── phase_8_audit.md
+│   ├── phase_10_claim_verification.md
+│   ├── phase_11_severity_verification.md
+│   └── phase_14_judge_ruling.md
+├── review_panel_report.md                  # Phase 15.1
+├── review_panel_process.md                 # Phase 15.2
+└── review_panel_report.html                # Phase 15.3
+```
+
+**Multi-run layout (Phase 16):**
+
+```
+docs/reviews/<date>-<topic>/
+├── state/
+│   ├── run_1/reviewer_<name>_phase_3.md
+│   ├── run_1/reviewer_<name>_phase_4.md
+│   ├── ...
+│   ├── run_2/reviewer_<name>_phase_3.md
+│   └── ...
+```
+
+Each run's state lives under `state/run_<N>/` (e.g.
+`state/run_1/reviewer_<name>_phase_3.md`,
+`state/run_2/reviewer_<name>_phase_3.md`). The merge step (Phase 16) reads
+state files from each run independently when computing union findings.
+
+This pattern mirrors `overnight-insight-discovery`, `successor-handoff`, and
+`cloud-run-results-bq-postsync` — every long-running multi-agent skill in the
+local catalog routes intermediate outputs through disk to keep the
+orchestrator window small.
+
 - **Parallel execution:** Phases 3, 4, 5, 7 use single message with multiple
   Agent tool calls. Phases 2, 8, 9, 10, 11, 12, 13, 14 are sequential (Phase 9 is
   orchestrator-driven via Bash, not a subagent). Phase 12a is orchestrator

--- a/skills/agent-review-panel/SKILL.md
+++ b/skills/agent-review-panel/SKILL.md
@@ -973,8 +973,18 @@ structurally, not just by file presence.
 
 ## Phase 14: Supreme Judge
 
-Single agent (`model: "opus"`). Receives all prior outputs (including the
-Verification Round Summary from Phase 13 as input item 8). Steps (in order):
+Single agent (`model: "opus"`). The launch prompt is ~200 tokens of metadata:
+the paths to the state files produced by Phases 3, 4, 5, 7, 8, 10, 11, and
+13. The judge **reads state files on demand** using the Read tool — it does
+NOT receive verbatim phase outputs pre-stuffed into its launch prompt. This
+mirrors the Phase 15.3 HTML-agent pattern (v2.16.4) and caps the judge's
+window load even when the panel has produced hundreds of kilobytes of
+material.
+
+The judge's ruling is materialized to `state/phase_14_judge_ruling.md` so
+Phase 15.1 can later consume it from disk (rather than from chat).
+
+Steps (in order):
 0. Review verification results (claims, severity, commands, **and verification round**)
 0.5a-b. Verify audit findings, anti-rhetoric assessment
 0.5c. Severity dampening — minimum evidence-justified severity. **In Precise mode, findings without code citations cannot exceed P2.**
@@ -983,6 +993,7 @@ Verification Round Summary from Phase 13 as input item 8). Steps (in order):
 4-5. Absent-safeguard check, independent gap scan, score assessment
 6-7. Epistemic label classification, final verdict
 8-9. Action items, meta-observation
+10. **Write ruling to `{state_dir}/phase_14_judge_ruling.md`** (v3.1.0+).
 
 See `references/prompt-templates.md` for the full judge prompt.
 

--- a/skills/agent-review-panel/references/changelog.md
+++ b/skills/agent-review-panel/references/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0 (2026-04-27) — Silent-Phase-Compression Fix (#35)
+
+Eliminates silent compression of mandatory Phases 4 / 5 / 7 under context pressure. Subagent outputs now route through `state/<file>.md` on disk; orchestrator returns only path + 100-word summary. New Phase 13.5 verification gate confirms all mandatory phase outputs exist + meet bytes/header checks before the Supreme Judge launches; failures trigger a fail-loud `⚠️ COMPRESSED RUN` header in the report rather than a silently incomplete deliverable. Phase 14 reads state files on demand (mirrors Phase 15.3 v2.16.4 pattern) and materializes its ruling to `state/phase_14_judge_ruling.md`. Multi-run mode namespaces state under `state/run_<N>/`. 379/379 tests pass. Empirical motivation: a v3.0.0 compressed run missed 6 net-new findings (including 1 P0 FERPA / DPA gap) versus the full-run corrective review on the same input. See `docs/plans/2026-04-27-silent-phase-compression-fix-design.md` for full design.
+
 ## v2.16.5 (2026-04-19) — Plugin Skills Layout Fix (Claude Code ≥2.1.112)
 
 Fixes plugin loading on Claude Code 2.1.112, which tightened `skills` field

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -243,6 +243,8 @@ Re-read source line by line. For every code snippet, constant, set, SQL query:
 
 Report ONLY findings that NO reviewer mentioned. If the panel was thorough
 and you find nothing new, say so — do not manufacture issues.
+
+**Output protocol (v3.1.0+):** Write your full audit findings to `{state_dir}/phase_8_audit.md`. Return ONLY the path + a 100-word summary of overlooked issues. Do NOT return verbatim audit text in chat.
 ```
 
 ## Phase 10: Claim Verification Prompt
@@ -281,6 +283,57 @@ For each claim:
 **Summary:** Total claims checked: N. Verified: X%. Inaccurate: Y%. Hallucinated: Z%.
 
 **Flagged for Judge:** [list only [INACCURATE], [MISATTRIBUTED], and [HALLUCINATED] claims]
+
+**Output protocol (v3.1.0+):** Write your full verification verdicts to `{state_dir}/phase_10_claim_verification.md`. Return ONLY the path + a 100-word summary of verdicts (verified / refuted / unverifiable counts). Do NOT return verbatim verification text in chat.
+```
+
+## Phase 11: Severity Verification Prompt
+
+```
+You are a Severity Verification Agent. The expert review panel has flagged
+P0 and P1 findings. Your job is to read the actual codebase and verify each
+high-severity claim, downgrading any that were overstated.
+
+## The Source Material
+{injection boundary + full content}
+
+## P0/P1 Findings to Verify
+{list of P0 and P1 findings from the panel, each with reviewer + claim + cited location}
+
+## Verification Procedure
+
+For each P0/P1 finding:
+
+1. **Classify as `[EXISTING_DEFECT]` or `[PLAN_RISK]`**
+   - `[EXISTING_DEFECT]`: bug exists in current running code right now
+   - `[PLAN_RISK]`: risk only materializes if plan is implemented as written
+   - P0 severity REQUIRES `[EXISTING_DEFECT]`. A `[PLAN_RISK]` is at most P1.
+
+2. **Verify the claim against actual code**
+   - If finding says "X is missing", grep for X in the codebase
+   - If finding cites a specific file/line, read that file and verify
+   - If no specific line cited, flag as `[UNCITED]`
+
+3. **Check for existing safety mechanisms**
+   - Grep for DELETE, MERGE, upsert, idempotent, dry-run, duplicate, assertion
+   - A "missing safety" finding is invalid if the safety exists but the reviewer didn't look
+
+4. **External domain claims (web verify)**
+   - If the finding depends on facts outside the codebase (product limits,
+     API behavior, regulatory jurisdiction), run a web search (cap: 2 per claim,
+     5 claims max). Tag `[WEB-VERIFIED]`, `[WEB-CONTRADICTED]` (demote 1 level),
+     or `[WEB-INCONCLUSIVE]`.
+
+## Output Format
+
+| Finding | Panel Severity | Verified? | Actual Severity | Reason |
+|---------|---------------|-----------|-----------------|--------|
+
+For external claims, extend with Domain Type, Web Result, Source columns.
+
+**Summary:** Total P0/P1 verified: N. Confirmed: X. Demoted: Y. Not-a-bug: Z.
+
+**Output protocol (v3.1.0+):** Write your full severity assessment to `{state_dir}/phase_11_severity_verification.md`. Return ONLY the path + a 100-word summary of severity dampening decisions. Do NOT return verbatim severity text in chat.
 ```
 
 ## Phase 12a: Confidence-Based Tier Draft (Orchestrator Logic — no agent)

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -146,6 +146,8 @@ Also note:
 
 This reflection is private — no one else will see it directly. Be honest
 about your uncertainty.
+
+**Output protocol (v3.1.0+):** Write your full reflection to `{state_dir}/reviewer_{persona_short_name}_phase_4.md`. Return ONLY the path plus a 100-word summary of changes from your Phase 3 review (what you'd update, what you'd add, what you'd retract). Do NOT return the verbatim reflection in chat.
 ```
 
 ## Phase 5: Debate Round Prompt

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -115,7 +115,6 @@ Be specific. Reference exact lines, sections, or components. Vague feedback
 like "could be better" is not useful. If you find no issues in an area, say so
 explicitly rather than manufacturing criticism. If the line-by-line audit found
 nothing, state: "Line-by-line audit: no issues found."
-```
 
 **Output protocol (v3.1.0+):** Write your full review to `{state_dir}/reviewer_{persona_short_name}_phase_3.md`. Then return ONLY:
 
@@ -123,6 +122,7 @@ nothing, state: "Line-by-line audit: no issues found."
 2. A 100-word summary of your top conclusions and severity counts.
 
 Do NOT return your full review in chat. The orchestrator reads from disk.
+```
 
 ## Phase 4: Private Reflection Prompt
 

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -117,6 +117,13 @@ explicitly rather than manufacturing criticism. If the line-by-line audit found
 nothing, state: "Line-by-line audit: no issues found."
 ```
 
+**Output protocol (v3.1.0+):** Write your full review to `{state_dir}/reviewer_{persona_short_name}_phase_3.md`. Then return ONLY:
+
+1. The absolute path you wrote to.
+2. A 100-word summary of your top conclusions and severity counts.
+
+Do NOT return your full review in chat. The orchestrator reads from disk.
+
 ## Phase 4: Private Reflection Prompt
 
 ```

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -183,6 +183,8 @@ with strong evidence is rigor, not weakness.
 Remember: your agreement intensity is {X}%. You don't disagree reflexively,
 but you hold a high evidence bar. If you genuinely cannot find a new
 discovery after careful re-reading, state that explicitly.
+
+**Output protocol (v3.1.0+):** Write your full debate response to `{state_dir}/reviewer_{persona_short_name}_phase_5_round{round_number}.md` (e.g. `reviewer_security_phase_5_round1.md`, `reviewer_security_phase_5_round2.md`, `reviewer_security_phase_5_round3.md`). Return ONLY the path + a 100-word summary of: which reviewers you agreed with, which you challenged, and your one new finding. Do NOT return the verbatim debate response in chat.
 ```
 
 ## Phase 7: Blind Final Assessment Prompt

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -535,6 +535,18 @@ Do not re-litigate the entire review. Stay focused on the specific dispute.
 ## Phase 14: Supreme Judge Prompt
 
 ```
+**Input protocol (v3.1.0+):** You will receive only file paths in your launch prompt — not verbatim phase content. Use the Read tool to load specific files when you need them for adjudication. The available state files are:
+
+- `{state_dir}/reviewer_<name>_phase_3.md` for each reviewer
+- `{state_dir}/reviewer_<name>_phase_4.md` for each reviewer
+- `{state_dir}/reviewer_<name>_phase_5_round<R>.md` for each reviewer per round
+- `{state_dir}/reviewer_<name>_phase_7.md` for each reviewer
+- `{state_dir}/phase_8_audit.md`
+- `{state_dir}/phase_10_claim_verification.md`
+- `{state_dir}/phase_11_severity_verification.md`
+
+Read what you need to adjudicate. You do not need to read everything.
+
 You are the Supreme Judge. You receive:
 1. Original work  2. Independent reviews  3. Debate transcript
 4. Blind finals  5. Completeness audit  6. Claim verification report
@@ -617,6 +629,8 @@ You are the Supreme Judge. You receive:
 
 Be thorough, be fair, and be specific. Your verdict is the one the human will
 read first.
+
+**Output protocol (v3.1.0+):** Write your full ruling to `{state_dir}/phase_14_judge_ruling.md`. The ruling must include all sections defined in the steps below (verdict, action items, severity assessment, meta-observation, etc.). Phase 15.1 will read this file from disk.
 ```
 
 ## Sycophancy Alert Injection (when triggered)

--- a/skills/agent-review-panel/references/prompt-templates.md
+++ b/skills/agent-review-panel/references/prompt-templates.md
@@ -206,6 +206,8 @@ Give your FINAL independent assessment. Others will NOT see this.
 3. [Point 3]
 ### Final Recommendation: {Accept as-is | Accept with minor changes | Needs significant revision | Reject}
 ### One-line verdict: [Single sentence summary]
+
+**Output protocol (v3.1.0+):** Write your blind final assessment to `{state_dir}/reviewer_{persona_short_name}_phase_7.md`. Return ONLY the path + a 100-word summary of new findings (those NO reviewer mentioned). Do NOT return the verbatim assessment in chat.
 ```
 
 ## Phase 8: Completeness Auditor Prompt

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -525,6 +525,14 @@ describe("v3.1.0 file-based state convention", () => {
       "SKILL.md must define the [COMPRESSED] epistemic label suffix for action items in compressed runs"
     );
   });
+
+  it("Phase 15.3 documents COMPRESSED RUN HTML banner", () => {
+    assert.match(
+      skillMd,
+      /## Phase 15[\s\S]+?### Phase 15\.3[\s\S]+?COMPRESSED RUN[\s\S]+?banner/i,
+      "Phase 15.3 must document the red HTML banner for compressed runs"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -491,6 +491,22 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 13.5 must document the single-retry policy"
     );
   });
+
+  it("Phase 14 reads state files on demand", () => {
+    assert.match(
+      skillMd,
+      /## Phase 14: Supreme Judge[\s\S]+?reads? .*state.*on demand/i,
+      "Phase 14 must document reading state files on demand"
+    );
+  });
+
+  it("Phase 14 materializes ruling to phase_14_judge_ruling.md", () => {
+    assert.match(
+      skillMd,
+      /phase_14_judge_ruling\.md/,
+      "Phase 14 must write its ruling to state/phase_14_judge_ruling.md"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -436,6 +436,21 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 5 prompt must direct disk-write to state/reviewer_<name>_phase_5_round<R>.md"
     );
   });
+
+  it("Phase 7 blind final prompt writes output to disk", () => {
+    const promptTemplates = readFileSync(
+      resolve(ROOT, "skills/agent-review-panel/references/prompt-templates.md"),
+      "utf-8"
+    );
+    const phase7 = promptTemplates
+      .split(/^## Phase 7/m)[1]
+      .split(/^## (Phase 8|Phase 10|Claim Verification)/m)[0];
+    assert.match(
+      phase7,
+      /reviewer_.*phase_7\.md/i,
+      "Phase 7 prompt must direct disk-write to state/reviewer_<name>_phase_7.md"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -507,6 +507,24 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 14 must write its ruling to state/phase_14_judge_ruling.md"
     );
   });
+
+  it("Phase 15.1 documents COMPRESSED RUN header schema", () => {
+    assert.match(
+      skillMd,
+      /COMPRESSED RUN/,
+      "SKILL.md must mention the COMPRESSED RUN header"
+    );
+    assert.match(
+      skillMd,
+      /## Phase 15\.1[\s\S]+?⚠️[\s\S]+?COMPRESSED RUN[\s\S]+?Phases skipped/,
+      "Phase 15.1 must define the warning header format with phases-skipped list"
+    );
+    assert.match(
+      skillMd,
+      /\[COMPRESSED\]/,
+      "SKILL.md must define the [COMPRESSED] epistemic label suffix for action items in compressed runs"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -473,6 +473,24 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 11 severity verification prompt must direct disk-write"
     );
   });
+
+  it("Phase 13.5 pre-judge verification gate is documented", () => {
+    assert.match(
+      skillMd,
+      /## Phase 13\.5: Pre-Judge Verification Gate/,
+      "SKILL.md must contain the Phase 13.5 verification gate section"
+    );
+    assert.match(
+      skillMd,
+      /## Phase 13\.5[\s\S]+?Existence check[\s\S]+?Minimum-bytes[\s\S]+?Required-headers/,
+      "Phase 13.5 must document existence + minimum-bytes + required-headers checks"
+    );
+    assert.match(
+      skillMd,
+      /## Phase 13\.5[\s\S]+?single retry/i,
+      "Phase 13.5 must document the single-retry policy"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -406,6 +406,21 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 3 prompt must request a 100-word summary in the chat return"
     );
   });
+
+  it("Phase 4 reflection prompt writes output to disk", () => {
+    const promptTemplates = readFileSync(
+      resolve(ROOT, "skills/agent-review-panel/references/prompt-templates.md"),
+      "utf-8"
+    );
+    const phase4 = promptTemplates
+      .split(/^## Phase 4/m)[1]
+      .split(/^## Phase 5/m)[0];
+    assert.match(
+      phase4,
+      /reviewer_.*phase_4\.md/i,
+      "Phase 4 prompt must direct disk-write to state/reviewer_<name>_phase_4.md"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -367,5 +367,28 @@ describe("SKILL.md behavioral contract validation", () => {
   });
 });
 
+describe("v3.1.0 file-based state convention", () => {
+  it("documents the state/ directory layout in Implementation Notes", () => {
+    assert.match(
+      skillMd,
+      /state\/reviewer_<name>_phase_<N>\.md/,
+      "SKILL.md must document the state file naming convention"
+    );
+    assert.match(
+      skillMd,
+      /Implementation Notes[\s\S]+?state\/.+?phase_14_judge_ruling\.md/,
+      "Implementation Notes must list phase_14_judge_ruling.md as a materialized state file"
+    );
+  });
+
+  it("documents multi-run namespacing under state/", () => {
+    assert.match(
+      skillMd,
+      /state\/run_\d+\/reviewer/,
+      "SKILL.md must document run_<N>/ namespacing for multi-run mode"
+    );
+  });
+});
+
 // Export utilities for other test files
 export { makeAssertionChecker, runAssertions };

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -451,6 +451,28 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 7 prompt must direct disk-write to state/reviewer_<name>_phase_7.md"
     );
   });
+
+  it("Phases 8, 10, 11 verifier prompts write outputs to disk", () => {
+    const promptTemplates = readFileSync(
+      resolve(ROOT, "skills/agent-review-panel/references/prompt-templates.md"),
+      "utf-8"
+    );
+    assert.match(
+      promptTemplates,
+      /phase_8_audit\.md/,
+      "Phase 8 audit prompt must direct disk-write"
+    );
+    assert.match(
+      promptTemplates,
+      /phase_10_claim_verification\.md/,
+      "Phase 10 verification prompt must direct disk-write"
+    );
+    assert.match(
+      promptTemplates,
+      /phase_11_severity_verification\.md/,
+      "Phase 11 severity verification prompt must direct disk-write"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -388,6 +388,24 @@ describe("v3.1.0 file-based state convention", () => {
       "SKILL.md must document run_<N>/ namespacing for multi-run mode"
     );
   });
+
+  it("Phase 3 reviewer prompt writes output to disk", () => {
+    const promptTemplates = readFileSync(
+      resolve(ROOT, "skills/agent-review-panel/references/prompt-templates.md"),
+      "utf-8"
+    );
+    const phase3 = promptTemplates.split(/^## Phase 4/m)[0];
+    assert.match(
+      phase3,
+      /Write your full (output|review) to.*reviewer_.*phase_3\.md/i,
+      "Phase 3 prompt must direct the reviewer to write to state/reviewer_<name>_phase_3.md"
+    );
+    assert.match(
+      phase3,
+      /100[- ]word summary/i,
+      "Phase 3 prompt must request a 100-word summary in the chat return"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/behavioral-assertions.test.mjs
+++ b/tests/behavioral-assertions.test.mjs
@@ -421,6 +421,21 @@ describe("v3.1.0 file-based state convention", () => {
       "Phase 4 prompt must direct disk-write to state/reviewer_<name>_phase_4.md"
     );
   });
+
+  it("Phase 5 debate prompt writes round outputs to disk", () => {
+    const promptTemplates = readFileSync(
+      resolve(ROOT, "skills/agent-review-panel/references/prompt-templates.md"),
+      "utf-8"
+    );
+    const phase5 = promptTemplates
+      .split(/^## Phase 5/m)[1]
+      .split(/^## Phase 6|^## Phase 7/m)[0];
+    assert.match(
+      phase5,
+      /reviewer_.*phase_5_round\d+\.md/i,
+      "Phase 5 prompt must direct disk-write to state/reviewer_<name>_phase_5_round<R>.md"
+    );
+  });
 });
 
 // Export utilities for other test files

--- a/tests/fixtures/sample-report-compressed-run.md
+++ b/tests/fixtures/sample-report-compressed-run.md
@@ -1,0 +1,47 @@
+> ⚠️ **COMPRESSED RUN — Phases skipped: 4 (security), 5 (security, devils-advocate), 7 (architecture)**
+>
+> This run did not complete the full panel protocol. The Supreme Judge ruled on partial input. Findings below should be treated as **lower confidence** than a full-run report. Re-run the panel for a complete review.
+
+# Review Panel Report
+**Work reviewed:** PR #999 — example compressed run  |  **Date:** 2026-04-27
+**Panel:** 5 reviewers + Auditor + Judge
+**Verdict:** Needs significant revision  |  **Confidence:** Low
+**Auto-detected signals:** test-fixture
+**Review mode:** Mixed (compressed)
+
+## Executive Summary
+This is a synthetic fixture demonstrating the COMPRESSED RUN warning pattern. The panel ran with Phases 4, 5 (rounds), and 7 partially missing for 3 reviewers. The judge ruled on partial input. Findings are flagged with `[COMPRESSED]` suffix.
+
+⚠️ HUMAN REVIEW RECOMMENDED: Compressed run with low confidence. A human should validate findings before acting on them.
+
+## Scope & Limitations
+Reviewed: synthetic test fixture. Not a real review.
+Structural limitation: this run skipped MANDATORY phases (4, 5, 7) for some reviewers — see the COMPRESSED RUN warning above.
+Epistemic labels: [VERIFIED] [CONSENSUS] [SINGLE-SOURCE] [UNVERIFIED] [DISPUTED]
+Defect type labels: [EXISTING_DEFECT] (bug in current code) [PLAN_RISK] (risk if plan is implemented as written)
+
+## Score Summary
+| Reviewer | Persona | Intensity | Initial | Final | Recommendation |
+|----------|---------|-----------|---------|-------|----------------|
+| Reviewer 1 | Architecture Critic | 50% | 5/10 | 5/10 | Needs significant revision |
+| Reviewer 2 | Security Auditor | 30% | 5/10 | 6/10 | Needs significant revision |
+| Reviewer 3 | SRE | 30% | 4/10 | 5/10 | Needs significant revision |
+| Reviewer 4 | Correctness Hawk | 30% | 6/10 | 6/10 | Accept with minor changes |
+| Reviewer 5 | Devil's Advocate | 20% | 5/10 | 5/10 | Needs significant revision |
+
+## Consensus Points
+- Example consensus point [CONSENSUS] [COMPRESSED]
+
+## Disagreement Points (with judge rulings)
+- Example disagreement [SINGLE-SOURCE] [COMPRESSED]
+
+## Completeness Audit Findings
+Synthetic — limited audit due to compressed run.
+
+## Action Items (with severity AND epistemic labels)
+1. **[P1] [VERIFIED] [COMPRESSED]** Example action — re-run the panel with full protocol
+2. **[P2] [CONSENSUS] [COMPRESSED]** Example action — review compressed-run findings manually
+
+## Detailed Reviews (collapsible sections)
+
+<details><summary>Architecture review</summary>Synthetic.</details>

--- a/tests/golden/sample-report-compressed-run.golden.json
+++ b/tests/golden/sample-report-compressed-run.golden.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "sections": [
+    "Executive Summary",
+    "Scope & Limitations",
+    "Score Summary",
+    "Consensus Points",
+    "Disagreement Points (with judge rulings)",
+    "Completeness Audit Findings",
+    "Action Items (with severity AND epistemic labels)",
+    "Detailed Reviews (collapsible sections)"
+  ],
+  "headerFields": [
+    "Work reviewed",
+    "Date",
+    "Panel",
+    "Verdict",
+    "Confidence",
+    "Auto-detected signals",
+    "Review mode"
+  ],
+  "metrics": {
+    "reviewerCount": 5,
+    "actionItemCount": 2,
+    "debateRoundCount": 0,
+    "epistemicLabelsUsed": [
+      "VERIFIED",
+      "CONSENSUS",
+      "SINGLE-SOURCE",
+      "UNVERIFIED",
+      "DISPUTED"
+    ],
+    "hasCollapsibleSections": true,
+    "hasScoreTable": true,
+    "hasClaimVerification": false,
+    "hasSeverityVerification": false,
+    "hasCorrelationNotice": false,
+    "hasHumanReviewWarning": true
+  }
+}

--- a/tests/report-structure.test.mjs
+++ b/tests/report-structure.test.mjs
@@ -45,6 +45,19 @@ function parseReport(markdown) {
     }
   }
 
+  // --- Compressed-run warning (v3.1.0+) ---
+  const compressedMatch = markdown.match(
+    /^>\s*⚠️\s*\*\*COMPRESSED RUN — Phases skipped:\s*(.+?)\*\*/m
+  );
+  if (compressedMatch) {
+    report.compressedRun = {
+      detected: true,
+      phasesSkipped: compressedMatch[1].trim(),
+    };
+  } else {
+    report.compressedRun = { detected: false, phasesSkipped: null };
+  }
+
   // --- Required sections ---
   const requiredSections = [
     "Executive Summary",
@@ -378,6 +391,35 @@ describe("Report structure validation", () => {
         "Action Items section must have content"
       );
     });
+  });
+});
+
+describe("compressed-run fixture", () => {
+  it("parses the COMPRESSED RUN warning block", () => {
+    const fixturePath = resolve(FIXTURES, "sample-report-compressed-run.md");
+    const md = readFileSync(fixturePath, "utf-8");
+    const report = parseReport(md);
+    assert.equal(
+      report.compressedRun?.detected,
+      true,
+      "parser must set report.compressedRun.detected = true"
+    );
+    assert.match(
+      report.compressedRun.phasesSkipped,
+      /4|5|7/,
+      "parser must extract the phases-skipped list"
+    );
+  });
+
+  it("non-compressed fixtures have compressedRun.detected = false", () => {
+    const fixturePath = resolve(FIXTURES, "sample-report-valid.md");
+    const md = readFileSync(fixturePath, "utf-8");
+    const report = parseReport(md);
+    assert.equal(
+      report.compressedRun?.detected ?? false,
+      false,
+      "non-compressed fixture must report compressedRun.detected = false"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes [#35](https://github.com/wan-huiyan/agent-review-panel/issues/35) — under context-budget pressure, the v3.0.0 orchestrator silently inlined Phases 4 / 5 / 7 into the Supreme Judge step, producing deliverables indistinguishable from full runs. Empirical cost: 6 missed findings (incl. 1 P0 FERPA / DPA gap) on a real review.

### Architectural changes

- **File-based subagent state** — Phase 3 / 4 / 5 / 7 / 8 / 10 / 11 / 14 outputs route through `state/<file>.md` on disk; subagents return only `{path, 100-word summary}`. Eliminates the orchestrator-context bloat (~75k tokens × 6 phases) that drove silent compression.
- **Phase 13.5 — Pre-Judge Verification Gate (NEW)** — checks file existence + ≥500 B + required headers before the judge launches; single retry on miss, then fail-loud `⚠️ COMPRESSED RUN` warning rather than a silently incomplete report.
- **Phase 14 reads on demand** — judge launch prompt is ~200 tokens of paths; mirrors the v2.16.4 Phase 15.3 pattern. Ruling materializes to `state/phase_14_judge_ruling.md`.
- **`⚠️ COMPRESSED RUN` warning** — prominent blockquote in the markdown report and red banner in the HTML report when the gate detected unrecoverable phase loss; every action item gets a `[COMPRESSED]` epistemic-label suffix.

### Documentation

- Design doc: `docs/plans/2026-04-27-silent-phase-compression-fix-design.md`
- Implementation plan: `docs/plans/2026-04-27-silent-phase-compression-fix-plan.md`
- CHANGELOG entry under v3.1.0
- Mirror entry in `skills/agent-review-panel/references/changelog.md`

### Tests

- New fixture `tests/fixtures/sample-report-compressed-run.md` + golden snapshot
- `parseReport()` extended to extract `report.compressedRun.{detected, phasesSkipped}`
- `behavioral-assertions.test.mjs` gains a `v3.1.0 file-based state convention` describe block validating SKILL.md documents the new architecture
- 379 / 379 tests pass

### Breaking changes

None. The `state/` directory is net-new and may be `.gitignore`d.

### Future directions (captured in the design doc, not in scope here)

Chunked judge (Phase 14a synthesis + 14b ruling), per-issue judges, MANDATORY/SKIPPABLE matrix, Phase Execution Manifest, anti-rationalization red-flags table, named-input judge schema, upfront context-pressure tradeoff menu. All deferred to v3.2+ pending empirical signal from v3.1.0 in production.

## Test plan

- [x] Full automated suite: \`npm test\` → 379/0
- [ ] Manual E2E happy path: run \`/agent-review-panel\` on a small target, confirm \`state/\` files materialize, no COMPRESSED RUN header
- [ ] Manual E2E gate-failure: delete a state file mid-run, confirm gate detects + COMPRESSED RUN header appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)