### PR TITLE
Restructure README and extract docs into separate guides

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,119 @@
+# Migration
+
+If you installed the plugin before v3.0 (a marketplace rename in PR #22) or
+under an older marketplace handle, this guide migrates you to the current
+single-plugin layout. **New users do not need anything in this file — just
+follow [Quick Start](README.md#quick-start) in the README.**
+
+## Current install handle (since v3.0)
+
+```bash
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+```
+
+Marketplace name: `agent-review-panel`. Plugin name: `roundtable`. The full
+handle is `roundtable@agent-review-panel`.
+
+## Historical handles (and how to clean them up)
+
+| Era | Marketplace name | Plugin handle |
+|---|---|---|
+| pre-v2.16 | `agent-review-panel` (bare) | `agent-review-panel@agent-review-panel` |
+| v2.16.0 | `wan-huiyan-agent-review-panel` | `agent-review-panel@wan-huiyan-agent-review-panel` |
+| pre-v2.16.1 | `plugin` (bare) | `agent-review-panel@plugin` |
+| v2.16.1 – v2.x | `wan-huiyan-agent-review-panel` | `agent-review-panel@wan-huiyan-agent-review-panel` |
+| pre-v3.0 (`plan-review-integrator` was standalone) | `wan-huiyan-plan-review-integrator` | `plan-review-integrator@wan-huiyan-plan-review-integrator` |
+| **v3.0+** | **`agent-review-panel`** | **`roundtable@agent-review-panel`** |
+
+## Migrate from any pre-v3.0 install
+
+From your terminal:
+
+```bash
+# Remove any pre-v3.0 install (run only the lines that apply to you)
+claude plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+claude plugin marketplace remove wan-huiyan-agent-review-panel
+claude plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
+claude plugin marketplace remove wan-huiyan-plan-review-integrator
+
+# Install the current bundle (one plugin, both skills)
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+```
+
+REPL form (inside a Claude Code session, replace `claude plugin` with `/plugin`):
+
+```
+/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
+/plugin marketplace remove wan-huiyan-agent-review-panel
+/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
+/plugin marketplace remove wan-huiyan-plan-review-integrator
+/plugin marketplace add wan-huiyan/agent-review-panel
+/plugin install roundtable@agent-review-panel
+```
+
+Restart your Claude Code session. Verify:
+
+```bash
+ls ~/.claude/plugins/cache/agent-review-panel/
+# expected: roundtable  (one plugin dir; both skills live inside it)
+```
+
+## Stale-state cleanup (when uninstall isn't enough)
+
+If `claude plugin update` or `install` misbehaves, leftover state from older
+marketplace handles may be shadowing the new install. The fastest fix is to
+paste this prompt into any Claude Code session and let Claude do the cleanup:
+
+> Install the `agent-review-panel` plugin from `wan-huiyan/agent-review-panel`.
+> Before installing:
+> 1. Check `~/.claude/plugins/known_marketplaces.json` for any cached registration
+>    of this repo under an old name (`plugin`, `wan-huiyan-agent-review-panel`) —
+>    if found, `claude plugin marketplace remove <old-name>` first.
+> 2. Check `~/.claude/plugins/marketplaces/` for orphan directories with trailing
+>    whitespace.
+> 3. Check `~/.claude/skills/` for loose-clone shadows of `agent-review-panel`,
+>    `agent-review-panel-workspace`, `plan-review-integrator`, or `roundtable` —
+>    back up to `*.bak.<timestamp>` then remove.
+> 4. Then run `claude plugin marketplace add wan-huiyan/agent-review-panel` and
+>    `claude plugin install roundtable@agent-review-panel`.
+> 5. Verify the install by listing
+>    `~/.claude/plugins/cache/agent-review-panel/roundtable/*/skills/` and confirming
+>    both `agent-review-panel/SKILL.md` and `plan-review-integrator/SKILL.md` are
+>    present.
+> 6. Remind me to restart my Claude Code session.
+> Report each step's outcome.
+
+Claude will ask you to confirm any destructive `rm` actions before running them.
+
+Manual bash equivalent:
+
+```bash
+# Old marketplace name (pre-v2.16.1 was "plugin")
+claude plugin marketplace remove plugin 2>/dev/null
+
+# Orphan marketplace dirs (sometimes have trailing whitespace in the name)
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel "  # note trailing space
+rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel"   # no space
+
+# Loose-clone shadows from pre-marketplace-era manual clones
+rm -rf "$HOME/.claude/skills/agent-review-panel" \
+       "$HOME/.claude/skills/agent-review-panel-workspace" \
+       "$HOME/.claude/skills/plan-review-integrator" \
+       "$HOME/.claude/skills/roundtable"
+
+# Fresh install
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+```
+
+Restart your Claude Code session after install.
+
+## v3.0 layout change
+
+Pre-v3.0 the marketplace shipped two independently-installable plugins
+(`roundtable` + `plan-review-integrator`). v3.0 collapses them into one plugin
+(`roundtable`) bundling both skills, mirroring [obra/superpowers](https://github.com/obra/superpowers).
+If you previously ran `claude plugin install plan-review-integrator@agent-review-panel`,
+install just `roundtable@agent-review-panel` and you'll get both skills.

--- a/README.md
+++ b/README.md
@@ -1,242 +1,66 @@
-[![GitHub release](https://img.shields.io/github/v/release/wan-huiyan/agent-review-panel)](https://github.com/wan-huiyan/agent-review-panel/releases) [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-orange)](https://claude.com/claude-code) [![license](https://img.shields.io/github/license/wan-huiyan/agent-review-panel)](LICENSE) [![last commit](https://img.shields.io/github/last-commit/wan-huiyan/agent-review-panel)](https://github.com/wan-huiyan/agent-review-panel/commits)
-[![Tests](https://github.com/wan-huiyan/agent-review-panel/actions/workflows/test.yml/badge.svg)](https://github.com/wan-huiyan/agent-review-panel/actions/workflows/test.yml)
-[![Research Papers](https://img.shields.io/badge/research%20foundations-9%20papers-orange)](#research-foundations)
+[![Version](https://img.shields.io/github/package-json/v/wan-huiyan/agent-review-panel)](https://github.com/wan-huiyan/agent-review-panel/releases) [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-orange)](https://claude.com/claude-code) [![license](https://img.shields.io/github/license/wan-huiyan/agent-review-panel)](LICENSE) [![Tests](https://github.com/wan-huiyan/agent-review-panel/actions/workflows/test.yml/badge.svg)](https://github.com/wan-huiyan/agent-review-panel/actions/workflows/test.yml)
 
 # Agent Review Panel
 
-**4–6 AI reviewers independently evaluate your code, plan, or docs, then debate each other's findings. A judge resolves disagreements. You get three artifacts: a Markdown report (`review_panel_report.md`), a verbatim process log (`review_panel_process.md`), and an interactive HTML dashboard (`review_panel_report.html`).**
+**4–6 AI reviewers independently evaluate your code, plan, or docs, debate each other's findings, then a judge resolves disagreements.** A [Claude Code](https://claude.ai/code) plugin that orchestrates structured multi-stance review. Each run costs roughly **$3–$20** in Opus tokens and takes **6–15 minutes** — built for high-stakes reviews, not routine code review.
 
-A [Claude Code](https://claude.ai/code) **plugin** that orchestrates multi-agent adversarial review panels backed by [9 research papers](#research-foundations) on multi-agent debate.
+[![Agent Review Panel — pipeline architecture](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/main/docs/hero-flow.svg)](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/main/docs/hero-flow.svg)
 
-> Packaged as a Claude Code plugin (`roundtable`) that bundles **two skills**: `agent-review-panel` (the panel itself) and `plan-review-integrator` (applies findings back into a plan). One install gets you both; details under [Bundled skills](#bundled-skills).
->
-> **Runs only on Claude Code surfaces** — CLI, IDE extension, or the **Code tab inside the Claude Desktop app**. Does not work with claude.ai web chat or the Anthropic API direct ([why](#requires-claude-code)).
+> Runs only on Claude Code surfaces (CLI, IDE extension, Desktop "Code" tab) and the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/plugins). Does not work on claude.ai web chat or the raw Anthropic API — see [Surfaces & Requirements](#surfaces--requirements).
 
-[![Agent Review Panel — pipeline architecture](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/hero-flow.svg)](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/hero-flow.svg)
-
-[![Agent Review Panel — terminal demo](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/demo.gif)](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/demo.gif)
-
-[![Agent Review Panel — interactive HTML dashboard with expandable issue cards](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/html-demo.gif)](https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/html-demo.gif)
-
-*The HTML report: expandable 10-section issue cards (narrative, code evidence with Prism.js syntax highlighting, debate transcripts, judge rulings, fix recommendations, cross-references), deep-linkable, keyboard-navigable, print-friendly.*
-
-## Contents
-
-- [Quick Start](#quick-start) — install + first-run verification
-- [Installation](#installation) — supported surfaces, marketplace, manual clone
-- [How It Works](#how-it-works) — the 16-phase pipeline
-- [Features](#features) — review process, verification layer, anti-groupthink, advanced
-- [Usage Examples](#usage-examples) and [Configuration / Modes](#configuration--modes)
-- [Cost & Performance](#cost--performance) and [Known Limitations](#known-limitations)
-- [Migration](#migration-from-previous-marketplaces) and [Troubleshooting](#troubleshooting)
-- [Reading the Report](#reading-the-report) — vocabulary, severity rubric, epistemic labels
-
-<a id="quick-start"></a>
 ## Quick Start
-
-**In your terminal** (bash/zsh):
 
 ```bash
 claude plugin marketplace add wan-huiyan/agent-review-panel
 claude plugin install roundtable@agent-review-panel
 ```
 
-Then restart your Claude Code session — skills load at session start.
-
-**After install — verify it loaded.** In a fresh Claude Code session, type `/roundtable:agent-review-panel` (with no target). The skill should respond by introducing itself and asking what to review. If you get `unknown command` instead, the skills didn't load — see [Troubleshooting → After install, slash command not recognized](#after-install-roundtableagent-review-panel-is-not-recognized).
+Restart your Claude Code session — skills load at session start.
 
 <details>
-<summary>Already inside a Claude Code session? Use the slash-command form instead</summary>
-
-Type these at the REPL prompt (note the leading `/` and no `claude` prefix):
+<summary>Already inside a Claude Code session? Use the slash-command form</summary>
 
 ```
 /plugin marketplace add wan-huiyan/agent-review-panel
 /plugin install roundtable@agent-review-panel
 ```
 
-Both forms do the same thing. Pick whichever matches where you are: shell-form `claude plugin …` for terminal, REPL-form `/plugin …` for inside Claude Code.
+Same effect. Shell form (`claude plugin …`) from the terminal; REPL form (`/plugin …`) from inside Claude Code.
 </details>
 
-<a id="upgrading-from-v2x"></a>
-<details>
-<summary><strong>Upgrading from v2.x?</strong> Have Claude Code do the cleanup + install for you (recommended)</summary>
-
-If you already installed under an older marketplace name (`@wan-huiyan-agent-review-panel`, `@agent-review-panel` pre-v2.16.1, or the bare `plugin` name pre-v2.16) you may have stale state that silently shadows the new install. The fastest fix is to paste the prompt below into any Claude Code session and let Claude do the cleanup, install, and verification:
-
-> Install the `agent-review-panel` plugin from `wan-huiyan/agent-review-panel`. Before installing:
-> 1. Check `~/.claude/plugins/known_marketplaces.json` for any cached registration of this repo under an old name (`plugin`, `wan-huiyan-agent-review-panel`) — if found, `claude plugin marketplace remove <old-name>` first.
-> 2. Check `~/.claude/plugins/marketplaces/` for orphan directories with trailing whitespace.
-> 3. Check `~/.claude/skills/` for loose-clone shadows of `agent-review-panel`, `agent-review-panel-workspace`, `plan-review-integrator`, or `roundtable` — back up to `*.bak.<timestamp>` then remove.
-> 4. Then run `claude plugin marketplace add wan-huiyan/agent-review-panel` and `claude plugin install roundtable@agent-review-panel`.
-> 5. Verify the install by listing `~/.claude/plugins/cache/agent-review-panel/roundtable/*/skills/` and confirming both `agent-review-panel/SKILL.md` and `plan-review-integrator/SKILL.md` are present.
-> 6. Remind me to restart my Claude Code session.
-> Report each step's outcome.
-
-Claude will ask you to confirm any destructive `rm` actions before running them. Manual equivalent is in [Migration](#migration-from-previous-marketplaces).
-</details>
-
-> The `roundtable` plugin bundles **two skills**: `agent-review-panel` (the review panel) and `plan-review-integrator` (the review→integrate companion). One install gets you both. See [Bundled skills](#bundled-skills) below. Upgrading from v2.x? See [Migration](#migration-from-previous-marketplaces).
+**Verify it loaded.** In a fresh Claude Code session, type `/roundtable:agent-review-panel` with no arguments. The skill should introduce itself and ask what to review. If you get `unknown command`, see [Troubleshooting](TROUBLESHOOTING.md#after-install-roundtableagent-review-panel-is-not-recognized). Migrating from an older install handle? See [MIGRATION.md](MIGRATION.md).
 
 **Use:**
+
 ```
 > Review this implementation plan from multiple perspectives: docs/my_plan.md
 
 > /roundtable:agent-review-panel
 ```
 
-> ⚠️ Slash commands are `/<plugin>:<skill>` — `/roundtable:agent-review-panel` and `/roundtable:plan-review-integrator`. Natural-language invocation also works (the skill's description triggers it), so use whichever feels natural.
+Natural-language invocation also works ("red team this", "stress-test this design", "get a panel review of …").
 
-**What you get:** Three output files:
-- `review_panel_report.md` — executive summary, consensus, disagreements (with judge rulings), prioritized action items tagged with epistemic labels
-- `review_panel_process.md` — full "director's cut" log of every agent's verbatim output with persona profiles
-- `review_panel_report.html` — interactive dashboard with **expandable 10-section issue cards** (Narrative, Code Evidence, Debate, Judge Ruling, Fix Recommendation, and more — new in v2.15), filterable issue cards, charts, and a Panel Gallery
+**What you get** — three files written to your current working directory:
 
-_See the [demo GIFs](#agent-review-panel) at the top of this README for what the markdown report and HTML dashboard look like._
+- `review_panel_report.md` — executive summary, consensus, judge-resolved disagreements, action items
+- `review_panel_process.md` — verbatim "director's cut" of every reviewer's output
+- `review_panel_report.html` — interactive dashboard with expandable issue cards, charts, and a panel gallery
 
-## Installation
+See [Sample output](#sample-output) below for what a real report looks like.
 
-### Requires Claude Code
+## When to use it — and when not
 
-This plugin **only works on Claude Code surfaces** — or on the **[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/plugins)** — because it needs the `Agent` tool for subagent spawning, local-filesystem access for output files, and a plugin-loader. Supported surfaces:
+**Use a panel for:** high-stakes plans you'd want a second/third/fourth opinion on; security-sensitive code; architecture decisions that are expensive to reverse; docs that have to be right; "I'm too close to this — stress-test it."
 
-**Works ✅**
-- ✅ **CLI** — `claude` command in your terminal
-- ✅ **VS Code extension** — Claude Code extension from the VS Code marketplace
-- ✅ **JetBrains IDE extension** — IntelliJ, PyCharm, WebStorm, GoLand, Rider, etc.
-- ✅ **Claude Desktop app → Code tab** — the Desktop app bundles a Claude Code surface in its dedicated "Code" tab; the plugin installs and runs there the same way it does in the CLI. ([official docs](https://code.claude.com/docs/en/desktop))
-- ✅ **Claude Agent SDK** — programmatic agent-building library on top of the Anthropic API. Load this plugin with `options.plugins: [{ type: "local", path: "./agent-review-panel" }]` in TypeScript or Python; subagents, skills, slash commands, and filesystem tools all work. See [Plugins in the SDK](https://code.claude.com/docs/en/agent-sdk/plugins).
+**Don't use a panel for** (use a single review or `/review` instead): a quick look before pushing; type-error fixes; routine code review; addressing existing PR comments; "what does this code do?"; deployments; writing tests or docs from scratch.
 
-**Does not work ❌**
-- ❌ **Claude Desktop app → regular chat tabs** — the chat surface has no `/plugin` marketplace; and although [Agent Skills](https://www.anthropic.com/news/skills) can run there, this plugin's 4–6 parallel reviewers plus three local-file outputs need Claude Code's subagent + filesystem infrastructure. Use the Code tab instead.
-- ❌ **claude.ai web chat** — same reason: no `/plugin` marketplace, and Skills on the web surface can't spawn the parallel subagents or write the `review_panel_*.md`/`.html` files the plugin produces.
-- ❌ **Anthropic Messages API called directly (without the Agent SDK)** — the raw API is a prompt→response interface; it has no plugin loader, no subagent orchestration, and no filesystem. If you want to run the plugin against the API, use the **Claude Agent SDK** entry above.
+The key signal is **multiple independent perspectives** — if one opinion would do, you're paying 4–6× more for nothing.
 
-**Why:** the panel spawns 4–6 reviewer subagents in parallel via Claude Code's `Agent` tool, reads/writes files on your local filesystem to generate the three output reports, and responds to the `/roundtable:agent-review-panel` slash command (or any natural-language "review panel" request). Only Claude Code surfaces expose those capabilities.
+## Why a panel, not a single reviewer?
 
-Don't have Claude Code yet? Install it from **[claude.ai/code](https://claude.ai/code)**, then come back and run the [Quick Start](#quick-start) commands above.
+Ask one reviewer "review this" and you get one perspective. It won't argue with itself, catch its own blind spots, or volunteer "I'm not sure about this."
 
-### Claude Code marketplace (recommended)
-
-Install commands are in [Quick Start](#quick-start) above. Claude Code caches the plugin, loads its skills, and activates trigger phrases automatically. Two things worth knowing about the install handle:
-
-<!-- release-check:marketplace-name-callout — load-bearing for scripts/release-check.sh; do not delete without updating both -->
-> **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `agent-review-panel` (defined in `.claude-plugin/marketplace.json`); the plugin install name inside it is `roundtable`. Hence `roundtable@agent-review-panel`. Pre-v2.16.1 releases used `@wan-huiyan-agent-review-panel`; pre-v2.16 used `@agent-review-panel`. If you installed under an older marketplace name, see [Migration](#migration-from-previous-marketplaces).
-<!-- /release-check:marketplace-name-callout -->
-
-**Why the marketplace path?** The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests (v3.0+ single-plugin layout) that Claude Code reads to register the plugin — the marketplace install handles caching, version tracking, and activation in one step. [Manual clone](#manual-clone-development--custom-setup) works but bypasses the manifests.
-
-### Updating to the latest version
-
-New releases land on `main`; Claude Code does not auto-pull. Run the update flow after each release (or any time you want the newest features) **in your terminal**:
-
-```bash
-claude plugin marketplace update agent-review-panel
-claude plugin update roundtable@agent-review-panel
-```
-
-<details>
-<summary>Or, if you're already in a Claude Code session, use the slash-command form</summary>
-
-```
-/plugin marketplace update agent-review-panel
-/plugin update roundtable@agent-review-panel
-```
-
-</details>
-
-**Verify the update worked:**
-```bash
-ls ~/.claude/plugins/cache/agent-review-panel/roundtable/
-```
-The directory name is the installed version (e.g. `3.1.0`). It should match the [latest GitHub release](https://github.com/wan-huiyan/agent-review-panel/releases/latest). If you have the [GitHub CLI](https://cli.github.com/), `gh release view --repo wan-huiyan/agent-review-panel` is the most direct check.
-
-(Cache layout is `cache/<marketplace-name>/<plugin-name>/<version>/` — the `plugins/` intermediate directory from the repo is flattened out during install, and a version segment is added.)
-
-**If the update appears to work but you're still getting old behavior** (e.g. missing the HTML report, missing expandable cards, or missing the data-flow trace phase), check for a **stale local clone** that shadows the marketplace install:
-
-```bash
-ls ~/.claude/skills/agent-review-panel 2>/dev/null
-```
-
-If that directory exists, it's loaded *before* the marketplace cache and pins you to whatever version was cloned. Back it up first (irreversible if you delete it outright with local edits inside), then remove the original:
-
-```bash
-mv "$HOME/.claude/skills/agent-review-panel" "$HOME/.claude/skills/agent-review-panel.bak.$(date +%s)"
-```
-
-Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/agent-review-panel/` will take over. Delete the `.bak.*` directory once the marketplace version is confirmed working.
-
-**Fallback — clean reinstall:** If the update commands misbehave, uninstall and reinstall from scratch. From your terminal:
-
-```bash
-claude plugin uninstall roundtable@agent-review-panel
-claude plugin marketplace remove agent-review-panel
-claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install roundtable@agent-review-panel
-```
-
-<details>
-<summary>REPL-form equivalent (inside a Claude Code session)</summary>
-
-```
-/plugin uninstall roundtable@agent-review-panel
-/plugin marketplace remove agent-review-panel
-/plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install roundtable@agent-review-panel
-```
-
-</details>
-
-<a id="manual-clone-development--custom-setup"></a>
-### Manual clone (development / custom setup)
-
-For local development, forking, or air-gapped environments. **Do NOT clone into `~/.claude/skills/`** — that path shadows marketplace installs and is the destructive-cleanup target in [Updating](#updating-to-the-latest-version) above. Use a separate workspace path instead:
-
-```bash
-git clone https://github.com/wan-huiyan/agent-review-panel.git ~/projects/agent-review-panel-dev
-```
-
-Then load the cloned repo as a local plugin for testing without committing to a marketplace install:
-
-```bash
-claude --plugin-dir ~/projects/agent-review-panel-dev
-```
-
-### Claude Code version requirement
-
-**Claude Code v1.0+** — the plugin uses the `Agent` tool for parallel subagent spawning. Reviewer model selection is documented under [How It Works](#how-it-works).
-
-### Cursor (experimental)
-
-<details>
-<summary>Cursor installation options</summary>
-
-> **Confidence: untested by maintainers.** Community PRs welcome — see [Contributing](#contributing). The recipes below are starting points, not verified flows.
-
-This skill was built for Claude Code's Agent tool (parallel subagent spawning, model selection). Cursor has its own mechanisms that may require adaptation.
-
-**Per-project rule (most reliable):**
-```bash
-mkdir -p .cursor/rules
-# Create .cursor/rules/agent-review-panel.mdc with the content of SKILL.md
-# Add frontmatter: alwaysApply: true
-```
-
-**Manual global install:**
-```bash
-git clone https://github.com/wan-huiyan/agent-review-panel.git ~/.cursor/skills/agent-review-panel
-```
-
-The core pattern is straightforward — one subagent/task per reviewer in Phase 3, collect results, then one per reviewer in Phase 5 (debate), then single agents for verification and judge. If you adapt it, PRs are welcome.
-
-</details>
-
-## Why Use a Panel Instead of a Single Reviewer?
-
-When you ask Claude to "review this code," you get one perspective. It won't argue with itself, catch its own blind spots, or tell you "I'm not sure about this."
-
-The panel spawns independent reviewers that genuinely engage:
+The panel forces the same model to take multiple passes from assigned, divergent stances — Correctness Hawk, Security Auditor, Devil's Advocate, etc. — *before* they see each other's output. Then they debate, then a separate judge step resolves disputes against verified evidence. You get a deliberation, not a list:
 
 > **Feasibility Analyst:** "The `data_available_through` hardcoding is minor — it's documented."
 >
@@ -244,81 +68,180 @@ The panel spawns independent reviewers that genuinely engage:
 >
 > **Feasibility Analyst (Round 2):** "Valid point. I upgrade this to IMPORTANT."
 
-A single reviewer gives you a list. The panel gives you a deliberation — with structured disagreements, judge rulings, and confidence levels.
+**Honest caveat:** all reviewers are Claude instances running the same base model. This is structured *self-critique*, not independent verification — unanimous agreement may reflect shared model bias rather than ground truth. The architecture includes anti-groupthink safeguards (blind final scoring, sycophancy detection, correlated-bias warnings) but cannot eliminate the structural limitation. The value is the forced multi-stance discipline plus verification against actual source, not the appearance of disagreement.
+
+## Sample output
+
+The panel was run against this very README on 2026-05-14. Excerpt from the resulting `review_panel_report.md`:
+
+```markdown
+# Review Panel Report — README.md
+
+**Verdict:** REVISE — substantial edit needed | **Confidence:** Medium-High
+**Score:** 5/10 | **Mode:** Exhaustive (pure documentation)
+
+## Executive Summary
+
+The README is factually careful where it counts — install commands, marketplace
+handles, slash commands, "401 tests", and spot-checked anchors all verify
+cleanly against the repo. But three problems pull the score to 5/10: the
+version/release story is incoherent and actively misleads every current
+user, the document is roughly a third too long, and it never shows what a
+review actually produces.
+
+## Consensus Points (judge-confirmed)
+
+- Version/release story is broken — all four reviewers, independently.
+  package.json declares 3.3.0; the only git tags are up to v3.1.0. The
+  "Updating" section tells users to verify against "the latest GitHub
+  release" — which resolves to v3.1.0, so every correctly-installed
+  v3.3.0 user concludes their install is wrong.  [VERIFIED][CONSENSUS]
+
+## Action Items
+
+| # | Severity | Action                                                       |
+|---|----------|--------------------------------------------------------------|
+| 1 | P1 [VERIFIED][CONSENSUS] | Fix the version/release story.            |
+| 3 | P1 [CONSENSUS]           | Cut ~⅓ length; split audiences.           |
+| 4 | P1 [VERIFIED]            | Add a text sample of a real report.       |
+```
+
+You're reading the v3.3.0 rewrite that lands those findings. The full artifacts live at:
+
+- [`docs/reviews/2026-05-14-readme/review_panel_report.md`](docs/reviews/2026-05-14-readme/review_panel_report.md) — the full markdown report (13 action items)
+- [`docs/reviews/2026-05-14-readme/review_panel_report.html`](docs/reviews/2026-05-14-readme/review_panel_report.html) — the interactive HTML dashboard
+- [`docs/reviews/2026-05-14-readme/review_panel_process.md`](docs/reviews/2026-05-14-readme/review_panel_process.md) — verbatim process log with all four reviewers' raw output
+
+## Surfaces & Requirements
+
+This plugin needs the Claude Code `Agent` tool for parallel subagent spawning, local-filesystem access for output files, and a plugin loader.
+
+**Works ✅**
+- **CLI** — `claude` in your terminal
+- **VS Code extension** — Claude Code extension
+- **JetBrains IDE extension** — IntelliJ, PyCharm, WebStorm, GoLand, Rider, etc.
+- **Claude Desktop app → Code tab** — the dedicated "Code" tab inside the Desktop app ([docs](https://code.claude.com/docs/en/desktop))
+- **Claude Agent SDK** — load via `options.plugins: [{ type: "local", path: "./agent-review-panel" }]` ([docs](https://code.claude.com/docs/en/agent-sdk/plugins))
+
+**Does not work ❌**
+- **claude.ai web chat** and **Claude Desktop regular chat tabs** — no `/plugin` marketplace; Agent Skills there can't spawn parallel subagents or write the output files
+- **Anthropic Messages API called directly** (without the Agent SDK) — no plugin loader, no subagent orchestration, no filesystem. Use the Agent SDK entry above.
+
+**Prerequisites in one place:**
+
+- **Claude Code v1.0+** on a supported surface, or the Claude Agent SDK
+- A Claude **Pro / Max** subscription or API access (Opus is the reviewer model)
+- **Node ≥18** (only needed if running `npm test` or developing locally)
+- **Optional:** [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) for stronger domain-specific reviews
+
+Don't have Claude Code yet? Install it from [claude.ai/code](https://claude.ai/code), then come back to [Quick Start](#quick-start).
+
+### Marketplace install (recommended)
+
+Install commands are in [Quick Start](#quick-start). The marketplace install handles caching, version tracking, and trigger-phrase activation in one step.
+
+<!-- release-check:marketplace-name-callout — load-bearing for scripts/release-check.sh; do not delete without updating both -->
+> **Command format:** `@<marketplace-name>`, not `@<repo-name>`. The marketplace name is `agent-review-panel` (defined in `.claude-plugin/marketplace.json`); the plugin install name inside it is `roundtable`. Hence `roundtable@agent-review-panel`. If you installed under an older marketplace name, see [MIGRATION.md](MIGRATION.md).
+<!-- /release-check:marketplace-name-callout -->
+
+**Why the marketplace path?** The repo ships `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` manifests that Claude Code reads to register the plugin. The marketplace install reads those manifests and wires everything up in one step. [Manual clone](#manual-clone) works but bypasses the manifests.
+
+### Manual clone
+
+For local development, forking, or air-gapped environments. **Do NOT clone into `~/.claude/skills/`** — that path shadows marketplace installs.
+
+```bash
+git clone https://github.com/wan-huiyan/agent-review-panel.git ~/projects/agent-review-panel-dev
+claude --plugin-dir ~/projects/agent-review-panel-dev
+```
+
+### Cursor (untested by maintainers)
+
+<details>
+<summary>Community-contributed starting points — see <a href="#contributing">Contributing</a> if you want to help</summary>
+
+Per-project rule:
+```bash
+mkdir -p .cursor/rules
+# Create .cursor/rules/agent-review-panel.mdc with the content of SKILL.md
+# Add frontmatter: alwaysApply: true
+```
+
+Manual global install:
+```bash
+git clone https://github.com/wan-huiyan/agent-review-panel.git ~/.cursor/skills/agent-review-panel
+```
+
+The core pattern is straightforward — one subagent per reviewer in Phase 3, collect results, debate in Phase 5, verification and judge after. PRs welcome.
+</details>
 
 ## How It Works
 
-16 top-level phases + optional multi-run merge, numbered as sequential integers (Phase 1 through Phase 16). Phase 15 is a parent step with three sub-steps — Phase 15.1 (markdown report), Phase 15.2 (process history), Phase 15.3 (HTML dashboard) — written sequentially per the v2.16.4 disk-reading architecture. The v2.14 cleanup retired purely artifactual intermediate decimals like the old Phase 4.55; the load-bearing 15.x sub-steps are deliberate.
+A run executes 16 top-level phases (plus two verification gates — 13.5 and 14.5 — and an optional multi-run merge at Phase 16). The numbered phase table:
 
 | Stage | Phase | Action |
 |---|---|---|
-| **Gather** | 1. | Setup — scan sibling dirs, trace references, discover safeguards, detect signals, select personas |
-| | 2. | **Data Flow Trace** *(v2.14, code only)* — trace critical path(s), document schemas at each function boundary, flag composition/seam bugs |
-| **Review** | 3. | Independent Review — 4-6 reviewers evaluate in parallel (no cross-talk) |
-| | 4. | Private Reflection — each reviewer re-reads and rates own confidence |
-| **Debate** | 5. | Adversarial Debate (1-3 rounds) — reviewers engage + find new issues |
-| | 6. | Round Summarization — distill resolved/unresolved points between rounds |
-| | 7. | Blind Final — each reviewer gives final score independently |
-| **Verify** | 8. | Completeness Audit — dedicated agent scans for what the panel missed |
-| | 9. | Verify Commands — run reviewer grep/read commands for P0/P1 findings (advisory) |
-| | 10. | Claim Verification — verify all line-number citations against source |
-| | 11. | Severity Verification — read actual code for every P0/P1; downgrade if overstated; **web-verify external domain claims** *(v2.16.3)* |
-| | 12. | Tier Assignment — confidence-based draft → judge-advised refinement per dispute |
-| | 13. | Targeted Verification — persona-matched agents investigate each dispute point |
-| **Adjudicate** | 14. | Supreme Judge — Opus arbitrates everything including verification round evidence |
-| **Output** | 15. | Triple output: Primary Report (`.md`) + Process History (`.md`) + **Expandable-card Dashboard (`.html`)** *(v2.15)* |
-| **Merge** | 16. | **Multi-Run Merge** *(v2.14, optional)* — deduplicate findings across runs, score stability, resolve judge divergence |
+| **Gather** | 1 | Setup — scan sibling dirs, trace references, discover safeguards, detect signals, select personas |
+| | 2 | Data Flow Trace (code only) — trace critical path(s), document schemas at each function boundary, flag composition/seam bugs |
+| **Review** | 3 | Independent Review — 4–6 reviewers evaluate in parallel (no cross-talk) |
+| | 4 | Private Reflection — each reviewer re-reads and rates own confidence |
+| **Debate** | 5 | Adversarial Debate (1–3 rounds) — reviewers engage + find new issues |
+| | 6 | Round Summarization — distill resolved/unresolved points between rounds |
+| | 7 | Blind Final — each reviewer gives final score independently |
+| **Verify** | 8 | Completeness Audit — dedicated agent scans for what the panel missed |
+| | 9 | Verify Commands — run reviewer grep/read commands for P0/P1 findings (advisory) |
+| | 10 | Claim Verification — verify all line-number citations against source |
+| | 11 | Severity Verification — read actual code for every P0/P1; downgrade if overstated; web-verify external domain claims |
+| | 12 | Tier Assignment — confidence-based draft → judge-advised refinement per dispute |
+| | 13 | Targeted Verification — persona-matched agents investigate each dispute point |
+| | **13.5** | **Pre-Judge Verification Gate** — orchestrator confirms all phase outputs exist on disk before launching the judge |
+| **Adjudicate** | 14 | Supreme Judge — Opus arbitrates everything including verification-round evidence |
+| | **14.5** | **Post-Judge Verification Gate** — re-verifies judge-introduced P0/P1 against ground truth (catches judge hallucinations) |
+| **Output** | 15 | Triple output: Primary Report (`.md`) + Process History (`.md`) + Expandable-card Dashboard (`.html`) |
+| **Merge** | 16 | Multi-Run Merge (optional) — deduplicate findings across runs, score stability, resolve judge divergence |
+
+Phase 15 has three sequential sub-steps (15.1 → 15.2 → 15.3) so the HTML agent can read the already-written markdown and process files from disk.
 
 ## Features
 
-**Review process:**
-- 4-6 reviewers with distinct personas evaluate in parallel, then debate across 1-3 rounds
-- Auto-selects personas based on content type (code, plan, docs, mixed) and technology signals across 10 signal groups (SQL, ML, Terraform, Auth, API, Frontend, Cost, Pipeline, Portability, Repo Hygiene)
+**Review process**
+- 4–6 reviewers with distinct personas evaluate in parallel, then debate across 1–3 rounds
+- Auto-selects personas from content type (code, plan, docs, mixed) and 10 technology signal groups (SQL/Data, Auth/Security, Infrastructure, ML/Statistics, API/Integration, Frontend, Cost, Pipeline, Repo/Data Hygiene, Skill/Docs Portability)
 - Each reviewer uses a different reasoning strategy (systematic enumeration, adversarial simulation, backward reasoning, etc.)
 - Auto Precise/Exhaustive mode: code requires line citations; plans allow broader risk identification
 
-**Verification layer:**
-- Claim verification checks all reviewer citations against actual source code
-- Severity verification reads the codebase to confirm P0/P1 findings before the judge sees them. **External domain claims** (product limits, regulatory jurisdiction, API behavior) are automatically web-searched and tagged `[WEB-VERIFIED]`, `[WEB-CONTRADICTED]`, or `[WEB-INCONCLUSIVE]`
-- Verification commands: runs read-only grep/cat commands from reviewers to confirm or contradict claims
-- Defect classification: findings labeled [EXISTING_DEFECT] or [PLAN_RISK] — P0 requires existing defect evidence
-- **Live-State Claim Discipline:** findings asserting facts about *live infrastructure or runtime state* (deployed IAM/IAP/auth, running crons, production env vars) must distinguish declarative config from imperative documentation (`echo`/comment/usage lines are never evidence) from live `describe`-class output. Such claims are tagged `[LIVE-VERIFIED]` or `[STATIC-INFERENCE]` — the latter capped at P1, since a static read of a deploy script can't prove what production is doing right now
-- Completeness audit: post-debate agent re-reads source line-by-line for what everyone missed
-- **Targeted verification round:** each unresolved dispute gets a tiered (Light ~2k / Standard ~8k / Deep ~32k tokens) verification agent matched to the claim type (statistician for stats claims, security auditor for security claims, etc.) — verdicts feed directly into the judge's rulings
-- **Data Flow Trace:** a dedicated agent traces data through critical paths before reviewers begin, flagging composition/seam bugs (two individually-correct functions producing incorrect results together). Three tiers: Standard (default, single path), Thorough (top 3 paths + transform-completeness checks), Exhaustive (all paths, no token limit). Uses Meta's semi-formal certificate prompting. Skipped for pure docs/plans or code with no data transforms.
-- **Force opus on all launches:** every `subagent_type` launch — including VoltAgent specialist agents — passes `model: "opus"` explicitly. Fixes an invisible source of cross-run variance where VoltAgent agents silently fell through to their frontmatter-declared default model (potentially sonnet or haiku), producing different reasoning depths across otherwise identical runs.
+**Verification layer**
+- **Claim verification** checks all reviewer citations against actual source code
+- **Severity verification** reads the codebase to confirm P0/P1 findings before the judge sees them. External domain claims (product limits, regulatory jurisdiction, API behavior) are automatically web-searched and tagged `[WEB-VERIFIED]`, `[WEB-CONTRADICTED]`, or `[WEB-INCONCLUSIVE]`
+- **Verification commands**: runs read-only grep/cat commands from reviewers to confirm or contradict claims
+- **Defect classification**: findings labeled `[EXISTING_DEFECT]` or `[PLAN_RISK]` — P0 requires existing defect evidence
+- **Live-State Claim Discipline**: findings asserting facts about *live infrastructure or runtime state* (deployed IAM, running crons, production env vars) must distinguish declarative config from imperative documentation from live `describe`-class output. Tagged `[LIVE-VERIFIED]` or `[STATIC-INFERENCE]` — the latter is capped at P1
+- **Completeness audit**: post-debate agent re-reads source line-by-line for what everyone missed
+- **Targeted verification**: each unresolved dispute gets a tiered (Light / Standard / Deep) verification agent matched to the claim type
+- **Data Flow Trace** (code only, three tiers): a dedicated agent traces data through critical paths before reviewers begin, flagging composition/seam bugs
+- **Post-judge verification gate**: re-verifies any P0/P1 the judge introduced (vs. raised by panel) against ground truth; hallucinated findings are demoted and the verdict score is recomputed
+- **Force-opus**: every subagent launch passes `model: "opus"` explicitly to eliminate cross-run reasoning variance
 
-**Anti-groupthink safeguards:**
-- Blind final scoring, private reflection, calibrated skepticism levels (20-60%)
+**Anti-groupthink safeguards**
+- Blind final scoring, private reflection, calibrated skepticism levels (20–60%)
 - Sycophancy detection intervenes when >50% of position changes lack new evidence
 - Anti-rhetoric assessment flags position changes driven by eloquence rather than evidence
-- Judge confidence gating: low-confidence verdicts flag "HUMAN REVIEW RECOMMENDED"
+- Judge confidence gating: low-confidence verdicts flag `⚠️ HUMAN REVIEW RECOMMENDED`
 - Correlated-bias warning when all reviewers converge (unanimous agreement is the most dangerous failure mode)
 
-**Output (three files per review):**
-- **Primary report** (`review_panel_report.md`): executive summary, consensus, disagreements (with judge rulings), prioritized action items with epistemic labels ([VERIFIED], [CONSENSUS], [SINGLE-SOURCE], [UNVERIFIED], [DISPUTED], [WEB-VERIFIED], [WEB-CONTRADICTED], [WEB-INCONCLUSIVE], [LIVE-VERIFIED], [STATIC-INFERENCE], [STATIC-INFERENCE-CONSENSUS])
-- **Process history** (`review_panel_process.md`): verbatim "director's cut" of every agent's output with persona profiles at each entry point — full transparency into the panel's reasoning
-- **Interactive HTML dashboard** (`review_panel_report.html`) with expandable 10-section issue cards. Each card opens a nested accordion:
-  - 📖 **Narrative** — full reviewer reasoning
-  - 📄 **Code Evidence** — Prism.js-highlighted snippets with `file:line` headers
-  - 👥 **Raised by** — per-reviewer rating and reasoning
-  - 🔍 **Verification Trail** — full output of the verification-round agent
-  - 💬 **Debate** — round-by-round transcript
-  - ⚖️ **Judge Ruling**
-  - 🛠️ **Fix Recommendation** — proposed change, before/after code, regression test, blast radius, effort
-  - 🔗 **Cross-references**
-  - 🏷️ **Epistemic Tags** — with hover tooltips
-  - 📊 **Prior Runs**
+**Outputs (three files per review)**
 
-  Plus deep-link support (`report.html#issue-A1`), keyboard navigation, expand-all / collapse-all controls, and print-friendly `@media print` CSS. Dashboard also includes a filterable/sortable issue list, Panel Gallery with avatar cards for every agent, and confidence/tier/verdict charts (Tailwind CSS + Chart.js + Prism.js via CDN).
-- Scope & limitations disclosure — every report states what the panel cannot evaluate
+- **Primary report** (`review_panel_report.md`): executive summary, consensus, disagreements (with judge rulings), prioritized action items with epistemic labels — see [Reading the Report](#reading-the-report).
+- **Process history** (`review_panel_process.md`): verbatim "director's cut" log of every agent's output, with persona profiles embedded.
+- **Interactive HTML dashboard** (`review_panel_report.html`) with **expandable 10-section issue cards** — each card opens a nested accordion: 📖 Narrative, 📄 Code Evidence (Prism.js-highlighted), 👥 Raised by, 🔍 Verification Trail, 💬 Debate, ⚖️ Judge Ruling, 🛠️ Fix Recommendation, 🔗 Cross-references, 🏷️ Epistemic Tags, 📊 Prior Runs. Deep-linkable (`report.html#issue-A1`), keyboard-navigable, print-friendly. Tailwind + Chart.js + Prism.js via CDN.
 
-**Advanced:**
-- VoltAgent integration — maps personas to 127+ specialist agents for deeper domain-specific reviews when installed
-- **Multi-Run Union Protocol** — invoke `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions (Run 1: standard base; Run 2: complementary set; Run 3: adversarial-heavy 3 DAs + Correctness Hawk). Phase 16 merges findings by location + bug class, scores stability as `[K/N RUNS]`, uses highest severity when runs disagree, resolves judge divergence. Designed to mitigate the ~30% single-run blind spot observed in early consistency analyses.
-- Codebase state check — detects worktree/branch divergence to prevent false "missing code" findings
-- Tiered knowledge mining (L0/L1/L2) — scans index lines first, then summaries, then full content only for relevant items
-- Deep research mode — opt-in web research for domain best practices
+**Advanced**
+
+- **VoltAgent integration** — maps personas to 127+ specialist agents across 10 families for deeper domain-specific reviews when installed
+- **Multi-Run Union Protocol** — invoke `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions. Phase 16 merges findings by location + bug class, scores stability as `[K/N RUNS]`, resolves judge divergence. Mitigates the ~30% single-run blind spot observed in early consistency analyses
+- **Codebase state check** — detects worktree/branch divergence to prevent false "missing code" findings
+- **Tiered knowledge mining** (L0 index / L1 summary / L2 full) — scans index lines first, only reads full content for relevant items
+- **Deep research mode** — opt-in web research for domain best practices
 
 ## Usage Examples
 
@@ -335,36 +258,30 @@ A single reviewer gives you a list. The panel gives you a deliberation — with 
 
 > /roundtable:agent-review-panel deep   # adds web research for domain best practices
 
-> Do a deep review of this ML pipeline          # also triggers deep research mode
+> Do a deep review of this ML pipeline
 ```
 
-After a panel review of a plan document, integrate the findings back into the plan with traceability:
+After a panel review of a plan document, integrate findings back into the plan with traceability:
 
 ```
 > /roundtable:plan-review-integrator review_panel_report.md docs/my_plan.md
 ```
 
-The integrator classifies each panel finding (apply / defer / reject), edits the plan in place, and produces a per-finding traceability summary so a later reviewer can see what landed and why.
+The integrator classifies each finding (apply / defer / reject), edits the plan in place, and produces a per-finding traceability summary.
 
-The panel skill auto-detects content type and selects appropriate personas and review mode. You can also specify custom reviewers.
-
-<a id="configuration--modes"></a>
 ## Configuration / Modes
 
-All modes are LLM-interpreted phrases — the skill's description matches them at invocation. There are no shell flags; whichever phrasing you use, the same configuration knobs are read.
+All modes are LLM-interpreted phrases — the skill's description matches them at invocation. There are no shell flags.
 
 | Mode | Invoke with | Effect |
 |---|---|---|
 | **Default panel** | `/roundtable:agent-review-panel` (or any "review panel" phrasing) | 4-reviewer panel; auto-personas; auto Precise/Exhaustive |
 | **Deep research** | `/roundtable:agent-review-panel deep` or "do a deep review of …" | Adds opt-in web research for domain best practices |
-| **Multi-run union** | `--runs 3` or "run 3 times and merge" | Runs the panel N times with rotated persona compositions; Phase 16 deduplicates findings, scores stability `[K/N RUNS]` |
-| **Trace tier** | "use Thorough trace" / "use Exhaustive trace" | Phase 2 Data Flow Trace tier (Standard ~default / Thorough top-3 paths / Exhaustive all paths) |
-| **Custom personas** | "include a Security Auditor and a Cost Modeler" | Overrides auto-persona detection with the named reviewers; panel size still 4–6 |
+| **Multi-run union** | `--runs 3` or "run 3 times and merge" | Runs the panel N times with rotated personas; deduplicates findings; scores stability `[K/N RUNS]` |
+| **Trace tier** | "use Thorough trace" / "use Exhaustive trace" | Data Flow Trace tier (Standard default / Thorough top-3 paths / Exhaustive all paths) |
+| **Custom personas** | "include a Security Auditor and a Cost Modeler" | Overrides auto-persona detection; panel size still 4–6 |
 
-<a id="cost--performance"></a>
 ## Cost & Performance
-
-A single panel run is in the 150k–350k total-token range across all subagents (input + output). Concrete budget by content type:
 
 | Content type | Duration | Tokens | Approx $ at current Opus pricing |
 |---|---|---|---|
@@ -374,182 +291,16 @@ A single panel run is in the 150k–350k total-token range across all subagents 
 | Code + Exhaustive Data Flow Trace | ~12–15 min | ~350k | ~$20 |
 | `--runs 3` multi-run union | 3× base | 3× base | 3× base |
 
-Numbers are rough — Opus pricing varies and reviewer count auto-scales 4–6 by signal density. **Best for** high-stakes reviews where structured disagreement tracking matters. **Not for** quick code reviews, style checks, or single-opinion feedback.
+Cost is driven by: reviewer count (4–6 auto-scales by signal density), content size, debate rounds, `deep` mode (adds web research), and `--runs N` (linear multiplier). Pricing assumes Anthropic's published Opus rate at time of run; check [Anthropic pricing](https://www.anthropic.com/pricing) for current numbers.
 
 ## Known Limitations
 
-- **Same base model:** All reviewers are Claude instances. Unanimous agreement may reflect shared model biases rather than genuine quality. The correlated-bias warning flags this, but cannot eliminate it.
-- **No runtime analysis:** The panel reviews static code and documents. It cannot evaluate runtime behavior, production data patterns, or performance under load.
-- **Token cost:** Multi-agent review costs more than single-agent. Use for high-stakes reviews, not routine checks.
-- **Temporal reasoning:** Despite explicit checks, temporal scope verification (e.g., "excludes Christmas" with multi-year data) remains the hardest class of bug for panels to catch reliably.
-- **Privacy & network:** Reviewers run via Claude Code, so reviewed content is subject to Claude Code's standard data-handling policy. The deep-research mode and Phase 11 web-verification step make outbound HTTPS requests to verify external claims; both can be skipped if you stay in default mode and review proprietary code.
-- **Output location:** All three files (`review_panel_report.md`, `review_panel_process.md`, `review_panel_report.html`) are written to your Claude Code session's current working directory and overwrite any prior `review_panel_*` files there. Run one panel at a time per directory.
-
-## Research Foundations
-
-Agent Review Panel is grounded in [9 peer-reviewed papers](docs/research-foundations.md) on multi-agent debate and evaluation quality. The full enumeration with venue, link, and per-paper contribution lives in [`docs/research-foundations.md`](docs/research-foundations.md); a few load-bearing paper→architecture mappings, to give a sense of what's actually adopted:
-
-- **ChatEval (ICLR 2024)** — Phase 7 (Blind Final Assessments) implements ChatEval's strongest anti-groupthink mechanism: each reviewer commits a final verdict in writing, before seeing peers' finals. Without this, debate would converge to the loudest position.
-- **MachineSoM (ACL 2024)** — Phase 4 (Private Reflection) is MachineSoM's `tf/ft/tt/ff` conformity-tracking pattern. Reviewers reflect privately *before* the debate round, which makes a position flip in Phase 5 detectable as a signal rather than untraceable convergence.
-- **Trust or Escalate (ICLR 2025 Oral)** — the judge's `Verdict Confidence: High|Medium|Low` field comes from this paper's escalation calculus. Low-confidence verdicts get a `⚠️ HUMAN REVIEW RECOMMENDED` flag rather than a forced call, instead of forcing a definitive ruling under high panel disagreement or novel domain.
-- **DMAD (ICLR 2025)** — Each persona ships with a distinct `reasoning_strategy` (systematic enumeration, backward reasoning, adversarial simulation, etc.) injected into the Phase 3 prompt. Diverse strategies outperformed homogeneous panels by 12–18% in DMAD's benchmarks.
-
-Additionally inspired by [MiroFish](https://github.com/666ghj/MiroFish) (multi-agent prediction engine with heterogeneous agent personalities) — MiroFish's research patterns influenced the v2.1 auto-persona detection and the v2.11 persona-matched verification agent design. See [ROADMAP.md](ROADMAP.md) for the full research roadmap, and [`docs/research-foundations.md`](docs/research-foundations.md) for the complete table of all 9 papers with venues, links, and contributions.
-
-## Prerequisites
-
-- **Claude Code** v1.0+ (the skill uses the Agent tool for parallel subagent spawning)
-- Works with Claude Pro, Max, or API access
-- **Optional:** [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) for stronger domain-specific reviews
-
-## Tests
-
-The project includes a comprehensive test suite (401 tests) using Node.js built-in test runner (zero dependencies):
-
-```bash
-npm test                    # run all 401 tests
-npm run test:triggers       # trigger classification (55+ prompts)
-npm run test:manifest       # manifest consistency + phase/opus enforcement
-npm run test:eval-suite     # eval suite integrity + v2.14/v2.15 coverage
-npm run test:report         # report structure validation
-npm run test:behavioral     # behavioral assertion framework
-npm run test:golden         # golden-file structural snapshots
-```
-
-Manifest tests enforce key invariants introduced in v2.14/v2.15:
-- All 16 top-level phases present in SKILL.md (Phase 1 through Phase 16; Phase 15 has the three sequential sub-steps 15.1/15.2/15.3 — see [How It Works](#how-it-works))
-- Every `subagent_type:` launch co-occurs with `model: "opus"` (force-opus enforcement)
-- Phase 15.3 spec documents all 10 expandable-card accordion sections
-- The canonical `SKILL.md` lives at `skills/agent-review-panel/SKILL.md` (v3.0+ single-plugin layout)
-
-## Bundled skills
-
-The `roundtable` plugin ships **two skills** in one install. Both load together; you don't install them separately.
-
-| Skill | Source | What It Does | When to Use |
-|---|---|---|---|
-| `agent-review-panel` | [`skills/agent-review-panel/`](skills/agent-review-panel/) | Multi-agent adversarial review panel — 4–6 reviewers debate, judge renders final verdict (v3.0.0) | When you need a structured review of code, plans, docs, or configs |
-| `plan-review-integrator` | [`skills/plan-review-integrator/`](skills/plan-review-integrator/) | Takes review panel output and integrates findings into an implementation plan — classifies each finding, applies concrete edits, produces a traceability summary (v2.0.1) | After a panel review of a plan document, when you need findings reflected in the plan with traceability |
-
-Both are activated by their natural-language descriptions or via slash commands `/roundtable:agent-review-panel` and `/roundtable:plan-review-integrator`.
-
-> **v3.0 layout change:** Pre-v3.0 the marketplace shipped two independently-installable plugins (`roundtable` + `plan-review-integrator`). v3.0 collapses them into one plugin (`roundtable`) bundling both skills, mirroring the single-plugin pattern used by [obra/superpowers](https://github.com/obra/superpowers). If you previously ran `claude plugin install plan-review-integrator@agent-review-panel`, install just `roundtable@agent-review-panel` and you'll get both skills. See [Migration](#migration-from-previous-marketplaces).
-
-<details>
-<summary>Why is the plugin named <code>roundtable</code> and not <code>agent-review-panel</code>?</summary>
-
-`roundtable` is a collective noun for the bundle — "the roundtable holds these skills." It also reads more naturally in slash-command form: `/roundtable:agent-review-panel` over the alternative doubled-name form.
-
-`plan-review-integrator` was previously published as a standalone repo at `wan-huiyan/plan-review-integrator`. That repo is **archived** in favor of the bundled distribution here.
-
-</details>
-
-## Migration from previous marketplaces
-
-If you installed before v2.16.1, you used one of the old marketplace names. Migrate from your terminal:
-
-```bash
-# Old agent-review-panel install
-claude plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
-claude plugin marketplace remove wan-huiyan-agent-review-panel
-
-# Old plan-review-integrator standalone install (if applicable)
-claude plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
-claude plugin marketplace remove wan-huiyan-plan-review-integrator
-
-# New bundled install (v3.0+: one plugin, both skills bundled)
-claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install roundtable@agent-review-panel
-```
-
-<details>
-<summary>REPL-form equivalent (inside a Claude Code session)</summary>
-
-```
-/plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel
-/plugin marketplace remove wan-huiyan-agent-review-panel
-/plugin uninstall plan-review-integrator@wan-huiyan-plan-review-integrator
-/plugin marketplace remove wan-huiyan-plan-review-integrator
-/plugin marketplace add wan-huiyan/agent-review-panel
-/plugin install roundtable@agent-review-panel
-```
-
-</details>
-
-Verify both are loaded under the new marketplace:
-```
-ls ~/.claude/plugins/cache/agent-review-panel/
-# expected: roundtable  (one plugin dir; both skills live inside it)
-```
-
-<details>
-<summary><strong>Plugin install isn't working after migration?</strong> Bash recipe to clear stale state</summary>
-
-If you installed before v3.0, your `~/.claude/` directory may have stale state that silently shadows the new install (the [Upgrading from v2.x?](#upgrading-from-v2x) callout in Quick Start handles this automatically — this is the manual equivalent):
-
-```bash
-# Old marketplace name (pre-v2.16.1 was "plugin")
-claude plugin marketplace remove plugin 2>/dev/null
-
-# Orphan marketplace dirs (sometimes have trailing whitespace in the name)
-rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel "  # note trailing space
-rm -rf "$HOME/.claude/plugins/marketplaces/wan-huiyan-agent-review-panel"   # no space (also possible)
-
-# Loose-clone shadows from pre-marketplace-era manual clones
-rm -rf "$HOME/.claude/skills/agent-review-panel" \
-       "$HOME/.claude/skills/agent-review-panel-workspace" \
-       "$HOME/.claude/skills/plan-review-integrator" \
-       "$HOME/.claude/skills/roundtable"
-
-# Fresh install
-claude plugin marketplace add wan-huiyan/agent-review-panel
-claude plugin install roundtable@agent-review-panel
-```
-
-Restart your Claude Code session after install.
-</details>
-
-## Troubleshooting
-
-<a id="after-install-roundtableagent-review-panel-is-not-recognized"></a>
-### After install, `/roundtable:agent-review-panel` is not recognized
-
-Restart your Claude Code session — skills load at session start, not on install completion. If the slash command still doesn't appear after restart, see "Old version keeps loading" below.
-
-### The panel ran but no output files appeared
-
-The three output files (`review_panel_report.md`, `review_panel_process.md`, `review_panel_report.html`) are written to your Claude Code session's **current working directory**. Run `pwd` in the session to confirm where you are. If you start the session from one directory and `cd` elsewhere, files land in the original cwd. Only one panel can run per directory at a time — concurrent runs in the same directory will overwrite each other.
-
-### Old version keeps loading after `claude plugin update`
-
-A loose clone in `~/.claude/skills/agent-review-panel/` shadows the marketplace install and pins you to whatever version was cloned. Verify, back up, then remove:
-
-```bash
-ls ~/.claude/skills/agent-review-panel 2>/dev/null && \
-  mv "$HOME/.claude/skills/agent-review-panel" "$HOME/.claude/skills/agent-review-panel.bak.$(date +%s)"
-```
-
-Then restart Claude Code. The marketplace install in `~/.claude/plugins/cache/agent-review-panel/` will take over. The backup is reversible — delete it once you've confirmed the marketplace version works.
-
-### `review_panel_report.html` is missing or empty
-
-Phase 15.3 generates the HTML in a separate pass and may retry once on transient failures. If still missing after a run, the markdown report contains the same findings — the HTML is a presentation layer. To regenerate the HTML manually, ask Claude Code in the same session: *"generate the HTML review report"*.
-
-### The HTML report renders unstyled or charts are blank
-
-The dashboard pulls Tailwind, Chart.js, and Prism.js from CDN; first open requires internet. For air-gapped review, use `review_panel_report.md` — same content, no CDN dependency. (The three CDN libraries are MIT-licensed.)
-
-### `npm test` fails locally with `Cannot find module 'node:test'` or similar
-
-The test suite uses Node's built-in test runner, which requires **Node ≥ 18** (stable from 20). Check with `node --version` and upgrade if needed.
-
-### Panel hangs partway through Phase 3
-
-A reviewer subagent may have timed out. The panel doesn't auto-retry across runs — interrupt the session and re-invoke the panel. If it reproduces, file an issue with the content type (code/plan/docs) and approximate size.
-
-### Migration / install state from older marketplace names
-
-If you installed before v2.16.1 or v3.0 and `claude plugin update` misbehaves, the simplest fix is the "Upgrading from v2.x?" prompt in [Quick Start](#quick-start) — Claude Code does the cleanup and reinstall for you. Manual recipe is in [Migration](#migration-from-previous-marketplaces).
+- **Same base model.** All reviewers are Claude instances; unanimous agreement may reflect shared model biases. The correlated-bias warning flags this but cannot eliminate it. See [Why a panel](#why-a-panel-not-a-single-reviewer) for the honest framing.
+- **No runtime analysis.** The panel reviews static code and documents. It cannot evaluate runtime behavior, production data patterns, or performance under load.
+- **Token cost.** Multi-agent review costs more than single-agent. Use for high-stakes reviews, not routine checks.
+- **Temporal reasoning.** Despite explicit checks, temporal scope verification (e.g., "excludes Christmas" with multi-year data) remains the hardest class of bug for panels to catch reliably.
+- **Privacy & network.** Reviewed content is subject to Claude Code's data-handling policy. The deep-research mode and Phase 11 web-verification step make outbound HTTPS requests; both can be skipped if you stay in default mode and review proprietary code. The plugin itself sends no telemetry; all three output files are written locally and never transmitted by the plugin.
+- **Output location.** All three files are written to your Claude Code session's current working directory and overwrite any prior `review_panel_*` files there. Filenames are not configurable. Run one panel at a time per directory.
 
 ## Reading the Report
 
@@ -559,10 +310,10 @@ The panel produces three files per run; here's how to read them.
 
 | Term | Means |
 |---|---|
-| **plugin** | The marketplace package you install (`roundtable`) — one bundle that ships skills, manifests, and assets |
-| **skill** | A shipped behavior loaded by Claude Code; this plugin bundles two skills (`agent-review-panel`, `plan-review-integrator`) |
-| **reviewer** | One persona in the panel (e.g. Clarity Editor, Devil's Advocate). 4–6 reviewers participate per run |
-| **agent / subagent** | The Claude Code launch mechanism the skill uses to spawn each reviewer in parallel — not a synonym for "reviewer" or "skill" |
+| **plugin** | The marketplace package you install (`roundtable`) |
+| **skill** | A shipped behavior loaded by Claude Code; this plugin bundles two (`agent-review-panel`, `plan-review-integrator`) |
+| **reviewer** | One persona in the panel (e.g. Clarity Editor, Devil's Advocate). 4–6 reviewers per run |
+| **agent / subagent** | The Claude Code launch mechanism used to spawn each reviewer in parallel — not a synonym for "reviewer" or "skill" |
 | **panel** | The full set of reviewers participating in a single run |
 | **judge** | The Phase 14 arbiter that ingests all reviewer + verification output and renders the final verdict |
 
@@ -582,89 +333,162 @@ The panel produces three files per run; here's how to read them.
 | `[SINGLE-SOURCE]` | One reviewer raised it, no one refuted |
 | `[DISPUTED]` | Reviewers split on whether it's a real issue |
 | `[UNVERIFIED]` | Stated without a checkable citation; treat with care |
-| `[WEB-VERIFIED]` | External fact (product feature, regulation, API behavior) confirmed by an authoritative web source |
-| `[WEB-CONTRADICTED]` | External fact contradicted by an authoritative web source — severity demoted |
-| `[WEB-INCONCLUSIVE]` | External fact could not be confirmed via web search — flagged for human judgement |
+| `[WEB-VERIFIED]` / `[WEB-CONTRADICTED]` / `[WEB-INCONCLUSIVE]` | External fact confirmed / contradicted / unconfirmed by an authoritative web source |
 | `[CMD_CONFIRMED]` / `[CMD_CONTRADICTED]` | Reviewer's `verification_command` (read-only grep/cat/head) was run and the result confirmed/contradicted the claim |
 | `[LIVE-VERIFIED]` | Live-infrastructure/runtime-state claim backed by `describe`-class command output (`gcloud describe`, `bq show`, `kubectl get`, etc.) |
-| `[STATIC-INFERENCE]` | Live-state claim inferred from source/config/deploy scripts only — no live evidence; capped at P1 |
-| `[STATIC-INFERENCE-CONSENSUS]` | Multiple reviewers agreed off the *same* artifact lines (or cross-cited each other) — counts as one source, not independent verification; does not justify P0 |
+| `[STATIC-INFERENCE]` | Live-state claim inferred from source/config/deploy scripts only — capped at P1 |
+| `[STATIC-INFERENCE-CONSENSUS]` | Multiple reviewers agreed off the *same* artifact lines — counts as one source, not independent verification |
+| `[JUDGE-HALLUCINATED]` | The post-judge gate caught a finding the judge introduced that the panel never raised and ground-truth contradicted — heavily discount |
+| `[COMPRESSED]` | Suffix on every action item when the pre-judge gate detected unrecoverable phase loss; the run is lower confidence — re-run for a full report |
 
 **Defect type.** Code/plan reviews additionally label findings as `[EXISTING_DEFECT]` (bug exists right now) or `[PLAN_RISK]` (risk only materializes if the plan is implemented as written). P0 severity requires `[EXISTING_DEFECT]` evidence.
 
-**How to read in priority order:** start with the Executive Summary, then the Action Items table (sorted P0 → P3). Use the HTML dashboard's filter bar to narrow by severity or epistemic label. Process history (`review_panel_process.md`) is the verbatim director's-cut log — read this only when you need to see *why* a finding got a particular ruling.
+**How to read in priority order.** Start with the Executive Summary, then the Action Items table (sorted P0 → P3). Use the HTML dashboard's filter bar to narrow by severity or epistemic label. Read the process history (`review_panel_process.md`) only when you need to see *why* a finding got a particular ruling. For findings that look wrong, scrutinise the epistemic label first — see [TROUBLESHOOTING.md → A finding looks wrong](TROUBLESHOOTING.md#a-finding-looks-wrong-or-overstated).
+
+## Bundled skills
+
+The `roundtable` plugin ships **two skills** in one install:
+
+| Skill | Source | What it does | When to use |
+|---|---|---|---|
+| `agent-review-panel` | [`skills/agent-review-panel/`](skills/agent-review-panel/) | Multi-agent adversarial review panel | When you need a structured review of code, plans, docs, or configs |
+| `plan-review-integrator` | [`skills/plan-review-integrator/`](skills/plan-review-integrator/) | Takes review panel output and integrates findings into a plan with traceability | After a panel review of a plan document |
+
+Both are activated by natural language or by `/roundtable:agent-review-panel` and `/roundtable:plan-review-integrator`.
+
+<details>
+<summary>Why is the plugin named <code>roundtable</code> and not <code>agent-review-panel</code>?</summary>
+
+`roundtable` is a collective noun for the bundle. It also reads more naturally in slash-command form. `plan-review-integrator` was previously published as a standalone repo at `wan-huiyan/plan-review-integrator` — that repo is archived in favor of this bundle.
+</details>
+
+## Tests
+
+The test suite (401 tests) uses Node's built-in test runner — zero dependencies, requires Node ≥18:
+
+```bash
+npm test                    # run all 401 tests
+npm run test:triggers       # trigger classification
+npm run test:manifest       # manifest consistency + phase/opus enforcement
+npm run test:eval-suite     # eval suite integrity
+npm run test:report         # report structure validation
+npm run test:behavioral     # behavioral assertion framework
+npm run test:golden         # golden-file structural snapshots
+```
+
+Tests enforce key invariants: all 16 top-level phases (plus 13.5 / 14.5) present in `SKILL.md`; every `subagent_type:` launch co-occurs with `model: "opus"`; Phase 15.3 spec documents all 10 expandable-card sections; the canonical `SKILL.md` lives at `skills/agent-review-panel/SKILL.md`.
+
+## Updating
+
+New releases land on `main`; Claude Code does not auto-pull. From your terminal:
+
+```bash
+claude plugin marketplace update agent-review-panel
+claude plugin update roundtable@agent-review-panel
+```
+
+(REPL form: `/plugin marketplace update agent-review-panel` then `/plugin update roundtable@agent-review-panel`.)
+
+**Verify the update.** The installed version is the directory name under `~/.claude/plugins/cache/agent-review-panel/roundtable/`. Compare it against the canonical version in this repo's [`package.json`](package.json) or the top entry of [`CHANGELOG.md`](CHANGELOG.md). Note that GitHub releases may lag `main` — `package.json` is the authoritative version source.
+
+If the update appears to work but old behavior persists, a stale local clone may be shadowing the marketplace install — see [TROUBLESHOOTING.md → Old version keeps loading](TROUBLESHOOTING.md#old-version-keeps-loading-after-claude-plugin-update).
+
+## Migration
+
+If you installed before v3.0 or under an older marketplace handle (`@wan-huiyan-agent-review-panel`, `@plugin`, or the bare `@agent-review-panel`), see [MIGRATION.md](MIGRATION.md) for the uninstall + clean-install recipe and a stale-state cleanup prompt you can paste into Claude Code.
+
+## Troubleshooting
+
+Common problems and their fixes live in [TROUBLESHOOTING.md](TROUBLESHOOTING.md). The most-hit entries:
+
+- [After install, slash command not recognized](TROUBLESHOOTING.md#after-install-roundtableagent-review-panel-is-not-recognized) — restart Claude Code first
+- [No output files appeared](TROUBLESHOOTING.md#the-panel-ran-but-no-output-files-appeared) — they go to the session's cwd
+- [Old version keeps loading](TROUBLESHOOTING.md#old-version-keeps-loading-after-claude-plugin-update) — a loose clone is shadowing the marketplace install
+- [A finding looks wrong](TROUBLESHOOTING.md#a-finding-looks-wrong-or-overstated) — read its epistemic label first
+
+## Support
+
+Bug reports, questions, and feedback: open a [GitHub issue](https://github.com/wan-huiyan/agent-review-panel/issues). When filing a bug for a failed or weird review, include the content type (code/plan/docs), approximate size, and (if you can) the `review_panel_report.md` and `review_panel_process.md` files — they make repro practical.
 
 ## Contributing
 
-Contributions welcome! Areas where help is especially useful:
+Contributions welcome. Especially useful:
 
 - **Cursor adaptation** — adapting the Agent tool calls to Cursor's subagent mechanism
 - **New domain checklists** — adding signal groups beyond the current 10
 - **Benchmark cases** — real-world review scenarios for the eval suite
 
-Please open an issue to discuss before submitting large PRs.
+**Dev setup:**
+
+```bash
+git clone https://github.com/wan-huiyan/agent-review-panel.git ~/projects/agent-review-panel-dev
+cd ~/projects/agent-review-panel-dev
+npm test                            # requires Node ≥18
+bash scripts/release-check.sh       # pre-release doc-drift detector
+```
+
+The authoritative skill is `skills/agent-review-panel/SKILL.md`. Manifest invariants (phase count, force-opus, HTML-card schema, marketplace-name callout marker) are enforced by `tests/manifest-consistency.test.mjs` and `scripts/release-check.sh` — both must stay green. See [HOW_WE_BUILT_THIS.md](HOW_WE_BUILT_THIS.md) for the design journey. Open an issue to discuss before submitting large PRs.
 
 ## Uninstalling
 
-**If installed via marketplace**, from your terminal:
 ```bash
 claude plugin uninstall roundtable@agent-review-panel
 claude plugin marketplace remove agent-review-panel
 ```
 
-(REPL-form equivalent: `/plugin uninstall roundtable@agent-review-panel` and `/plugin marketplace remove agent-review-panel`.)
+(REPL form: `/plugin uninstall roundtable@agent-review-panel` and `/plugin marketplace remove agent-review-panel`.)
 
-**If installed via manual clone:**
-```bash
-rm -rf ~/.claude/skills/agent-review-panel
-```
+For a fully clean uninstall that removes cached state and any shadow clones, see [MIGRATION.md → Stale-state cleanup](MIGRATION.md#stale-state-cleanup-when-uninstall-isnt-enough). Manual-clone installs: `rm -rf ~/.claude/skills/agent-review-panel`.
 
-## Version History
+## Research foundations
 
-See [CHANGELOG.md](CHANGELOG.md) for detailed version history. See [ROADMAP.md](ROADMAP.md) for research sources and deferred items.
+Agent Review Panel is grounded in [9 research papers and projects](docs/research-foundations.md) on multi-agent debate and evaluation quality.
+
+**Mechanisms directly mapped to architecture:**
+
+- **ChatEval (ICLR 2024)** → Phase 7 Blind Final — each reviewer commits a final verdict in writing before seeing peers' finals.
+- **MachineSoM (ACL 2024)** → Phase 4 Private Reflection — `tf/ft/tt/ff` conformity tracking makes Phase 5 position flips detectable as signal.
+- **Trust or Escalate (ICLR 2025 Oral)** → judge `Verdict Confidence: High|Medium|Low` field; low-confidence verdicts get `⚠️ HUMAN REVIEW RECOMMENDED`.
+- **DMAD (ICLR 2025)** → distinct `reasoning_strategy` per persona injected into Phase 3 prompts.
+
+**Papers and projects that informed the design** (without 1:1 architecture mapping): AutoGen (multi-agent orchestration patterns — note: AutoGen is a Microsoft research project, not a peer-reviewed paper), Du et al. (ICML 2024), DebateLLM, "Talk Isn't Always Cheap" (ICML 2025) for failure-mode analysis, CONSENSAGENT (ACL 2025) for sycophancy detection.
+
+The cited papers validate multi-agent debate on reasoning benchmarks; this project has not independently benchmarked review quality. The full table with venues, links, and per-paper contributions lives in [`docs/research-foundations.md`](docs/research-foundations.md). Also inspired by [MiroFish](https://github.com/666ghj/MiroFish) for heterogeneous-persona patterns. See [ROADMAP.md](ROADMAP.md) for the research roadmap.
+
+## Version history
+
+See [CHANGELOG.md](CHANGELOG.md) for detailed version history and [ROADMAP.md](ROADMAP.md) for deferred items.
 
 | Version | Highlights |
-|---------|------------|
-| **v3.3** | Live-State Claim Discipline (#40) — cross-cutting rule set for findings asserting facts about *live infrastructure or runtime state*. Reviewers distinguish declarative config from imperative documentation (`echo`/comment/usage lines are never evidence) from live `describe`-class output; live-state claims tagged `[LIVE-VERIFIED]` or `[STATIC-INFERENCE]` (the latter capped at P1); consensus does not compound on a shared artifact (`[STATIC-INFERENCE-CONSENSUS]`); a pre-promotion falsification check gates every P0. Wired into Phases 3 / 5 / 6 / 11 / 14 |
-| **v3.2** | Post-judge verification gate + Chart.js wrapper-div mandate (#41, #42) — Phase 14.5 re-verifies judge-introduced P0/P1 against ground truth, non-replicating findings tagged `[JUDGE-HALLUCINATED]` and the verdict score recomputed against the panel mean; Phase 15.3 spec mandates a height-bounded wrapper div around every Chart.js `<canvas>` (PR #47) |
-| **v3.1** | Silent-phase-compression fix (#35) — file-based subagent state under `state/<phase>.md`, Phase 13.5 Pre-Judge Verification Gate, `⚠️ COMPRESSED RUN` header when phase loss is detected. Eliminates the v3.0 failure mode where context pressure silently inlined Phases 4 / 5 / 7 into the judge step (PR #39) |
-| v3.0 | Single-plugin layout (BREAKING) — collapses the multi-plugin marketplace into one plugin (`roundtable`) bundling both skills, mirroring [obra/superpowers](https://github.com/obra/superpowers). Install UX is one command instead of two. `release-check.sh` doc-drift detector folded in (PR #33) |
-| v2.16.5 | Plugin skills layout fixed for Claude Code ≥ 2.1.112 manifest validation (PR #30 by @okuuva) |
-| v2.16.4 | Phase 15.3 reliability — disk-reading prompt strategy + verification gate; manual HTML report recovery |
-| v2.16.3 | External domain claim web verification in Phase 11 — `[WEB-VERIFIED]` / `[WEB-CONTRADICTED]` / `[WEB-INCONCLUSIVE]` labels |
-| v2.16.2 | Hotfix for plugin layout bug that silently broke all marketplace installs since 2026-04-07 |
-| v2.16.1 | Marketplace bundle (PR #22) |
-| v2.16.0 | Plugin layout (PR #18) |
-| v2.15 | Expandable 10-section issue cards in HTML dashboard (narrative, code evidence, debate, judge ruling, fix, cross-refs, prior runs); Prism.js syntax highlighting; deep-linking; keyboard nav; print-friendly |
-| v2.14 | Phase 2 Data Flow Trace (composition bug detector, 3 tiers); Multi-Run Union Protocol + Phase 16 Merge; force `model: "opus"` on all launches; integer phase renumbering (1–16) |
+|---|---|
+| **v3.3** | Live-State Claim Discipline — cross-cutting rule set for findings asserting facts about *live* infrastructure or runtime state |
+| **v3.2** | Post-judge verification gate + Chart.js wrapper-div mandate — Phase 14.5 re-verifies judge-introduced P0/P1 against ground truth |
+| **v3.1** | Silent-phase-compression fix — file-based subagent state under `state/`, Phase 13.5 Pre-Judge Verification Gate |
+| v3.0 | Single-plugin layout (BREAKING) — one plugin (`roundtable`) bundling both skills |
+| v2.16 | Plugin layout + marketplace bundle |
+| v2.15 | Expandable 10-section issue cards in HTML dashboard; Prism.js syntax highlighting; deep-linking |
+| v2.14 | Data Flow Trace (3 tiers); Multi-Run Union Protocol + Phase 16 Merge; force-opus on all launches |
 | v2.13 | Persona profiles in process history + Panel Gallery in HTML dashboard |
-| v2.12 | Triple output: primary report + process history + interactive HTML dashboard |
-| v2.11 | Verification round: tiered (Light/Standard/Deep) persona-matched agents per dispute |
+| v2.12 | Triple output: primary + process history + interactive HTML dashboard |
+| v2.11 | Verification round: tiered persona-matched agents per dispute |
 | v2.10 | Codebase state check — prevents false "missing code" findings in worktrees |
-| v2.9 | VoltAgent specialist agent integration (127+ agents, 10 families) |
+| v2.9 | VoltAgent specialist agent integration |
 | v2.8 | Auto Precise/Exhaustive mode, verification commands, tiered knowledge mining |
 | v2.7 | Severity verification, defect classification, temporal scope checks |
-| v2.6 | Schliff optimization (75 → 86), reference extraction, A/B validated |
 | v2.5 | Trust layer: claim verification, epistemic labels, scope disclosure |
-| v2.4 | Portability signal group |
-| v2.3 | Knowledge mining, domain checklists, deep research mode |
-| v2.2 | DMAD reasoning strategies, context gathering, anti-rhetoric guard |
-| v2.1 | Auto-persona from content signals, source-grounded debate |
 | v2.0 | Completeness auditor, new discovery requirement |
 | v1.0 | Initial release: multi-agent review with debate and judge |
 
 ## License
 
-[MIT](LICENSE) — Huiyan Wan
+[MIT](LICENSE) — Huiyan Wan. Reports you generate are yours; the HTML dashboard loads Tailwind, Chart.js, and Prism.js from CDN — all MIT-licensed.
 
 ## Acknowledgements
 
-- Inspired by [MiroFish](https://github.com/666ghj/MiroFish) — multi-agent prediction engine with heterogeneous agent personalities and memory; influenced auto-persona detection and persona-matched verification agents
+- Inspired by [MiroFish](https://github.com/666ghj/MiroFish) — influenced auto-persona detection and persona-matched verification agents
 - Eval suite improved using [schliff](https://github.com/Zandereins/schliff)
 - See [HOW_WE_BUILT_THIS.md](HOW_WE_BUILT_THIS.md) for the design journey
 
-### Contributors
+**External contributors** — thank you!
 
-External contributions — thank you!
-
-- [@okuuva](https://github.com/okuuva) — [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30) restructured the plugin to the canonical nested skills layout for Claude Code ≥2.1.112 manifest validation (resolves [#28](https://github.com/wan-huiyan/agent-review-panel/issues/28))
+- [@okuuva](https://github.com/okuuva) — [#30](https://github.com/wan-huiyan/agent-review-panel/pull/30) restructured the plugin to the canonical nested skills layout for Claude Code ≥2.1.112 manifest validation

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,101 @@
+# Troubleshooting
+
+Common problems and recoveries. For first-time install help, see
+[Quick Start](README.md#quick-start). For migrating from an older install
+handle, see [MIGRATION.md](MIGRATION.md).
+
+## After install, `/roundtable:agent-review-panel` is not recognized
+
+Restart your Claude Code session — skills load at session start, not on
+install completion. If the slash command still doesn't appear after restart,
+see "Old version keeps loading" below.
+
+## The panel ran but no output files appeared
+
+The three output files (`review_panel_report.md`, `review_panel_process.md`,
+`review_panel_report.html`) are written to your Claude Code session's
+**current working directory**. Run `pwd` in the session to confirm where you
+are. If you start the session from one directory and `cd` elsewhere, files
+land in the original cwd. Only one panel can run per directory at a time —
+concurrent runs in the same directory will overwrite each other.
+
+Output filenames and location are not configurable. To keep multiple reviews,
+rename or move the three `review_panel_*` files (or `cd` to a fresh
+directory) before the next run.
+
+## A finding looks wrong or overstated
+
+The panel will sometimes produce a wrong finding — the
+[epistemic-label system](README.md#reading-the-report) exists to help you
+triage it:
+
+- Findings tagged `[STATIC-INFERENCE]`, `[UNVERIFIED]`, `[DISPUTED]`, or
+  `[SINGLE-SOURCE]` are the ones to scrutinise first.
+- `⚠️ HUMAN REVIEW RECOMMENDED` on the executive summary means the judge
+  itself flagged the verdict as low-confidence.
+- `[JUDGE-HALLUCINATED]` on an action item means the post-judge gate caught
+  the judge introducing a finding the panel never raised and ground-truth
+  contradicted it — discount that item heavily.
+- To test the stability of an unsure finding, re-run with `--runs 3` and
+  check the `[K/N RUNS]` stability label on the merged report.
+
+## Old version keeps loading after `claude plugin update`
+
+A loose clone in `~/.claude/skills/agent-review-panel/` shadows the
+marketplace install and pins you to whatever version was cloned. Verify,
+back up, then remove:
+
+```bash
+ls ~/.claude/skills/agent-review-panel 2>/dev/null && \
+  mv "$HOME/.claude/skills/agent-review-panel" "$HOME/.claude/skills/agent-review-panel.bak.$(date +%s)"
+```
+
+Then restart Claude Code. The marketplace install in
+`~/.claude/plugins/cache/agent-review-panel/` will take over. The backup is
+reversible — delete it once you've confirmed the marketplace version works.
+
+## `claude plugin update` doesn't seem to apply
+
+Clean reinstall as a fallback:
+
+```bash
+claude plugin uninstall roundtable@agent-review-panel
+claude plugin marketplace remove agent-review-panel
+claude plugin marketplace add wan-huiyan/agent-review-panel
+claude plugin install roundtable@agent-review-panel
+```
+
+If state from a pre-v3.0 install is interfering, see
+[MIGRATION.md](MIGRATION.md#stale-state-cleanup-when-uninstall-isnt-enough).
+
+## `review_panel_report.html` is missing or empty
+
+Phase 15.3 generates the HTML in a separate pass and may retry once on
+transient failures. If still missing after a run, the markdown report
+contains the same findings — the HTML is a presentation layer. To regenerate
+the HTML manually, ask Claude Code in the same session:
+*"generate the HTML review report"*.
+
+## The HTML report renders unstyled or charts are blank
+
+The dashboard pulls Tailwind, Chart.js, and Prism.js from CDN; first open
+requires internet. For air-gapped review, use `review_panel_report.md` — same
+content, no CDN dependency. (The three CDN libraries are MIT-licensed.)
+
+## `npm test` fails locally with `Cannot find module 'node:test'` or similar
+
+The test suite uses Node's built-in test runner, which requires **Node ≥ 18**
+(stable from 20). Check with `node --version` and upgrade if needed.
+
+## Panel hangs partway through Phase 3
+
+A reviewer subagent may have timed out. The panel doesn't auto-retry across
+runs — interrupt the session and re-invoke the panel. If it reproduces,
+file an issue (see [Support](README.md#support)) with the content type
+(code/plan/docs) and approximate size.
+
+## Update appears to work but old behavior persists
+
+Same root cause as "Old version keeps loading" above — a loose
+`~/.claude/skills/agent-review-panel/` clone shadowing the marketplace
+install. The verify/back-up/remove recipe above applies.

--- a/docs/reviews/2026-05-14-readme/review_panel_process.md
+++ b/docs/reviews/2026-05-14-readme/review_panel_process.md
@@ -1,0 +1,113 @@
+# Review Panel — Process History ("Director's Cut")
+
+**Work reviewed:** `README.md` (671 lines)
+**Date:** 2026-05-14
+**Mode:** Exhaustive (pure documentation) | Data Flow Trace: skipped (no code)
+
+> **Run note:** This run executed the panel in streamlined single-pass form —
+> four independent Phase 3 reviewer subagents launched in parallel, then the
+> orchestrator performed the completeness audit, claim verification, severity
+> verification, and Supreme Judge synthesis directly (Phases 4–7 reflection/debate
+> and Phases 12–13 targeted verification were folded into the judge's
+> consensus/disagreement analysis rather than dispatched as separate subagent
+> rounds). Verbatim Phase 3 output is preserved below and in `state/`.
+
+---
+
+## Persona Profiles Registry
+
+- **Clarity Editor** — evaluates whether the document communicates clearly to its
+  intended audience. Reasoning strategy: first-principles. Agreement intensity 60%.
+  Phases: 3.
+- **Technical Accuracy Reviewer** — verifies every factual/technical/procedural
+  claim against the actual repo. Reasoning strategy: checklist verification.
+  Agreement intensity 30%. Phases: 3.
+- **Completeness Checker** — finds what is missing that a reader needs. Reasoning
+  strategy: checklist verification. Agreement intensity 40%. Phases: 3.
+- **Devil's Advocate** — challenges framing, credibility, and whether the doc
+  persuades or misleads. Reasoning strategy: analogical. Agreement intensity 20%.
+  Phases: 3.
+- **Supreme Judge** — domain-neutral arbiter; ingests all reviewer output plus
+  verification results and renders the final verdict. Phase 14.
+
+---
+
+## Phase 1: Setup
+
+**Content classification:** Documentation (pure docs) → **Exhaustive** review mode.
+**Data Flow Trace:** skipped — pure documentation, no code data transforms.
+**Persona selection:** documentation base set (Clarity Editor, Technical Accuracy
+Reviewer, Completeness Checker, Devil's Advocate). No technology signals detected.
+
+**Context Brief:**
+- The repo *is* the `agent-review-panel` plugin (`roundtable`); the README is its
+  primary marketing + onboarding document.
+- `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  all declare version `3.3.0`.
+- **Codebase state:** branch `claude/review-readme-improvements-3y4d1`; clean tree.
+- **Known fact injected to reviewers:** remote git tags are only `v2.10.0,
+  v2.16.5, v3.0.0, v3.1.0` — no `v3.2.0`/`v3.3.0` release exists. Hero images are
+  pinned to the `v3.1.0` tag URL.
+- Sibling files available for cross-checks: `CHANGELOG.md`, `ROADMAP.md`,
+  `HOW_WE_BUILT_THIS.md`, `docs/research-foundations.md`, `skills/*/SKILL.md`,
+  `tests/`, `.github/`, `.claude-plugin/`.
+
+---
+
+## Phase 3: Independent Reviews (verbatim)
+
+The four reviewers worked in parallel with no cross-talk. Full verbatim output:
+
+- **Clarity Editor** — `state/reviewer_clarity-editor_phase_3.md` — Score 5.5/10,
+  15 findings.
+- **Technical Accuracy Reviewer** — `state/reviewer_technical-accuracy_phase_3.md`
+  — Score 4/10, 15 findings.
+- **Completeness Checker** — `state/reviewer_completeness-checker_phase_3.md` —
+  Score 6/10, 14 findings.
+- **Devil's Advocate** — `state/reviewer_devils-advocate_phase_3.md` — Score
+  4.5/10, 12 findings.
+
+Each file is the complete, unedited reviewer output (findings with severities,
+line citations, fix recommendations, top-3 most/least defensible self-critique,
+and a one-line verdict). They are reproduced in full in those state files.
+
+---
+
+## Phases 8–11: Completeness Audit + Claim/Severity Verification (orchestrator)
+
+Claims verified against the repository:
+
+| Claim under review | Verification command / file | Result |
+|---|---|---|
+| No `v3.2.0`/`v3.3.0` release exists | `git ls-remote --tags origin` | **[VERIFIED]** — only v2.10.0, v2.16.5, v3.0.0, v3.1.0 |
+| Manifests declare 3.3.0 | `package.json`, `.claude-plugin/*.json` | **[VERIFIED]** — all say 3.3.0 |
+| Phase 13.5 / 14.5 are real | `skills/agent-review-panel/SKILL.md:1027,1110` | **[VERIFIED]** — both defined; README table omits them |
+| `docs/archive/review_panel_report.md` exists & unlinked | `ls docs/archive/` + README grep | **[VERIFIED]** — 6,920-byte real sample, never linked |
+| "9 papers" count | `docs/research-foundations.md` (9 data rows) | **[VERIFIED]** — count correct |
+| "9 *peer-reviewed* papers" | AutoGen row venue = `—` | **[VERIFIED] inaccurate** — AutoGen is not peer-reviewed |
+| "401 tests" | `npm test` → 401/401 pass; `.github/workflows/test.yml` exists | **[VERIFIED]** — accurate |
+| Install handles / marketplace name / slash commands | `.claude-plugin/marketplace.json`, skill dirs | **[VERIFIED]** — accurate |
+| Inline `(vX.Y)` attributions in prose | `grep` on README | **[VERIFIED]** — 10+ instances confirmed |
+| Anchor links (spot-check) | heading / `<a id>` scan | **[VERIFIED]** — all checked anchors present |
+
+Audit additions: a prior README restructure attempt is archived at
+`docs/archive/2026-04-27-readme-restructure-rejected/` and should be consulted
+before any new restructure.
+
+---
+
+## Phase 14: Supreme Judge Deliberation (verbatim)
+
+Full ruling: `state/phase_14_judge_ruling.md`.
+
+**Verdict: REVISE — substantial edit needed. Score 5/10. Confidence: Medium-High.**
+
+Reviewer scores 5.5 / 4 / 6 / 4.5 → mean 5.0; spread 2.0 (moderate convergence,
+anchored by the unanimous version/release finding). The judge dampened the Devil's
+Advocate's P0 on the version issue to P1 (the README is fixable without a
+release-process change), downgraded the grandiose-naming finding to P3, merged
+Clarity's self-identified weakest finding into the duplication item, and partially
+upheld the "credibility theater" critique — the README discloses its
+shared-base-model limitation but buries it. Thirteen action items were issued
+(four P1, eight P2, one P3 bundle); see the primary report and the judge ruling
+state file for the full list with reasoning.

--- a/docs/reviews/2026-05-14-readme/review_panel_report.html
+++ b/docs/reviews/2026-05-14-readme/review_panel_report.html
@@ -1,0 +1,1772 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Review Panel Report — README.md — 2026-05-14</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+<style>
+/* v2.15 — expandable card styles */
+.section-accordion { margin-top: 1rem; }
+.section-accordion > details {
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+.section-accordion > details > summary {
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+}
+.section-accordion > details > summary::-webkit-details-marker { display: none; }
+.section-accordion > details[open] > summary {
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(100, 116, 139, 0.3);
+  padding-bottom: 0.5rem;
+}
+.section-accordion > details > summary::after {
+  content: "\25BE";
+  margin-left: auto;
+  color: #64748b;
+  transition: transform 0.15s;
+}
+.section-accordion > details[open] > summary::after {
+  transform: rotate(180deg);
+}
+
+/* Highlight pulse for deep-link navigation and cross-reference clicks */
+.issue-highlight {
+  animation: highlight-pulse 2s ease-out;
+}
+@keyframes highlight-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(250, 204, 21, 0.7); }
+  100% { box-shadow: 0 0 0 12px rgba(250, 204, 21, 0); }
+}
+
+/* Code evidence styling */
+.code-evidence-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin-bottom: 0.25rem;
+}
+.code-evidence-header .file-path {
+  font-family: ui-monospace, monospace;
+  color: #cbd5e1;
+}
+.code-evidence-header .line-range {
+  background: rgba(51, 65, 85, 0.5);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, monospace;
+}
+.code-evidence-header .caption {
+  font-style: italic;
+  color: #94a3b8;
+}
+
+/* Chat-bubble styling for debate transcript */
+.debate-bubble {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.debate-bubble .avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: white;
+}
+.debate-bubble .content-box {
+  flex: 1;
+  background: rgba(30, 41, 59, 0.5);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+/* Cross-reference link chips */
+.xref-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: transform 0.1s;
+}
+.xref-link:hover { transform: translateY(-1px); }
+.xref-root-cause    { background: rgba(127, 29, 29, 0.5); color: #fca5a5; }
+.xref-same-class    { background: rgba(30, 58, 138, 0.5); color: #93c5fd; }
+.xref-depends-on    { background: rgba(120, 53, 15, 0.5); color: #fcd34d; }
+.xref-blocks        { background: rgba(88, 28, 135, 0.5); color: #d8b4fe; }
+
+/* chips */
+.chip { display:inline-flex; align-items:center; gap:.25rem; padding:.125rem .5rem; border-radius:9999px; font-size:.7rem; font-weight:600; }
+.chip-low   { background: rgba(6,78,59,.6);  color:#6ee7b7; }
+.chip-med   { background: rgba(120,53,15,.6); color:#fcd34d; }
+.chip-high  { background: rgba(127,29,29,.6); color:#fca5a5; }
+.chip-blue  { background: rgba(30,58,138,.6); color:#93c5fd; }
+
+/* Print styles — v2.15 print-friendly expanded view */
+@media print {
+  body { background: white !important; color: black !important; }
+  details { display: block !important; }
+  details > *:not(summary) { display: block !important; }
+  summary { list-style: none; }
+  canvas, #panel-gallery, .filter-bar, .tab-btn, #expand-all, #collapse-all { display: none !important; }
+  .issue-card {
+    page-break-inside: avoid;
+    break-inside: avoid;
+    margin-bottom: 1rem;
+    border: 1px solid #ccc !important;
+    background: white !important;
+    color: black !important;
+  }
+  .card { background: white !important; border: 1px solid #ccc !important; }
+  pre, code { background: #f5f5f5 !important; color: #000 !important; }
+  @page { margin: 1in; }
+}
+
+.issue-card > summary { list-style: none; cursor: pointer; }
+.issue-card > summary::-webkit-details-marker { display: none; }
+.issue-card { scroll-margin-top: 1rem; }
+.tooltip-pop { display:none; }
+</style>
+</head>
+<body class="bg-slate-950 text-slate-200 font-sans">
+
+<!-- ====================== 1. HEADER BAR ====================== -->
+<header class="bg-slate-900 border-b border-slate-800 px-6 py-4">
+  <div class="max-w-7xl mx-auto flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-xl font-bold text-white">Review Panel Report — <code class="text-indigo-300">README.md</code></h1>
+      <p class="text-sm text-slate-400">671 lines &middot; 2026-05-14 &middot; 4 reviewers + Completeness Audit + Supreme Judge</p>
+    </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="px-3 py-1 rounded-full text-sm font-bold bg-orange-600 text-white">REVISE — substantial edit needed</span>
+      <span class="px-3 py-1 rounded-full text-xs font-semibold bg-slate-700 text-slate-200">Confidence: Medium-High</span>
+      <span class="px-3 py-1 rounded-full text-xs font-semibold bg-slate-700 text-slate-200">Mode: Exhaustive</span>
+    </div>
+  </div>
+</header>
+
+<main class="max-w-7xl mx-auto px-6 py-6 space-y-6">
+
+  <!-- ====================== 2. STATS DASHBOARD ROW ====================== -->
+  <section id="stats-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Overview</h2>
+      <button class="toggle-btn text-xs text-slate-400 hover:text-white" data-target="stats-body">Toggle</button>
+    </div>
+    <div id="stats-body" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 transition-all duration-200">
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <div class="text-xs text-slate-400 uppercase tracking-wide">Total Action Items</div>
+        <div class="text-4xl font-bold text-white mt-1">13</div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <div class="text-xs text-slate-400 uppercase tracking-wide mb-2">By Severity</div>
+        <div class="flex flex-wrap gap-2 text-sm font-semibold">
+          <span class="px-2 py-0.5 rounded bg-red-900/60 text-red-300">P0&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-orange-900/60 text-orange-300">P1&nbsp;4</span>
+          <span class="px-2 py-0.5 rounded bg-yellow-900/60 text-yellow-300">P2&nbsp;8</span>
+          <span class="px-2 py-0.5 rounded bg-slate-700 text-slate-300">P3&nbsp;1</span>
+        </div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <div class="text-xs text-slate-400 uppercase tracking-wide mb-2">By Tier</div>
+        <div class="flex flex-wrap gap-2 text-sm font-semibold">
+          <span class="px-2 py-0.5 rounded bg-sky-900/60 text-sky-300">Light&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-blue-900/60 text-blue-300">Standard&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-indigo-900/60 text-indigo-300">Deep&nbsp;0</span>
+        </div>
+        <div class="text-xs text-slate-500 mt-2">Phase 13 not dispatched (pure-docs run)</div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <div class="text-xs text-slate-400 uppercase tracking-wide mb-2">By Verdict</div>
+        <div class="flex flex-wrap gap-1.5 text-xs font-semibold">
+          <span class="px-2 py-0.5 rounded bg-green-900/60 text-green-300">Confirmed&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-red-900/60 text-red-300">Refuted&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-amber-900/60 text-amber-300">Partial&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-slate-700 text-slate-300">Inconclusive&nbsp;0</span>
+          <span class="px-2 py-0.5 rounded bg-purple-900/60 text-purple-300">New&nbsp;0</span>
+        </div>
+        <div class="text-xs text-slate-500 mt-2">Claims verified by orchestrator (Phases 8&ndash;11)</div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4 flex items-center gap-4">
+        <div>
+          <div class="text-xs text-slate-400 uppercase tracking-wide">Panel Score</div>
+          <div class="text-xs text-slate-500 mt-1">Supreme Judge</div>
+        </div>
+        <div style="position: relative; height: 90px; width: 90px;">
+          <canvas id="chart-score"></canvas>
+          <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <span class="text-2xl font-bold text-white">5<span class="text-sm text-slate-400">/10</span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ====================== 3. PANEL GALLERY ====================== -->
+  <section id="panel-gallery-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Review Panel <span class="text-slate-500 text-sm">(6 agents)</span></h2>
+      <button id="gallery-toggle" class="text-xs px-3 py-1 rounded bg-slate-800 text-slate-300 hover:bg-slate-700">Expand</button>
+    </div>
+    <div id="panel-gallery" class="hidden transition-all duration-200"></div>
+  </section>
+
+  <!-- ====================== 4. CHARTS ROW ====================== -->
+  <section id="charts-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Charts</h2>
+      <button class="toggle-btn text-xs text-slate-400 hover:text-white" data-target="charts-body">Toggle</button>
+    </div>
+    <div id="charts-body" class="grid grid-cols-1 lg:grid-cols-3 gap-4 transition-all duration-200">
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <h3 class="text-sm font-semibold text-white mb-2">Confidence Distribution</h3>
+        <div style="position: relative; height: 220px; width: 100%;">
+          <canvas id="chart-confidence"></canvas>
+        </div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <h3 class="text-sm font-semibold text-white mb-2">Severity Breakdown</h3>
+        <div style="position: relative; height: 220px; width: 100%;">
+          <canvas id="chart-severity"></canvas>
+        </div>
+        <p class="text-xs text-slate-500 mt-2">Tier Breakdown donut omitted &mdash; Phase 13 verification did not run for this pure-documentation review.</p>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <h3 class="text-sm font-semibold text-white mb-2">Epistemic Label Breakdown</h3>
+        <div style="position: relative; height: 220px; width: 100%;">
+          <canvas id="chart-epistemic"></canvas>
+        </div>
+        <p class="text-xs text-slate-500 mt-2">Verification Verdict chart omitted &mdash; Phase 13 verification did not run.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ====================== 5. REVIEWER SCORE TABLE ====================== -->
+  <section id="score-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Reviewer Score Table</h2>
+      <button id="score-toggle" class="text-xs px-3 py-1 rounded bg-slate-800 text-slate-300 hover:bg-slate-700">Expand</button>
+    </div>
+    <div id="score-body" class="hidden transition-all duration-200">
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-slate-800 text-slate-300">
+            <tr>
+              <th class="text-left px-4 py-2">Reviewer</th>
+              <th class="text-left px-4 py-2">Persona</th>
+              <th class="text-center px-4 py-2">Initial</th>
+              <th class="text-center px-4 py-2">Final</th>
+              <th class="text-center px-4 py-2">&Delta;</th>
+              <th class="text-left px-4 py-2">Recommendation</th>
+            </tr>
+          </thead>
+          <tbody id="score-table-body" class="divide-y divide-slate-800"></tbody>
+        </table>
+      </div>
+      <p class="text-xs text-slate-500 mt-2">Reviewer scores 5.5 / 4 / 6 / 4.5 &rarr; mean 5.0; spread 2.0 (moderate convergence, anchored by the unanimous version/release finding). All four reviewers run on the same base model &mdash; treat the convergence with mild caution.</p>
+    </div>
+  </section>
+
+  <!-- ====================== 6. ACTION ITEMS SECTION ====================== -->
+  <section id="action-items-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Action Items</h2>
+      <button class="toggle-btn text-xs text-slate-400 hover:text-white" data-target="action-items-body">Toggle</button>
+    </div>
+    <div id="action-items-body" class="transition-all duration-200">
+      <!-- Filter Bar -->
+      <div class="filter-bar card bg-slate-900 border border-slate-800 rounded-lg p-4 mb-4 flex flex-wrap items-end gap-3">
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Search</label>
+          <input id="search-box" type="text" placeholder="Search findings  ( / )" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200 w-48">
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Severity</label>
+          <select id="filter-severity" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200">
+            <option value="all">All</option><option value="P0">P0</option><option value="P1">P1</option><option value="P2">P2</option><option value="P3">P3</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Tier</label>
+          <select id="filter-tier" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200">
+            <option value="all">All</option><option value="Light">Light</option><option value="Standard">Standard</option><option value="Deep">Deep</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Verdict</label>
+          <select id="filter-verdict" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200">
+            <option value="all">All</option><option value="VR_CONFIRMED">Confirmed</option><option value="VR_REFUTED">Refuted</option><option value="VR_PARTIAL">Partial</option><option value="VR_INCONCLUSIVE">Inconclusive</option><option value="VR_NEW_FINDING">New</option><option value="none">Not Verified</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Epistemic</label>
+          <select id="filter-epistemic" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200">
+            <option value="all">All</option><option value="[VERIFIED]">Verified</option><option value="[CONSENSUS]">Consensus</option><option value="[SINGLE-SOURCE]">Single-Source</option><option value="[UNVERIFIED]">Unverified</option><option value="[DISPUTED]">Disputed</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">Sort</label>
+          <select id="sort-by" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-slate-200">
+            <option value="severity">By Severity</option><option value="confidence">By Confidence</option><option value="tier">By Tier</option>
+          </select>
+        </div>
+        <div class="flex gap-2 ml-auto">
+          <button id="expand-all" class="text-xs px-3 py-1.5 rounded bg-slate-800 text-slate-300 hover:bg-slate-700">Expand all</button>
+          <button id="collapse-all" class="text-xs px-3 py-1.5 rounded bg-slate-800 text-slate-300 hover:bg-slate-700">Collapse all</button>
+        </div>
+        <div class="w-full text-xs text-slate-400" id="live-count">Showing 13 of 13 items</div>
+      </div>
+
+      <!-- Reviewer filter banner -->
+      <div id="reviewer-filter-banner" class="hidden mb-3 px-4 py-2 rounded bg-indigo-900/40 border border-indigo-700 text-sm text-indigo-200 flex items-center justify-between">
+        <span id="reviewer-filter-text"></span>
+        <button id="clear-reviewer-filter" class="text-indigo-300 hover:text-white font-bold">clear &#10005;</button>
+      </div>
+
+      <!-- Issue cards -->
+      <div id="issues-container" class="space-y-3"></div>
+    </div>
+  </section>
+
+  <!-- ====================== 7. CONSENSUS & DISAGREEMENTS ====================== -->
+  <section id="consensus-section">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-white">Consensus &amp; Disagreements</h2>
+      <button id="consensus-toggle" class="text-xs px-3 py-1 rounded bg-slate-800 text-slate-300 hover:bg-slate-700">Expand</button>
+    </div>
+    <div id="consensus-body" class="hidden space-y-6 transition-all duration-200">
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-5">
+        <h3 class="text-sm font-semibold text-white mb-3">Consensus Points <span class="text-slate-500">(judge-confirmed)</span></h3>
+        <ul class="space-y-3 text-sm text-slate-300 list-disc pl-5">
+          <li><strong class="text-white">Version/release story is broken</strong> &mdash; all four reviewers, independently. <code class="bg-slate-800 px-1 rounded">package.json</code> and both manifests declare <code class="bg-slate-800 px-1 rounded">3.3.0</code>; the only git tags that exist are <code class="bg-slate-800 px-1 rounded">v2.10.0, v2.16.5, v3.0.0, v3.1.0</code>. The "Updating" section tells users to verify their install against "the latest GitHub release" &mdash; which resolves to <code class="bg-slate-800 px-1 rounded">v3.1.0</code>, so every correctly-installed v3.3.0 user concludes their install is wrong. The release badge renders <code class="bg-slate-800 px-1 rounded">v3.1.0</code> while the prose says v3.3; hero images are pinned to the <code class="bg-slate-800 px-1 rounded">v3.1.0</code> tag. <span class="chip chip-blue">[VERIFIED]</span> <span class="chip chip-blue">[CONSENSUS]</span></li>
+          <li><strong class="text-white">Too long, wrong audience</strong> &mdash; the README mixes user docs, contributor docs, and design-history/author-archaeology in 671 lines; inline <code class="bg-slate-800 px-1 rounded">(v2.16.3)</code>-style version attributions read as changelog bookkeeping, not user documentation. <span class="chip chip-blue">[CONSENSUS]</span></li>
+          <li><strong class="text-white">Migration / stale-state cleanup is bloated and duplicated</strong> &mdash; the same "remove old marketplace name, delete orphan dirs, remove loose clones, reinstall" procedure appears in 4&ndash;5 non-identical places (~30% of the file is migration/troubleshooting). <span class="chip chip-blue">[CONSENSUS]</span></li>
+        </ul>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-5">
+        <h3 class="text-sm font-semibold text-white mb-3">Disagreement Points <span class="text-slate-500">(with judge rulings)</span></h3>
+        <div class="space-y-4">
+          <div class="border border-slate-800 rounded-lg overflow-hidden">
+            <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-800">
+              <div class="p-3"><div class="text-xs font-semibold text-orange-300 mb-1">Side A &mdash; Devil's Advocate</div><p class="text-sm text-slate-300">Rated the version/release issue <strong>P0</strong> &mdash; the README documents two releases that do not exist; a self-refuting failure for a tool whose pitch is epistemic verification.</p></div>
+              <div class="p-3"><div class="text-xs font-semibold text-blue-300 mb-1">Side B &mdash; Judge</div><p class="text-sm text-slate-300">Dampened to <strong>P1</strong>. The README can be made fully correct without a release-process change (re-point the verify step, fix the badge, re-pin images). The untagged-release gap itself is a repo-process issue outside README scope.</p></div>
+            </div>
+            <div class="bg-yellow-950/20 border-t border-yellow-700/40 px-3 py-2 text-sm text-yellow-200"><strong>Judge ruling:</strong> P1, still ranked #1 action item.</div>
+          </div>
+          <div class="border border-slate-800 rounded-lg overflow-hidden">
+            <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-800">
+              <div class="p-3"><div class="text-xs font-semibold text-orange-300 mb-1">Side A &mdash; Devil's Advocate</div><p class="text-sm text-slate-300">"Credibility theater" / "vanity metrics" / "one model talking to itself" &mdash; the doc manufactures authority and hides that all reviewers share a base model.</p></div>
+              <div class="p-3"><div class="text-xs font-semibold text-blue-300 mb-1">Side B &mdash; Judge</div><p class="text-sm text-slate-300">Partially upheld. The README <em>does</em> disclose the shared-base-model limitation, so it is not dishonest &mdash; but the disclosure is buried at line 381 while the top sells "independent reviewers." The only hard factual defect is the "peer-reviewed" qualifier (AutoGen has no venue); the 9-paper count is accurate.</p></div>
+            </div>
+            <div class="bg-yellow-950/20 border-t border-yellow-700/40 px-3 py-2 text-sm text-yellow-200"><strong>Judge ruling:</strong> P2 &mdash; move the limitation up, soften "independent."</div>
+          </div>
+          <div class="border border-slate-800 rounded-lg overflow-hidden">
+            <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-800">
+              <div class="p-3"><div class="text-xs font-semibold text-orange-300 mb-1">Side A &mdash; Reviewers (self-critique)</div><p class="text-sm text-slate-300">DA F10 (grandiose naming) and Clarity F15 (output files explained 3&times;) &mdash; both reviewers flagged these as their own least-defensible findings.</p></div>
+              <div class="p-3"><div class="text-xs font-semibold text-blue-300 mb-1">Side B &mdash; Judge</div><p class="text-sm text-slate-300">DA F10 downgraded to P3. Clarity F15 merged into the duplication finding, not carried as a separate item.</p></div>
+            </div>
+            <div class="bg-yellow-950/20 border-t border-yellow-700/40 px-3 py-2 text-sm text-yellow-200"><strong>Judge ruling:</strong> F10 &rarr; P3 bundle; F15 &rarr; merged.</div>
+          </div>
+        </div>
+      </div>
+      <div class="card bg-slate-900 border border-slate-800 rounded-lg p-5">
+        <h3 class="text-sm font-semibold text-white mb-3">Completeness Audit Findings</h3>
+        <ul class="space-y-2 text-sm text-slate-300 list-disc pl-5">
+          <li><code class="bg-slate-800 px-1 rounded">docs/archive/review_panel_report.md</code> is a real, full sample report (6,920 bytes) that exists in-repo and is <strong>never linked</strong> &mdash; the README shows output only as GIFs. <span class="chip chip-blue">[VERIFIED]</span></li>
+          <li>The "How It Works" table is two releases stale: SKILL.md defines <strong>Phase 13.5</strong> (Pre-Judge Verification Gate, v3.1.0) and <strong>Phase 14.5</strong> (Post-Judge Verification Gate, v3.2.0); neither appears in the README's headline table. <span class="chip chip-blue">[VERIFIED]</span></li>
+          <li>The epistemic-labels glossary omits <code class="bg-slate-800 px-1 rounded">[JUDGE-HALLUCINATED]</code> and <code class="bg-slate-800 px-1 rounded">[COMPRESSED]</code>, both real shipped labels. <span class="chip chip-blue">[VERIFIED]</span></li>
+          <li>A prior README restructure attempt is archived at <code class="bg-slate-800 px-1 rounded">docs/archive/2026-04-27-readme-restructure-rejected/</code> &mdash; read why it was rejected before attempting another.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ====================== 8. FOOTER ====================== -->
+  <footer class="border-t border-slate-800 pt-6 pb-4 text-center text-sm text-slate-500">
+    <p>Generated by Agent Review Panel v3.3.0 &middot; 2026-05-14 &middot; 4 reviewers &middot; README.md</p>
+    <p class="text-xs mt-1">Charts, styling, and code highlighting require internet connection.</p>
+  </footer>
+
+</main>
+
+<script>
+/* ============================ REVIEW DATA ============================ */
+const reviewData = {
+  meta: {
+    work: "README.md (671 lines)",
+    date: "2026-05-14",
+    verdict: "REVISE — substantial edit needed",
+    score: 5,
+    confidence: "Medium-High",
+    mode: "Exhaustive"
+  },
+
+  personas: [
+    {
+      id: "p-1", name: "Clarity Editor", role: "Communicates clearly to its audience?",
+      agreement_intensity: 60, reasoning_strategy: "first-principles",
+      reasoning_injection: "Question every assumption — would a first-time reader actually understand this?",
+      domain_focus: "Whether the document communicates clearly to its intended audience.",
+      agent_type: "generic", voltagent_upgrade: false, phases_active: [3],
+      items_raised: ["AI-3","AI-5","AI-6","AI-13"], avatar_color: "indigo"
+    },
+    {
+      id: "p-2", name: "Technical Accuracy Reviewer", role: "Every claim correct vs. the repo?",
+      agreement_intensity: 30, reasoning_strategy: "checklist verification",
+      reasoning_injection: "Verify every factual, technical, and procedural claim against the actual repo.",
+      domain_focus: "Claim-by-claim correctness of the README against repository source files.",
+      agent_type: "generic", voltagent_upgrade: false, phases_active: [3],
+      items_raised: ["AI-1","AI-2","AI-4","AI-8","AI-9"], avatar_color: "blue"
+    },
+    {
+      id: "p-3", name: "Completeness Checker", role: "What's missing the reader needs?",
+      agreement_intensity: 40, reasoning_strategy: "checklist verification",
+      reasoning_injection: "Find what is missing that a reader needs.",
+      domain_focus: "Gaps between what the README provides and what a first-time evaluator needs.",
+      agent_type: "generic", voltagent_upgrade: false, phases_active: [3],
+      items_raised: ["AI-1","AI-4","AI-7","AI-10","AI-12","AI-13"], avatar_color: "cyan"
+    },
+    {
+      id: "p-4", name: "Devil's Advocate", role: "Does it persuade or mislead?",
+      agreement_intensity: 20, reasoning_strategy: "analogical",
+      reasoning_injection: "Challenge framing, credibility claims, and whether the doc persuades or misleads.",
+      domain_focus: "Framing, credibility, vanity metrics, and over-marketing.",
+      agent_type: "generic", voltagent_upgrade: false, phases_active: [3],
+      items_raised: ["AI-1","AI-3","AI-5","AI-7","AI-8","AI-11","AI-13"], avatar_color: "teal"
+    }
+  ],
+
+  verificationAgents: [],
+
+  supportAgents: [
+    { id: "completeness-auditor", name: "Completeness Auditor", role: "Phases 8–11 — audits for missing content the reader needs; flagged the unlinked sample report, the stale phase table, and the incomplete label glossary.", phase: "Phase 8" },
+    { id: "claim-verifier", name: "Claim Verifier", role: "Phases 8–11 — verified README claims against git tags, package.json, SKILL.md, research-foundations.md, and a live npm test run.", phase: "Phase 11" },
+    { id: "severity-verifier", name: "Severity Verifier", role: "Phase 12 — checked proposed severities; folded into the judge's dampening analysis (P0→P1 on the version finding).", phase: "Phase 12" },
+    { id: "tier-advisor", name: "Tier Refinement Advisor", role: "Reviews confidence-based tier draft, corrects misleading assignments. Inactive — Phase 13 verification did not run for this pure-docs review.", phase: "Phase 4.8b" },
+    { id: "judge", name: "Supreme Judge", role: "Final arbiter — overrides severity, dismisses hallucinations, identifies coverage gaps. Produced REVISE / 5--10, zero [JUDGE-HALLUCINATED] findings.", phase: "Phase 14" }
+  ],
+
+  scoreTable: [
+    { reviewerId: "p-1", reviewer: "Clarity Editor", persona: "Communicates clearly to its audience?", intensity: 60, initial: 5.5, final: 5.5, recommendation: "Cut ~⅓; split reader vs. maintainer content" },
+    { reviewerId: "p-2", reviewer: "Technical Accuracy Reviewer", persona: "Every claim correct vs. the repo?", intensity: 30, initial: 4, final: 4, recommendation: "Fix phase table, release story, label glossary" },
+    { reviewerId: "p-3", reviewer: "Completeness Checker", persona: "What's missing the reader needs?", intensity: 40, initial: 6, final: 6, recommendation: "Operationally exhaustive but evaluator-hostile" },
+    { reviewerId: "p-4", reviewer: "Devil's Advocate", persona: "Does it persuade or mislead?", intensity: 20, initial: 4.5, final: 4.5, recommendation: "Documents unreleased versions; vanity metrics" }
+  ],
+
+  actionItems: [
+    {
+      id: "AI-1",
+      summary: "Fix the version/release story: re-point the \"Updating\" verify step at package.json/CHANGELOG, bump the example version, and re-pin the three hero-image URLs to a current tag or main.",
+      severity: "P1",
+      epistemicLabel: "[VERIFIED]",
+      defectType: "[EXISTING_DEFECT]",
+      sourceReviewers: ["Clarity Editor", "Technical Accuracy Reviewer", "Completeness Checker", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "git ls-remote --tags origin returns only v2.10.0, v2.16.5, v3.0.0, v3.1.0. package.json and both .claude-plugin manifests declare 3.3.0. The README's \"Updating\" verify step points users at the latest GitHub release (v3.1.0).",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `git ls-remote --tags origin` → tags: v2.10.0, v2.16.5, v3.0.0, v3.1.0. No v3.2.0 or v3.3.0 tag exists. [VERIFIED]\n- `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` all declare version 3.3.0. [VERIFIED]\n- README lines 15/17/19 pin hero/demo images to raw.githubusercontent.com/.../v3.1.0/docs/... [VERIFIED]\n- README lines 148–152 instruct users to compare their install against \"the latest GitHub release\" via `gh release view` — guaranteed false-negative for every v3.3.0 user. [VERIFIED]\n- Defect type: [EXISTING_DEFECT] — current instructions misfire for every v3.3.0 user.",
+      narrative: "All four reviewers independently anchored on this finding; it is the single point of unanimous consensus and the reason the score spread was only 2.0.\n\nTechnical Accuracy (P1-2): \"The version story is incoherent because no v3.2.0/v3.3.0 release tag exists yet the README tells users their cache version 'should match the latest GitHub release.' `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` all declare `3.3.0`. So a correctly-installed v3.3.0 user runs `ls ~/.claude/plugins/cache/.../`, sees `3.3.0`, compares to 'latest GitHub release' (v3.1.0), and concludes their install is ahead/broken. The single most actionable instruction in the Updating section produces a false negative for every current user. The badge will also render `v3.1.0` while the repo is `v3.3.0`.\"\n\nClarity Editor (F6): \"From a clarity lens this is an audience-trust problem: a reader who clicks the release badge and sees v3.1.0 will distrust the rest of the doc. The hero images are the first visual a newcomer sees; pinning them to a stale tag means onboarding screenshots can silently lag the product.\"\n\nCompleteness Checker (P1-2): \"A user following the documented verification flow will conclude their install is broken when it is not. This is an actively misleading instruction.\"\n\nDevil's Advocate (F1, originally P0): \"This is the analogical twin of the classic 'changelog written ahead of the release' failure — except here it has escaped into the marketing surface. The whole product is about verification and epistemic honesty; shipping a README whose central version claim fails its own falsification check is self-refuting.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-2", reviewerName: "Technical Accuracy Reviewer", rating: "P1", reasoning: "The update-verification instruction produces a guaranteed false negative for every current v3.3.0 user; the release badge renders a version older than the stated one." },
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P1", reasoning: "The documented verification flow points at GitHub releases that do not exist — a user will conclude a correct install is broken." },
+        { reviewerId: "p-1", reviewerName: "Clarity Editor", rating: "P1", reasoning: "A reader who clicks the release badge and sees v3.1.0 distrusts the rest of the doc; the hero images are the first visual and they are stale." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P0", reasoning: "The README documents two releases that were never tagged — a self-refuting failure for a tool whose entire pitch is epistemic verification." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: true,
+        reasoning: "All four reviewers raised this independently — strong consensus, [VERIFIED] against `git ls-remote`, package.json, and the manifests. The Devil's Advocate rated it P0; I dampen to P1. The README itself can be made fully correct without a release-process change: re-point the verify step at `package.json`/`CHANGELOG.md` (not GitHub releases) and note that releases may lag `main`, fix the badge, and re-pin the hero images. The underlying untagged-release gap is a repo-process issue outside README scope. It remains the #1 priority action item.",
+        finalSeverity: "P1",
+        severityChangeReason: "Downgraded from P0 to P1 because the README can be made fully correct without a release-process change — the untagged-release gap is a repo-process issue outside README scope. Still ranked the #1 action item."
+      },
+      fixRecommendation: {
+        summary: "Re-point the \"Updating\" verify step at package.json/CHANGELOG.md, bump the (e.g. 3.1.0) example to 3.3.0, and re-pin the three hero-image URLs to a current tag or main.",
+        proposedChange: "Either tag v3.2.0 and v3.3.0 so reality matches the README, OR change the \"Updating to the latest version\" verify step to compare the installed cache-dir version against the version in package.json / .claude-plugin/plugin.json (or the top CHANGELOG.md entry) instead of \"the latest GitHub release\", and add a note that GitHub releases may lag main. Bump the line-154 example version (e.g. 3.1.0) to 3.3.0. Re-pin the three raw.githubusercontent.com hero/demo image URLs (README lines 15, 17, 19) from the v3.1.0 tag to a current tag or to main.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a release-check assertion: scripts/release-check.sh should grep the README for the verify-step target and assert it does NOT reference \"latest GitHub release\" while package.json declares a version with no matching tag.",
+        blastRadius: "Low — text and URL edits in the README only; no code or API surface change.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-2", relationship: "same-class", note: "AI-2 is the other half of the same staleness problem — the README lagging the actual v3.3.0 repo state." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-2",
+      summary: "Add Phase 13.5 and Phase 14.5 rows to the \"How It Works\" table; reconcile the \"sequential integers 1–16\" prose.",
+      severity: "P1",
+      epistemicLabel: "[VERIFIED]",
+      defectType: null,
+      sourceReviewers: ["Technical Accuracy Reviewer"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "SKILL.md lines 1027 and 1110 define Phase 13.5 (Pre-Judge Verification Gate, v3.1.0) and Phase 14.5 (Post-Judge Verification Gate, v3.2.0). CHANGELOG [3.1.0] and [3.2.0] confirm both shipped. The README's \"How It Works\" table lists only integer phases 1–16.",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `skills/agent-review-panel/SKILL.md:1027` defines Phase 13.5 — Pre-Judge Verification Gate (v3.1.0). [VERIFIED]\n- `skills/agent-review-panel/SKILL.md:1110` defines Phase 14.5 — Post-Judge Verification (\"Re-verify judge-introduced P0/P1 against ground truth\", v3.2.0). [VERIFIED]\n- CHANGELOG [3.2.0] \"Added — Phase 14.5\" and [3.1.0] \"Phase 13.5 — Pre-Judge Verification Gate (NEW)\" confirm both are real, shipped phases. [VERIFIED]\n- README \"How It Works\" table (lines 249–270) reflects neither; line 251 prose claims \"sequential integers (Phase 1 through Phase 16)\".",
+      narrative: "Raised by the Technical Accuracy Reviewer (P1-1), unrefuted by the other reviewers and confirmed by the Completeness Audit.\n\n\"The 'How It Works' phase table is stale: missing Phase 13.5 AND Phase 14.5. The table lists phases 1–16 with no 13.5 or 14.5. SKILL.md Process Overview defines Phase 14.5: Post-Judge Verification ('Re-verify judge-introduced P0/P1 against ground truth') and SKILL.md line 1027 defines Phase 13.5: Pre-Judge Verification Gate. CHANGELOG [3.2.0] and [3.1.0] both confirm these are real, shipped phases. The README table reflects neither.\n\nA user reading 'How It Works' gets a process model that is two releases out of date and silently omits two verification gates that are core selling points of v3.1/v3.2. The README even cross-links this table from the Tests section as authoritative.\"\n\nThis was the reviewer's most-defensible finding: \"Directly contradicted by SKILL.md lines 1027 & 1110 and CHANGELOG [3.1.0]/[3.2.0]. Two whole phases missing from the headline 'How It Works' table. Unambiguous.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-2", reviewerName: "Technical Accuracy Reviewer", rating: "P1", reasoning: "Two whole verification phases — core v3.1/v3.2 selling points — are missing from the headline process table, which the README itself cites as authoritative." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source but [VERIFIED] against SKILL.md and CHANGELOG, and unrefuted by the other three reviewers. The Completeness Audit independently surfaced the same gap. No dispute required resolution — the finding stands as raised at P1.",
+        finalSeverity: "P1",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Add two rows to the \"How It Works\" table — Phase 13.5 under Verify, Phase 14.5 under Adjudicate — and update the \"sequential integers 1–16\" prose.",
+        proposedChange: "Add Phase 13.5 (Pre-Judge Verification Gate, v3.1.0) under the Verify grouping and Phase 14.5 (Post-Judge Verification Gate, v3.2.0) under the Adjudicate grouping of the \"How It Works\" table. Update the line-251 prose so it acknowledges the 13.5/14.5 decimals the same way it already acknowledges the 15.x sub-steps, rather than claiming \"sequential integers (Phase 1 through Phase 16).\"",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Extend the existing test that asserts \"All 16 top-level phases present in SKILL.md\" to also assert Phase 13.5 and Phase 14.5 appear in the README's How It Works table whenever they appear in SKILL.md.",
+        blastRadius: "Low — two table rows and one sentence of prose.",
+        estimatedEffort: "30 min"
+      },
+      crossRefs: [
+        { targetId: "AI-1", relationship: "same-class", note: "Both AI-1 and AI-2 are instances of the README lagging the actual v3.3.0 repository state." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-3",
+      summary: "Cut ~⅓ of the length and split audiences — move migration/troubleshooting to MIGRATION.md + TROUBLESHOOTING.md, design-history to HOW_WE_BUILT_THIS.md. Target ~250–350 lines.",
+      severity: "P1",
+      epistemicLabel: "[CONSENSUS]",
+      defectType: null,
+      sourceReviewers: ["Clarity Editor", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "The README mixes user docs, contributor docs, and design-history in 671 lines. Roughly 30% of the file is migration/stale-state/troubleshooting; the same cleanup recipe appears in 4–5 non-identical places.",
+      fullEvidence: "",
+      narrative: "Strong consensus: Clarity Editor's whole review, Devil's Advocate F6/F7/F9, and the Completeness Checker's \"lopsided\" framing all converge here.\n\nClarity Editor: \"A meticulously thorough README that documents everything at least once and the hard parts four or five times — it needs roughly a third cut, a slimmed opening, and a hard separation of reader content from maintainer/changelog content.\" F5 (the most defensible finding): \"The same cleanup procedure — remove old marketplace name, delete orphan dirs, remove loose `~/.claude/skills/` clones, reinstall — appears as a paste-to-Claude prompt, a manual bash recipe, a partial recipe, and a pointer-back. Five touchpoints for one procedure. A reader who hits the problem finds four overlapping-but-not-identical recipes and cannot tell which is authoritative.\"\n\nDevil's Advocate (F6): \"~200 lines of migration + troubleshooting + stale-state cleanup is a product smell, not just a doc problem. Roughly a third of the README... A README's migration burden is a mirror of the product's release discipline.\" (F9): \"A document for everyone is a document for no one. The README oscillates between three readers — users, contributors, and the author documenting their own cleverness.\"\n\nThe judge merged Clarity's self-identified weakest finding (F15, output files explained 3×) into this duplication item rather than carrying it separately.",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-1", reviewerName: "Clarity Editor", rating: "P1", reasoning: "The README over-serves the maintainer at the newcomer's expense — far too long, with core content repeated three to five times each." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P1", reasoning: "At 671 lines the README tries to be the user guide, the contributor guide, and the design memoir simultaneously — a document for everyone is a document for no one." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Strong consensus across reviewers, all independently. Not disputed — the disagreement was only about emphasis, not direction. I merged Clarity's self-identified least-defensible finding (F15 — output files explained three times) into this duplication item rather than carrying it as a separate action. The fix is subtraction and audience discipline, not more writing. Whoever revises should first read why the prior restructure attempt at docs/archive/2026-04-27-readme-restructure-rejected/ was rejected.",
+        finalSeverity: "P1",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Cut ~⅓ of the length; move migration/stale-state/deep troubleshooting to MIGRATION.md + TROUBLESHOOTING.md and design-history to HOW_WE_BUILT_THIS.md. Target ~250–350 lines.",
+        proposedChange: "Reduce the README from 671 lines to roughly 250–350. Move migration, stale-state cleanup, and deep troubleshooting content into MIGRATION.md and TROUBLESHOOTING.md (or collapse to one canonical recipe in the README with cross-links from the other 3–4 locations). Move design-history and author-archaeology (the Phase 4.55 renumbering note, the \"why roundtable\" debate, version-history minutiae) into HOW_WE_BUILT_THIS.md. Decide the README is for users evaluating and running the tool. Consult docs/archive/2026-04-27-readme-restructure-rejected/ before starting.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a soft line-count assertion to scripts/release-check.sh that warns if README.md exceeds ~400 lines.",
+        blastRadius: "Medium — large restructure touching most of the README and creating/expanding three sibling docs; a prior attempt was rejected.",
+        estimatedEffort: "1 day"
+      },
+      crossRefs: [
+        { targetId: "AI-5", relationship: "same-class", note: "AI-5 (strip inline version attributions) is one specific slice of the broader length/audience problem." },
+        { targetId: "AI-6", relationship: "same-class", note: "AI-6 (slim the opening) is the opening-block instance of the same over-length problem." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-4",
+      summary: "Add a text sample of a real report (Action Items table + one judged disagreement) in a <details> block; link docs/archive/review_panel_report.md.",
+      severity: "P1",
+      epistemicLabel: "[VERIFIED]",
+      defectType: null,
+      sourceReviewers: ["Completeness Checker"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "docs/archive/review_panel_report.md is a real, full sample report (6,920 bytes) that exists in-repo and is never linked. The README shows output only as animated GIFs — not copy-pasteable, not accessible, not indexed by search.",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `ls docs/archive/` confirms `review_panel_report.md` exists, 6,920 bytes — a real, full sample report. [VERIFIED]\n- `grep` of README.md finds no link to that file. [VERIFIED]\n- README illustrates output only via three animated GIFs (lines 15–19).",
+      narrative: "Raised by the Completeness Checker (P1-1) as one of its three most-defensible findings, and independently confirmed by the Completeness Audit.\n\n\"The README describes the three output files extensively and links to demo GIFs, but never shows a single finding, action-item row, or `review_panel_report.md` snippet as text. A reader cannot tell what they will actually receive. The GIFs are images (not copy-pasteable, not accessible, not indexed by search), and `docs/archive/review_panel_report.md` is a real sample that exists in-repo but is never linked.\n\nThis is the single biggest 'should I run this?' question. Worked output is the most persuasive content a tool README can have, and one already exists unlinked in the repo.\"\n\nThe Completeness Checker's P3-12 (accessibility of GIFs) folds into this fix: a text report sample doubles as the accessible alternative for screen-reader users and users on metered connections.",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P1", reasoning: "The README never shows what a report actually looks like as text — and a real 6,920-byte sample sits unlinked in docs/archive/." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source but [VERIFIED] — the sample file exists and is unlinked, confirmed by the Completeness Audit. Unrefuted. Not arbitrated as a dispute; stands at P1 as raised. Worked output is the most persuasive content a tool README can have and the README currently shows none in text form.",
+        finalSeverity: "P1",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Add a <details> block with ~15 lines of a real Action Items table + one judged disagreement lifted from docs/archive/review_panel_report.md, and link that file.",
+        proposedChange: "Add a collapsible <details> block — under Quick Start's \"What you get\" or as a \"Sample Output\" subsection before \"How It Works\" — containing ~15 lines of a real Action Items table plus one disagreement-with-judge-ruling excerpt, lifted from docs/archive/review_panel_report.md. Link that file explicitly: \"See a full real report: docs/archive/review_panel_report.md.\" Ensure GIF alt text is descriptive so the text sample also serves as the accessible alternative.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a test asserting README.md contains a link to docs/archive/review_panel_report.md (or whichever sample path is canonical).",
+        blastRadius: "Low — additive content block plus one link; no removals.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [],
+      priorRuns: []
+    },
+    {
+      id: "AI-5",
+      summary: "Strip inline (vX.Y) attributions from reader-facing prose; describe features in present tense.",
+      severity: "P2",
+      epistemicLabel: "[CONSENSUS]",
+      defectType: null,
+      sourceReviewers: ["Clarity Editor", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "grep of the README confirms 10+ inline (vX.Y)-style version attributions in reader-facing prose — How It Works, Features, Quick Start, Bundled skills. These read as changelog bookkeeping, not user documentation.",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `grep` on README confirms 10+ instances of inline `(vX.Y)` version attributions in reader-facing prose. [VERIFIED]\n- Examples: line 93 `(new in v2.15)`, line 251 `(v2.16.4 disk-reading architecture)`, lines 256–270 table `*(v2.14, code only)*` / `*(v2.16.3)*`, line 282 `(v2.16.3)`, line 431 `(v3.0.0)`.",
+      narrative: "Consensus between the Clarity Editor (F3) and the Devil's Advocate (F7).\n\nClarity Editor (F3, a most-defensible finding): \"Version-attribution tags litter reader-facing prose. A new user reading 'How It Works' or 'Features' does not care which release introduced a phase — that is changelog/maintainer information. The `(v2.16.3)` style annotations interrupt the reading flow and assume the reader has a mental model of the version timeline they do not have. It also dates the prose — a reader cannot tell if `(v2.15)` means 'recent' or 'ancient.'\"\n\nDevil's Advocate (F7): \"The body text is littered with version-attribution parentheticals. These attributions serve the author's memory of the build history, not the reader's understanding. They also rot: every one is a maintenance liability and a chance for drift — and given F1, the drift has already happened. There is already a 46KB CHANGELOG.md — the history has a home.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-1", reviewerName: "Clarity Editor", rating: "P2", reasoning: "Maintainer bookkeeping presented as user documentation — it interrupts reading flow and dates the prose." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P2", reasoning: "The README reads like release notes; the reader has to mentally strip version noise to find the actual feature description." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Consensus between two reviewers, [VERIFIED] by grep. Not disputed. Stands at P2 — strip the inline (vX.Y) attributions from How It Works / Features / Quick Start / Bundled skills, describe features in present tense, and leave history to the Version History table and CHANGELOG.",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Strip all (vX.Y) parentheticals from How It Works, Features, Quick Start, and Bundled skills; describe features in present tense.",
+        proposedChange: "Remove every inline (vX.Y) version-attribution parenthetical from the reader-facing sections (How It Works, Features, Quick Start, Bundled skills). Describe what the tool does now, in present tense. The Version History table and CHANGELOG.md already carry the introduction-version history for anyone who wants it.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a lint check that warns if reader-facing README sections contain `(v\\d+\\.\\d+` patterns outside the Version History table.",
+        blastRadius: "Low — inline text deletions across several sections.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-3", relationship: "root-cause", note: "AI-3's broader length/audience-discipline problem is the root cause; stripping version noise is one slice of that cleanup." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-6",
+      summary: "Slim the opening: H1, one-sentence tagline, one hero image, one \"Claude Code only\" note, then Quick Start.",
+      severity: "P2",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Clarity Editor"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "A first-time reader hits 3 badge lines, an H1, a 5-line bold tagline, a one-line description, a 4-line blockquote, three stacked hero images, an italic caption, and a 10-line Contents list — ~33 lines of preamble — before reaching a single actionable instruction.",
+      fullEvidence: "",
+      narrative: "Raised by the Clarity Editor (F1) as one of its three most-defensible findings; unrefuted.\n\n\"Before a newcomer reaches a single actionable instruction (Quick Start at line 35), they must wade through: 3 badge lines, an H1, a 5-line bold tagline, a one-line plugin description, a 4-line blockquote about bundled skills + supported surfaces, three stacked hero images/GIFs, an italic caption, and a 10-line Contents list. That is roughly 33 lines of preamble. First-principles test: a reader who has 'never heard of this' needs what it is and how to start — they get what it is four times over and how to start nowhere on screen one.\n\nThe opening must earn attention efficiently. The current opening buries the value proposition under its own thoroughness and delays the payoff.\"\n\nThe judge also pulled the related Devil's Advocate / Completeness recommendation into this item: add a one-line cost-and-fit statement under the hero (see AI-7).",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-1", reviewerName: "Clarity Editor", rating: "P2", reasoning: "~33 lines of preamble before the first actionable instruction — the value proposition is buried under its own thoroughness." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source, not independently verified as a count but directly checkable by reading lines 1–34; unrefuted. Advisory P2. Slim the opening to H1, one-sentence tagline, one hero image, one \"Claude Code only\" note, then Quick Start; move the bundled-skills blockquote and surfaces detail into their existing dedicated sections.",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Cut the opening to H1, one-sentence tagline, one hero image, one \"Claude Code only\" note, then Quick Start.",
+        proposedChange: "Trim the ~33-line preamble to: H1, a single-sentence tagline, one hero image, a one-line \"Runs only on Claude Code surfaces\" note, then Quick Start. Move the bundled-skills blockquote and the surfaces detail into their existing dedicated sections (they already exist). Demote two of the three GIFs to the HTML/How-It-Works sections where they are contextually relevant. Keep the Contents list terse or move it below Quick Start.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — reordering and trimming the README header region.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-3", relationship: "root-cause", note: "The opening bloat is one instance of AI-3's overall length/audience problem." },
+        { targetId: "AI-7", relationship: "depends-on", note: "The slimmed opening should include the one-line cost-and-fit statement from AI-7." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-7",
+      summary: "Surface \"When to use / When NOT to use\" near the top (from SKILL.md); add a one-line cost-and-fit statement under the hero.",
+      severity: "P2",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Completeness Checker", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "SKILL.md has a strong, specific \"When NOT to Use This Skill\" section; the README only has scattered fragments and never links it. The first dollar figure appears on line 369 of 671 — cost is below the fold for a paid-per-run tool.",
+      fullEvidence: "",
+      narrative: "Raised by the Completeness Checker (P1-3) and the Devil's Advocate (F2); both were flagged as most-defensible findings by their respective reviewers.\n\nCompleteness Checker (P1-3): \"`skills/agent-review-panel/SKILL.md` has a strong, specific 'When NOT to Use This Skill' section (single code review, quick sanity checks, bug fixes, 'what do you think?', etc.). The README only has scattered fragments. There is no consolidated decision section near the top, and SKILL.md's list is never linked. Cost is $3-$20 per run. Telling someone clearly not to run it for a quick review saves them money and a bad first impression.\"\n\nDevil's Advocate (F2): \"This tool costs $3–$20 per single run and 3× base for multi-run. The README's hero section, Quick Start, Installation, Why-Use-a-Panel, How It Works, and Features — roughly 360 lines — sell the machinery enthusiastically without once saying 'this is expensive.' The cost table is honest when you reach it, but placement is a soft form of dishonesty: the reader is fully sold before they learn the price.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P1", reasoning: "\"When NOT to use\" content exists in SKILL.md but is never surfaced or linked; for a $3–$20/run tool that omission costs users money." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P1", reasoning: "Cost is buried 360+ lines deep — pricing-below-the-fold is a soft dark pattern for a paid-per-run tool." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Two reviewers raised closely related aspects; I bundle them into one action item. Single-source per-aspect but mutually reinforcing and unrefuted; the SKILL.md \"When NOT to Use\" content is verifiable. Advisory P2 (not P1: the README does contain the cost table and scattered fragments — the defect is placement and surfacing, not absence). Surface a \"When to use / When NOT to use\" block near the top sourced from SKILL.md, and add a one-line cost-and-fit statement under the hero (\"~$3–$20 per run, 6–15 min; for high-stakes reviews, not routine checks\").",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Add a two-column \"Use it for / Don't use it for\" block up high (sourced from SKILL.md) and a one-line cost-and-fit statement under the hero.",
+        proposedChange: "Add a short \"When to use / When NOT to use\" block right after the hero/intro (or folded into \"Why Use a Panel\"), sourced verbatim from SKILL.md's \"When NOT to Use This Skill\" list. Add a one-line cost-and-fit statement in or immediately under the hero block: e.g. \"Each run costs roughly $3–$20 in Opus tokens and takes 6–15 min; built for high-stakes reviews, not routine checks.\" Keep the detailed cost table where it is.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — additive content near the top of the README.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-6", relationship: "blocks", note: "This cost-and-fit line should land in the slimmed opening defined by AI-6." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-8",
+      summary: "Change \"9 peer-reviewed papers\" → \"9 research papers/projects\"; separate architecture-mapped papers from inspirational ones.",
+      severity: "P2",
+      epistemicLabel: "[VERIFIED]",
+      defectType: null,
+      sourceReviewers: ["Technical Accuracy Reviewer", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "docs/research-foundations.md has exactly 9 paper rows — the count is correct — but lists AutoGen with venue \"—\" (no venue). AutoGen is a GitHub project / tech report, not peer-reviewed, so the \"peer-reviewed\" qualifier is inaccurate.",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `docs/research-foundations.md` has exactly 9 data rows → \"9 papers\" count is [VERIFIED] accurate.\n- The AutoGen row lists venue `—` (no venue). AutoGen is not peer-reviewed → \"9 peer-reviewed papers\" qualifier is [VERIFIED] inaccurate.\n- ROADMAP.md line 212 says \"Academic Papers (17+)\" — a different scope, not a contradiction.",
+      narrative: "Raised by the Technical Accuracy Reviewer (P2-4) and, more sharply, by the Devil's Advocate (F3).\n\nTechnical Accuracy (P2-4): \"`docs/research-foundations.md` table does list exactly 9 rows — count is correct. BUT the README says '9 peer-reviewed papers' while research-foundations.md lists AutoGen with venue '—' (no venue) — AutoGen is a GitHub project / tech report, not peer-reviewed. Core count (9) is accurate; the 'peer-reviewed' qualifier is the inaccuracy.\"\n\nDevil's Advocate (F3): \"'Grounded in 9 research papers' is credibility theater, not load-bearing methodology. The README maps 4 of 9 papers to phases and explicitly calls these 'load-bearing.' The other 5 get no architecture mapping. So the honest count of papers that actually shaped a mechanism is ~4, not 9. Citing ICLR/ACL papers does not make a tool's output better.\"\n\nThe judge ruled the research-grounding legitimate to cite — only the \"peer-reviewed\" qualifier is a hard defect; the framing critique is advisory.",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-2", reviewerName: "Technical Accuracy Reviewer", rating: "P2", reasoning: "The count of 9 is correct, but \"peer-reviewed\" is verifiably inaccurate — AutoGen has no venue in research-foundations.md." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P1", reasoning: "Borrowed academic authority for a domain transfer the papers don't support — only ~4 of 9 are actually mapped to architecture." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: true,
+        reasoning: "The Devil's Advocate framed this as P1 \"credibility theater.\" I partially uphold it. The research-grounding is legitimate to cite — multi-agent debate research genuinely informed the architecture. The only hard, verified factual defect is the \"peer-reviewed\" qualifier: research-foundations.md lists AutoGen with no venue. The 9-paper count itself is accurate. The broader \"vanity metrics / credibility theater\" framing is advisory [SINGLE-SOURCE], not a factual defect. Net: P2 — fix the qualifier and separate \"mechanisms mapped to architecture\" from \"papers that informed thinking.\"",
+        finalSeverity: "P2",
+        severityChangeReason: "Devil's Advocate rated the credibility-theater framing P1; dampened to P2 because only the \"peer-reviewed\" qualifier is a verified factual defect — the research-grounding itself is legitimate and the framing critique is advisory."
+      },
+      fixRecommendation: {
+        summary: "Change \"9 peer-reviewed papers\" → \"9 research papers/projects\"; in Research Foundations, separate architecture-mapped papers from inspirational ones.",
+        proposedChange: "Change \"9 peer-reviewed papers\" to \"9 research papers/projects\" (or footnote AutoGen as a non-peer-reviewed reference). In the Research Foundations section, clearly separate the ~4 papers whose mechanisms are mapped to architecture (ChatEval→Phase 7, MachineSoM→Phase 4, Trust-or-Escalate→judge confidence, DMAD→reasoning strategies) from the papers that informed thinking. Optionally add one honest sentence noting these papers validate multi-agent debate on reasoning benchmarks, not review quality specifically.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a test asserting the README does not use the phrase \"peer-reviewed\" alongside the paper count unless every research-foundations.md row has a non-empty venue.",
+        blastRadius: "Low — wording change plus a sub-section reorganization in Research Foundations.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-11", relationship: "same-class", note: "Both AI-8 and AI-11 are about over-claiming in the framing — research authority and reviewer independence respectively." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-9",
+      summary: "Add [JUDGE-HALLUCINATED] and [COMPRESSED] to the epistemic-labels glossary; sync the Quick Start mini-list with the full table.",
+      severity: "P2",
+      epistemicLabel: "[VERIFIED]",
+      defectType: null,
+      sourceReviewers: ["Technical Accuracy Reviewer"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "SKILL.md line 1227 is the canonical Phase 15.1 label list. The README's \"Reading the Report\" epistemic-labels table omits [JUDGE-HALLUCINATED] (a real v3.2.0 label) and [COMPRESSED] (a real v3.1.0 suffix). The Quick Start mini-list is also out of sync with the full table.",
+      fullEvidence: "Orchestrator verification (Phases 8–11):\n- `skills/agent-review-panel/SKILL.md:1227` — canonical label list — includes [JUDGE-HALLUCINATED] and [COMPRESSED]. [VERIFIED]\n- README \"Epistemic labels\" table (lines 578–591) omits both. [VERIFIED]\n- README line 299 (Quick Start mini-list) and the lines 578–591 table also differ in membership from each other.",
+      narrative: "Raised by the Technical Accuracy Reviewer (P2-11, a most-defensible finding) and independently confirmed by the Completeness Audit.\n\n\"`SKILL.md` line 1227 — the canonical Phase 15.1 label list — includes `[JUDGE-HALLUCINATED]` and `[COMPRESSED]`. The README table includes VERIFIED, CONSENSUS, SINGLE-SOURCE, DISPUTED, UNVERIFIED, WEB-*, CMD_CONFIRMED/CONTRADICTED, LIVE-VERIFIED, STATIC-INFERENCE, STATIC-INFERENCE-CONSENSUS — but omits `[JUDGE-HALLUCINATED]` (a real v3.2.0 label) and `[COMPRESSED]` (a real v3.1.0 suffix).\n\nA user who sees `[JUDGE-HALLUCINATED]` on an action item — the headline feature of v3.2.0 — finds no entry for it in the README's label glossary.\"\n\nThe reviewer also flagged P2-12: the Quick Start label mini-list (line 299) and the lines 578–591 table differ in membership from each other — two label enumerations in the same document with different contents.",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-2", reviewerName: "Technical Accuracy Reviewer", rating: "P2", reasoning: "SKILL.md line 1227 is canonical; the README table provably omits two real shipped labels, and the Quick Start mini-list is internally inconsistent with the table." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source but [VERIFIED] against SKILL.md, confirmed by the Completeness Audit, unrefuted. Not arbitrated as a dispute. Stands at P2 — add [JUDGE-HALLUCINATED] and [COMPRESSED] to the epistemic-labels glossary and sync the Quick Start mini-list with the full table.",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Add [JUDGE-HALLUCINATED] and [COMPRESSED] rows to the epistemic-labels table; make the Quick Start mini-list and the full table list the same set.",
+        proposedChange: "Add [JUDGE-HALLUCINATED] and [COMPRESSED] rows to the \"Epistemic labels\" table (README lines 578–591), and add [JUDGE-HALLUCINATED] to the Quick Start label mini-list (line 299). Make line 299 and the lines 578–591 table enumerate the same set, both synced to SKILL.md line 1227.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "Add a test that diffs the README's epistemic-labels table against SKILL.md's canonical label list and fails on any missing label.",
+        blastRadius: "Low — two table rows plus a mini-list sync.",
+        estimatedEffort: "30 min"
+      },
+      crossRefs: [
+        { targetId: "AI-2", relationship: "same-class", note: "Both AI-2 and AI-9 are README sections that have fallen out of sync with SKILL.md's canonical definitions." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-10",
+      summary: "Add a \"Support\" section; expand \"Contributing\" with a real dev on-ramp.",
+      severity: "P2",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Completeness Checker"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "Nowhere does the README say where to report a bug or get help — no Support section, no Issues link beyond two passing mentions. The Contributing section lists what help is wanted but nothing about how to start: no dev setup, no npm test pointer, no PR process.",
+      fullEvidence: "",
+      narrative: "Raised by the Completeness Checker (P1-4 and P1-5), unrefuted.\n\nP1-4: \"Nowhere does the README say where to report a bug, ask a question, or get help. 'Contributing' says 'open an issue to discuss before submitting large PRs' and Troubleshooting says 'file an issue' once, in passing — but there is no Support/Help section, no link to GitHub Issues, no Discussions, no issue-template pointer. When a review hangs or produces a wrong finding, the user needs an obvious, findable path to report it.\"\n\nP1-5: \"'Contributing' lists what help is wanted but nothing about how: no dev setup, no 'clone and run `npm test`' pointer, no Node version requirement restated here, no PR process, no pointer to where `SKILL.md` lives. A would-be contributor — the README explicitly solicits Cursor adaptation and new signal groups — has no on-ramp.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P1", reasoning: "No findable path to report a bug, and the Contributing section gives a would-be contributor no on-ramp despite explicitly soliciting contributions." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source, unrefuted. Advisory P2 (not P1: the content gap is real but lower-stakes than the version/release and length problems). Add a \"Support\" section with a GitHub Issues link and \"include content type & size\" guidance; expand \"Contributing\" with a dev on-ramp — clone location, npm test + Node ≥18, where SKILL.md lives, scripts/release-check.sh.",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Add a \"Support\" section (GitHub Issues link + guidance); expand \"Contributing\" with a concrete dev on-ramp.",
+        proposedChange: "Add a dedicated \"Support\" section near the end: link to GitHub Issues with a one-line \"include content type + size\" guidance, and Discussions if enabled. Expand \"Contributing\" with a real on-ramp: \"Dev setup: clone (not into ~/.claude/skills/), npm test (requires Node ≥18), edit skills/agent-review-panel/SKILL.md, run scripts/release-check.sh before release. PRs: open an issue first for large changes.\" Link the Tests section and HOW_WE_BUILT_THIS.md.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — additive sections near the end of the README.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-12", relationship: "same-class", note: "Both AI-10 and AI-12 are about consolidating scattered onboarding info (dev setup / prerequisites) into one findable place." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-11",
+      summary: "Move the \"same base model\" limitation up into \"Why Use a Panel\"; reframe \"independent reviewers\" as \"structured multi-stance self-critique.\"",
+      severity: "P2",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "The README discloses the shared-base-model limitation honestly — but at line 381, while the top of the doc is built on \"independent reviewers,\" \"adversarial,\" \"they debate each other.\" The disclosure is buried under the framing it contradicts.",
+      fullEvidence: "",
+      narrative: "Raised by the Devil's Advocate (F4) as one of its three most-defensible findings; partially upheld by the judge.\n\n\"Line 381 honestly says: 'All reviewers are Claude instances. Unanimous agreement may reflect shared model biases.' Good. But the entire top of the README is built on the opposite impression — '4–6 AI reviewers independently evaluate,' 'they debate each other,' 'genuinely engage,' 'independent reviewers.' A reader reaches the dialogue and is invited to believe two minds are arguing. They are not: it's one model role-playing a disagreement with itself.\n\nThis is the central honesty question for the whole product and the README resolves it in marketing's favor everywhere except one bullet on line 381. The fix: move the 'same base model' limitation up. Reframe the value proposition honestly: this isn't 'independent reviewers,' it's 'structured self-critique that forces one model to take multiple passes from assigned stances.' That's still a legitimately useful thing — sell that, not a fiction of independence.\"\n\nThe report itself echoes this caution: \"all four reviewers run on the same base model, so treat the convergence with mild caution.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P1", reasoning: "The core honesty question — one model talking to itself — is resolved in marketing's favor everywhere except one buried bullet." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: true,
+        reasoning: "Partially upheld. The README does disclose the shared-base-model limitation in Known Limitations, so it is not dishonest — the Devil's Advocate's framing overstates the case. But the disclosure is buried at line 381 while the top of the doc leans on \"independent reviewers.\" Valid P2 (not the P1 the reviewer implied): move the limitation up into \"Why Use a Panel\" and soften \"independent\" to \"structured multi-stance self-critique\" — keep it honest, it is still a real benefit.",
+        finalSeverity: "P2",
+        severityChangeReason: "Devil's Advocate implied P1-level severity; dampened to P2 because the README does disclose the limitation — the defect is placement and word choice, not dishonesty."
+      },
+      fixRecommendation: {
+        summary: "Move the \"same base model\" limitation up into \"Why Use a Panel\"; reframe \"independent reviewers\" as \"structured multi-stance self-critique.\"",
+        proposedChange: "Move the \"All reviewers are Claude instances\" limitation from Known Limitations (line 381) up into the \"Why Use a Panel\" section. Reframe \"independent reviewers\" throughout the top of the doc as \"structured multi-stance self-critique\" — it is still a real, legitimate benefit (parallel passes from assigned stances before cross-contamination), just sold honestly rather than as a fiction of independence.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — relocating one paragraph and adjusting framing wording in a few places.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-8", relationship: "same-class", note: "Both AI-8 and AI-11 address over-claiming in the README's framing." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-12",
+      summary: "Consolidate Prerequisites into one place (incl. Node ≥18, currently only in a troubleshooting footnote).",
+      severity: "P2",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Completeness Checker"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "Requirements appear in at least four places across the README and are inconsistent. Node ≥18 is not in the Prerequisites section at all — it only appears in a Troubleshooting footnote. OS support is never stated anywhere.",
+      fullEvidence: "",
+      narrative: "Raised by the Completeness Checker (P2-8), unrefuted.\n\n\"Requirements appear in at least four places: surfaces (line 13), 'Requires Claude Code' (lines 99–117), 'Claude Code version requirement' (lines 206–208), 'Prerequisites' (lines 399–403), and Node ≥18 (line 544, only in a Troubleshooting entry). Node version is not in the Prerequisites section at all — it only appears in a troubleshooting footnote. OS support is never stated anywhere.\n\nA reader checking 'can I run this?' should find one complete list, not assemble it from five fragments. Node ≥18 is a hard requirement for contributors/manual users and is effectively hidden.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P2", reasoning: "Prerequisites are scattered across four inconsistent locations; Node ≥18 is hidden in a troubleshooting footnote and OS support is never stated." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: false,
+        reasoning: "Single-source, unrefuted. Advisory P2. Consolidate Prerequisites into one place: Claude Code v1.0+, a supported surface, Pro/Max or API access, Node ≥18 (for tests/manual clone), OS. Node ≥18 currently only appears in a troubleshooting footnote.",
+        finalSeverity: "P2",
+        severityChangeReason: ""
+      },
+      fixRecommendation: {
+        summary: "Make the \"Prerequisites\" section the single source of truth: Claude Code v1.0+, supported surface, Pro/Max or API, Node ≥18, OS.",
+        proposedChange: "Consolidate all requirements into the \"Prerequisites\" section (around line 399): Claude Code v1.0+, a supported surface (link the surfaces list), Claude Pro/Max or API access, Node ≥18 (for tests/manual clone), OS support (state \"macOS/Linux/Windows — anywhere Claude Code runs\" or whatever is accurate), VoltAgent optional. Remove or cross-link the duplicate requirement fragments elsewhere.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — consolidating scattered requirement text into one section.",
+        estimatedEffort: "1 hr"
+      },
+      crossRefs: [
+        { targetId: "AI-10", relationship: "same-class", note: "Both AI-10 and AI-12 consolidate scattered onboarding/setup info into one findable place." }
+      ],
+      priorRuns: []
+    },
+    {
+      id: "AI-13",
+      summary: "P3 bundle: move the Vocabulary glossary up; add a \"finding looks wrong\" troubleshooting entry; note outputs aren't renameable; define or drop \"Schliff optimization (75 → 86)\"; reconcile the \"Claude Code surfaces\" vs. Agent SDK claim.",
+      severity: "P3",
+      epistemicLabel: "[SINGLE-SOURCE]",
+      defectType: null,
+      sourceReviewers: ["Clarity Editor", "Completeness Checker", "Devil's Advocate"],
+      verificationTier: null,
+      verificationVerdict: null,
+      verificationConfidence: null,
+      evidenceSummary: "A bundle of minor, individually low-impact polish items: glossary placement, a missing troubleshooting entry, undocumented output-naming constraints, an undefined \"Schliff\" metric, and a mild headline-scope contradiction with the Agent SDK.",
+      fullEvidence: "",
+      narrative: "A P3 bundle of minor items drawn from three reviewers, several of which the reviewers themselves flagged as their least-defensible findings.\n\nClarity Editor (F7): \"Move the Vocabulary table up — either right after the intro or as the first subsection of 'How It Works.' The README explicitly says 'This README uses these words consistently' and then provides the glossary as the second-to-last content section. The reader who needed it has already finished or given up.\"\n\nCompleteness Checker (P2-6, P2-7): \"State explicitly that output filenames and location are not configurable... Add a Troubleshooting entry for 'a finding looks wrong or overstated' tying the symptom to the epistemic-label/defect-type system and the HUMAN REVIEW RECOMMENDED flag.\"\n\nDevil's Advocate (F11, F12 — both self-identified as thin): \"'Schliff optimization (75 → 86)' is an undefined number presented as achievement — 75 → 86 of what? No unit, no scale, no definition anywhere. Define the score and the A/B setup, or remove the parenthetical.\" And: \"The hero callout says 'Runs only on Claude Code surfaces' then the Installation section adds the Agent SDK as a fourth supported surface. Make line 13 consistent.\"",
+      codeEvidence: [],
+      reviewerRatings: [
+        { reviewerId: "p-1", reviewerName: "Clarity Editor", rating: "P3", reasoning: "The Vocabulary glossary defining load-bearing terms sits ~550 lines below where those terms are first used." },
+        { reviewerId: "p-3", reviewerName: "Completeness Checker", rating: "P3", reasoning: "Minor gaps: output-naming constraints undocumented and no recovery guidance for when a finding itself is wrong." },
+        { reviewerId: "p-4", reviewerName: "Devil's Advocate", rating: "P3", reasoning: "Self-identified as thin — an undefined \"Schliff\" metric and a mild headline-scope contradiction with the Agent SDK." }
+      ],
+      debateTranscript: [],
+      judgeRuling: {
+        disputed: true,
+        reasoning: "Bundled the smallest items into a single P3 action. The Devil's Advocate self-identified F10 (grandiose naming) and F11 (Schliff metric) as its weakest findings; F10 is downgraded to this P3 bundle (the substantive part of F10 just restates the AI-11 framing critique), and F11 is folded in as a clean, fixable factual gap. Clarity's F7 (glossary placement) and the Completeness Checker's P2-6/P2-7 round out the bundle. None individually warrants its own action item; together they are a worthwhile polish pass.",
+        finalSeverity: "P3",
+        severityChangeReason: "Devil's Advocate F10 (grandiose naming) was self-identified as the reviewer's weakest finding and downgraded into this P3 bundle rather than carried as a standalone item."
+      },
+      fixRecommendation: {
+        summary: "A polish pass: relocate the Vocabulary glossary, add a \"finding looks wrong\" troubleshooting entry, document output-naming constraints, define or drop \"Schliff (75→86),\" and reconcile the surfaces-vs-SDK claim.",
+        proposedChange: "Move the Vocabulary glossary up (or add an early pointer to it). Add a Troubleshooting entry for \"a finding looks wrong\" tying the symptom to epistemic labels, defect types, and the HUMAN REVIEW RECOMMENDED flag, with a \"re-run with --runs 3 to test finding stability\" hint. State explicitly that output filenames and location are not configurable (rename/move the three review_panel_* files between runs). Define the \"Schliff optimization (75 → 86)\" score and its A/B setup, or remove the parenthetical. Make the line-13 \"Runs only on Claude Code surfaces\" headline consistent with the Agent SDK being listed as supported.",
+        beforeCode: "",
+        afterCode: "",
+        regressionTest: "",
+        blastRadius: "Low — a collection of small, independent text edits.",
+        estimatedEffort: "4 hr"
+      },
+      crossRefs: [],
+      priorRuns: []
+    }
+  ]
+};
+
+/* ============================ HELPERS ============================ */
+function escapeHtml(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function initials(name) {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+const COLOR_MAP = {
+  indigo:'#6366f1', blue:'#3b82f6', cyan:'#06b6d4', teal:'#14b8a6', green:'#22c55e',
+  emerald:'#10b981', violet:'#8b5cf6', purple:'#a855f7', fuchsia:'#d946ef', rose:'#f43f5e',
+  orange:'#f97316', amber:'#f59e0b', slate:'#64748b', zinc:'#71717a'
+};
+function personaColor(id) {
+  const p = reviewData.personas.find(x => x.id === id);
+  if (p) return COLOR_MAP[p.avatar_color] || '#64748b';
+  if (id === 'judge') return COLOR_MAP.slate;
+  return '#64748b';
+}
+function personaById(id) { return reviewData.personas.find(x => x.id === id); }
+function personaByName(name) { return reviewData.personas.find(x => x.name === name); }
+
+const SEV_ORDER = { P0:0, P1:1, P2:2, P3:3 };
+const SEV_STRIPE = { P0:'border-red-500', P1:'border-orange-500', P2:'border-yellow-500', P3:'border-slate-500' };
+const SEV_CHIP = {
+  P0:'bg-red-900/60 text-red-300', P1:'bg-orange-900/60 text-orange-300',
+  P2:'bg-yellow-900/60 text-yellow-300', P3:'bg-slate-700 text-slate-300'
+};
+const EPI_CHIP = {
+  '[VERIFIED]':'bg-green-900/60 text-green-300',
+  '[CONSENSUS]':'bg-blue-900/60 text-blue-300',
+  '[SINGLE-SOURCE]':'bg-yellow-900/60 text-yellow-300',
+  '[UNVERIFIED]':'bg-slate-700 text-slate-300',
+  '[DISPUTED]':'bg-red-900/60 text-red-300'
+};
+const EPI_TOOLTIP = {
+  '[VERIFIED]':'Confirmed by claim verification AND at least 2 reviewers independently',
+  '[CONSENSUS]':'3+ reviewers agreed, not independently verified',
+  '[SINGLE-SOURCE]':'Only one reviewer raised this, unverified',
+  '[UNVERIFIED]':'Cited but not confirmed against source material',
+  '[DISPUTED]':'Reviewers explicitly disagreed, resolution was forced',
+  '[VR_CONFIRMED]':'Verification agent independently confirmed the claim',
+  '[VR_REFUTED]':'Verification agent found the claim to be incorrect',
+  '[VR_NEW_FINDING]':'Verification revealed an additional issue',
+  '[EXISTING_DEFECT]':'This bug exists in the current running code',
+  '[PLAN_RISK]':'This is a risk that would materialize if the plan is implemented as written'
+};
+const EPI_GENERIC_CHIP = {
+  '[VR_CONFIRMED]':'bg-emerald-900/60 text-emerald-300',
+  '[VR_REFUTED]':'bg-red-900/60 text-red-300',
+  '[VR_NEW_FINDING]':'bg-purple-900/60 text-purple-300',
+  '[EXISTING_DEFECT]':'bg-red-900/60 text-red-300',
+  '[PLAN_RISK]':'bg-amber-900/60 text-amber-300'
+};
+
+/* ============================ FILTER STATE ============================ */
+let filters = { severity:'all', tier:'all', verdict:'all', epistemic:'all', reviewer:null, search:'' };
+let sortBy = 'severity';
+
+function applyFilters() {
+  let items = reviewData.actionItems.slice();
+  if (filters.severity !== 'all') items = items.filter(i => i.severity === filters.severity);
+  if (filters.tier !== 'all') items = items.filter(i => i.verificationTier === filters.tier);
+  if (filters.verdict !== 'all') {
+    if (filters.verdict === 'none') items = items.filter(i => !i.verificationVerdict);
+    else items = items.filter(i => i.verificationVerdict === filters.verdict);
+  }
+  if (filters.epistemic !== 'all') items = items.filter(i => i.epistemicLabel === filters.epistemic);
+  if (filters.reviewer) {
+    const p = personaById(filters.reviewer);
+    if (p) items = items.filter(i => i.sourceReviewers.includes(p.name));
+  }
+  if (filters.search) {
+    const q = filters.search.toLowerCase();
+    items = items.filter(i =>
+      (i.id + ' ' + i.summary + ' ' + i.narrative + ' ' + i.evidenceSummary).toLowerCase().includes(q));
+  }
+  const confRank = { High:0, Medium:1, Low:2, null:3 };
+  const tierRank = { Light:0, Standard:1, Deep:2, null:3 };
+  items.sort((a,b) => {
+    if (sortBy === 'severity') return SEV_ORDER[a.severity] - SEV_ORDER[b.severity] || a.id.localeCompare(b.id);
+    if (sortBy === 'confidence') return (confRank[a.verificationConfidence]??3) - (confRank[b.verificationConfidence]??3) || a.id.localeCompare(b.id);
+    if (sortBy === 'tier') return (tierRank[a.verificationTier]??3) - (tierRank[b.verificationTier]??3) || a.id.localeCompare(b.id);
+    return 0;
+  });
+  return items;
+}
+
+/* ============================ RENDER: ISSUE CARDS ============================ */
+function renderItems(items) {
+  const container = document.getElementById('issues-container');
+  const total = reviewData.actionItems.length;
+  document.getElementById('live-count').textContent = `Showing ${items.length} of ${total} items`;
+
+  if (items.length === 0) {
+    container.innerHTML = `<div class="card bg-slate-900 border border-slate-800 rounded-lg p-6 text-center text-slate-400">
+      No items match the current filters. <button id="clear-all-filters" class="text-indigo-400 hover:text-white underline">Clear filters &#10005;</button></div>`;
+    const cab = document.getElementById('clear-all-filters');
+    if (cab) cab.addEventListener('click', clearAllFilters);
+    return;
+  }
+
+  container.innerHTML = items.map(renderIssueCard).join('');
+  attachCardListeners();
+  try { if (window.Prism) Prism.highlightAll(); } catch(e) {}
+}
+
+function renderRaisedByChips(item) {
+  return item.sourceReviewers.map(name => {
+    const p = personaByName(name);
+    const color = p ? COLOR_MAP[p.avatar_color] : '#64748b';
+    const pid = p ? p.id : '';
+    return `<button class="raised-by-chip inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold text-white" style="background:${color}" data-pid="${pid}" title="${escapeHtml(name)}">${initials(name)}</button>`;
+  }).join('');
+}
+
+function renderIssueCard(item) {
+  const stripe = SEV_STRIPE[item.severity] || 'border-slate-500';
+  const sevChip = SEV_CHIP[item.severity] || 'bg-slate-700 text-slate-300';
+  const epiChip = EPI_CHIP[item.epistemicLabel] || 'bg-slate-700 text-slate-300';
+  const verdictBadge = item.verificationVerdict
+    ? `<span class="px-2 py-0.5 rounded text-xs font-semibold bg-slate-700 text-slate-200">${escapeHtml(item.verificationVerdict)}</span>` : '';
+  const tierChip = item.verificationTier
+    ? `<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-900/60 text-blue-300">${escapeHtml(item.verificationTier)}</span>` : '';
+  const defectChip = item.defectType
+    ? `<span class="px-2 py-0.5 rounded text-xs font-semibold ${EPI_GENERIC_CHIP[item.defectType]||'bg-slate-700 text-slate-300'}" title="${escapeHtml(EPI_TOOLTIP[item.defectType]||'')}">${escapeHtml(item.defectType)}</span>` : '';
+
+  // confidence bar
+  let confBar = '';
+  if (item.verificationTier && item.verificationConfidence) {
+    const lvl = item.verificationConfidence;
+    const w = lvl === 'High' ? '100%' : lvl === 'Medium' ? '50%' : '25%';
+    const col = lvl === 'High' ? 'bg-green-500' : lvl === 'Medium' ? 'bg-yellow-500' : 'bg-red-500';
+    confBar = `<div class="mt-2">
+      <div class="h-1.5 bg-slate-800 rounded-full overflow-hidden"><div class="h-full ${col}" style="width:${w}"></div></div>
+      <div class="text-[10px] text-slate-500 mt-0.5">Verification confidence: ${escapeHtml(lvl)}</div></div>`;
+  }
+
+  return `<details class="issue-card card bg-slate-900 border border-slate-800 border-l-4 ${stripe} rounded-lg" id="issue-${item.id}" tabindex="0">
+    <summary class="p-4">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-baseline gap-2">
+            <code class="text-xs text-slate-500">${escapeHtml(item.id)}</code>
+            <span class="font-semibold text-white">${escapeHtml(item.summary)}</span>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-1.5">
+          <span class="px-2 py-0.5 rounded text-xs font-bold ${sevChip}">${escapeHtml(item.severity)}</span>
+          <span class="px-2 py-0.5 rounded text-xs font-semibold ${epiChip}" title="${escapeHtml(EPI_TOOLTIP[item.epistemicLabel]||'')}">${escapeHtml(item.epistemicLabel)}</span>
+          ${defectChip}${verdictBadge}${tierChip}
+          <span class="text-slate-500 text-xs">&#9662;</span>
+        </div>
+      </div>
+      ${confBar}
+      <div class="mt-2 flex items-center gap-1.5 flex-wrap">
+        <span class="text-xs text-slate-500">Raised by:</span>
+        ${renderRaisedByChips(item)}
+      </div>
+    </summary>
+    <div class="px-4 pb-4">
+      <div class="section-accordion">
+        ${renderNarrative(item)}
+        ${renderCodeEvidence(item)}
+        ${renderRaisedBySection(item)}
+        ${renderVerificationTrail(item)}
+        ${renderDebate(item)}
+        ${renderJudgeRuling(item)}
+        ${renderFixRecommendation(item)}
+        ${renderCrossRefs(item)}
+        ${renderEpistemicTags(item)}
+        ${renderPriorRuns(item)}
+      </div>
+    </div>
+  </details>`;
+}
+
+function proseWithCode(text) {
+  // escape, then turn `backticks` into inline code, preserve paragraph breaks
+  const esc = escapeHtml(text);
+  const withCode = esc.replace(/`([^`]+)`/g, '<code class="bg-slate-800 px-1 rounded">$1</code>');
+  return withCode.split(/\n\n+/).map(p => `<p class="mb-2">${p.replace(/\n/g, '<br>')}</p>`).join('');
+}
+
+function renderNarrative(item) {
+  const body = item.narrative && item.narrative.trim()
+    ? `<div class="text-sm text-slate-300">${proseWithCode(item.narrative)}</div>`
+    : `<div class="text-sm text-slate-500 italic">No narrative captured for this finding.</div>`;
+  return `<details open><summary>&#128214; Narrative</summary>${body}</details>`;
+}
+
+function renderCodeEvidence(item) {
+  let body;
+  if (item.codeEvidence && item.codeEvidence.length) {
+    body = item.codeEvidence.map(ce => `
+      <div class="mt-3">
+        <div class="code-evidence-header">
+          <span class="file-path">${escapeHtml(ce.file)}</span>
+          <span class="line-range">${escapeHtml(ce.lineRange)}</span>
+          <span class="caption">${escapeHtml(ce.caption || '')}</span>
+        </div>
+        <pre class="max-h-96 overflow-y-auto rounded"><code class="language-${escapeHtml(ce.language||'text')}">${escapeHtml(ce.snippet)}</code></pre>
+      </div>`).join('');
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">No code evidence captured for this finding. The reviewer may have raised this as a design/framing concern rather than a concrete code defect.</div>`;
+  }
+  return `<details open><summary>&#128196; Code Evidence</summary>${body}</details>`;
+}
+
+function renderRaisedBySection(item) {
+  let body;
+  if (item.reviewerRatings && item.reviewerRatings.length) {
+    body = `<div class="grid grid-cols-1 md:grid-cols-2 gap-3">` + item.reviewerRatings.map(r => {
+      const color = personaColor(r.reviewerId);
+      const sevChip = SEV_CHIP[r.rating] || 'bg-slate-700 text-slate-300';
+      const diff = r.rating !== item.severity
+        ? `<div class="text-xs text-yellow-400 mt-1">Rated ${escapeHtml(r.rating)}, final ${escapeHtml(item.severity)}</div>` : '';
+      return `<div class="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50">
+        <div class="flex items-center gap-2">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold text-white" style="background:${color}">${initials(r.reviewerName)}</span>
+          <span class="font-semibold text-sm text-white">${escapeHtml(r.reviewerName)}</span>
+          <span class="ml-auto px-2 py-0.5 rounded text-xs font-bold ${sevChip}">${escapeHtml(r.rating)}</span>
+        </div>
+        <div class="text-sm text-slate-300 italic mt-2">${escapeHtml(r.reasoning)}</div>
+        ${diff}
+      </div>`;
+    }).join('') + `</div>`;
+  } else if (item.sourceReviewers && item.sourceReviewers.length) {
+    body = `<div class="flex flex-wrap gap-2">` + item.sourceReviewers.map(name => {
+      const p = personaByName(name);
+      const color = p ? COLOR_MAP[p.avatar_color] : '#64748b';
+      return `<span class="inline-flex items-center gap-2 bg-slate-800/50 rounded-full pl-1 pr-3 py-1">
+        <span class="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold text-white" style="background:${color}">${initials(name)}</span>
+        <span class="text-xs text-slate-300">${escapeHtml(name)}</span></span>`;
+    }).join('') + `</div>`;
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">No raised-by data for this finding.</div>`;
+  }
+  return `<details open><summary>&#128101; Raised by</summary>${body}</details>`;
+}
+
+function renderVerificationTrail(item) {
+  let body;
+  if (item.verificationTier) {
+    const verdictBanners = {
+      VR_CONFIRMED:['bg-green-900/40 border-green-600 text-green-200','&#10003; Claim independently confirmed by verification agent'],
+      VR_REFUTED:['bg-red-900/40 border-red-600 text-red-200','&#9888; Claim was refuted — recommend downgrading or removing this action item'],
+      VR_PARTIAL:['bg-amber-900/40 border-amber-600 text-amber-200','&#9680; Claim partially confirmed — some details verified, others refuted'],
+      VR_INCONCLUSIVE:['bg-slate-800 border-slate-600 text-slate-300','? Verification was inconclusive — needs further investigation'],
+      VR_NEW_FINDING:['bg-purple-900/40 border-purple-600 text-purple-200','&#128269; Verification revealed an additional issue']
+    };
+    const vb = verdictBanners[item.verificationVerdict];
+    body = `
+      <div class="text-sm text-slate-300">
+        <p class="font-semibold text-slate-200">What was investigated:</p>
+        <p class="mb-2">${escapeHtml(item.evidenceSummary || '')}</p>
+        <p class="font-semibold text-slate-200">Key evidence:</p>
+        <blockquote class="border-l-4 border-blue-500 pl-3 italic text-slate-300 mb-2">${escapeHtml(item.evidenceSummary || '')}</blockquote>
+        <p class="font-semibold text-slate-200">Full investigation trail:</p>
+        <pre class="max-h-96 overflow-y-auto text-xs bg-slate-950 p-3 rounded">${escapeHtml(item.fullEvidence || '')}</pre>
+      </div>
+      ${vb ? `<div class="mt-3 px-3 py-2 rounded border ${vb[0]} text-sm">${vb[1]}</div>` : ''}`;
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">This finding was not dispatched to a verification agent (Phase 13 was skipped or this finding was not disputed).`
+      + (item.fullEvidence ? ` Orchestrator claim-verification notes:</div><pre class="mt-2 max-h-96 overflow-y-auto text-xs bg-slate-950 p-3 rounded">${escapeHtml(item.fullEvidence)}</pre>`
+      : `</div>`);
+  }
+  return `<details open><summary>&#128269; Verification Trail</summary>${body}</details>`;
+}
+
+function renderDebate(item) {
+  let body;
+  if (item.debateTranscript && item.debateTranscript.length) {
+    body = item.debateTranscript.map(d => {
+      const p = personaByName(d.reviewer);
+      const color = p ? COLOR_MAP[p.avatar_color] : '#64748b';
+      return `<div class="debate-bubble">
+        <div class="avatar" style="background:${color}">${initials(d.reviewer)}</div>
+        <div class="content-box">
+          <div class="flex items-center gap-2">
+            <span class="font-semibold text-sm text-white">${escapeHtml(d.reviewer)}</span>
+            <span class="text-xs bg-slate-700 px-2 py-0.5 rounded-full">Round ${escapeHtml(String(d.round))}</span>
+          </div>
+          <div class="text-sm text-slate-300 mt-1">${escapeHtml(d.content)}</div>
+        </div>
+      </div>`;
+    }).join('');
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">This finding was not debated in Phase 5 (no open dispute between reviewers).</div>`;
+  }
+  return `<details open><summary>&#128172; Debate</summary>${body}</details>`;
+}
+
+function renderJudgeRuling(item) {
+  let body;
+  if (item.judgeRuling) {
+    const jr = item.judgeRuling;
+    const callout = jr.severityChangeReason && jr.severityChangeReason.trim()
+      ? `<div class="mt-3 p-3 border-l-4 border-yellow-500 bg-yellow-950/20 rounded-r-lg">
+           <span class="font-semibold text-yellow-300">Severity adjusted:</span>
+           <span class="text-sm text-slate-300"> ${escapeHtml(jr.severityChangeReason)}</span></div>` : '';
+    body = `
+      <div class="flex items-center gap-2 mb-2">
+        <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold text-white" style="background:${COLOR_MAP.slate}">SJ</span>
+        <span class="font-semibold text-sm text-white">Supreme Judge</span>
+        ${jr.disputed ? '<span class="px-2 py-0.5 rounded text-xs bg-red-900/60 text-red-300">Disputed</span>' : '<span class="px-2 py-0.5 rounded text-xs bg-slate-700 text-slate-300">No dispute</span>'}
+      </div>
+      <div class="text-sm text-slate-300">${proseWithCode(jr.reasoning)}</div>
+      ${callout}`;
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">The Supreme Judge did not arbitrate this finding (no dispute required resolution).</div>`;
+  }
+  return `<details open><summary>&#9878;&#65039; Judge Ruling</summary>${body}</details>`;
+}
+
+function renderFixRecommendation(item) {
+  const fr = item.fixRecommendation;
+  let body;
+  if (!fr) {
+    body = `<div class="text-sm text-slate-500 italic">No fix recommendation data for this finding.</div>`;
+    return `<details open><summary>&#128736;&#65039; Fix Recommendation</summary>${body}</details>`;
+  }
+  const hasDetail = fr.proposedChange || fr.beforeCode || fr.afterCode || fr.regressionTest || fr.blastRadius;
+  if (!hasDetail) {
+    body = `<div class="p-3 bg-slate-800/50 rounded text-sm text-slate-300">${escapeHtml(fr.summary||'')}</div>
+      <div class="text-sm text-slate-500 italic mt-2">Fix details not specified — see Narrative section for reviewer's recommendation.</div>`;
+    return `<details open><summary>&#128736;&#65039; Fix Recommendation</summary>${body}</details>`;
+  }
+  let codeBlock = '';
+  const lang = (item.codeEvidence && item.codeEvidence[0] && item.codeEvidence[0].language) || 'text';
+  if (fr.beforeCode && fr.afterCode) {
+    codeBlock = `<div class="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+      <div><div class="text-xs font-semibold text-red-300 mb-1">Before</div>
+        <pre class="bg-red-950/30 border border-red-800/50 rounded max-h-96 overflow-y-auto"><code class="language-${escapeHtml(lang)}">${escapeHtml(fr.beforeCode)}</code></pre></div>
+      <div><div class="text-xs font-semibold text-green-300 mb-1">After</div>
+        <pre class="bg-green-950/30 border border-green-800/50 rounded max-h-96 overflow-y-auto"><code class="language-${escapeHtml(lang)}">${escapeHtml(fr.afterCode)}</code></pre></div>
+    </div>`;
+  } else if (fr.beforeCode) {
+    codeBlock = `<div class="mt-3"><div class="text-xs font-semibold text-red-300 mb-1">Before</div>
+      <pre class="bg-red-950/30 border border-red-800/50 rounded max-h-96 overflow-y-auto"><code class="language-${escapeHtml(lang)}">${escapeHtml(fr.beforeCode)}</code></pre></div>`;
+  } else if (fr.afterCode) {
+    codeBlock = `<div class="mt-3"><div class="text-xs font-semibold text-green-300 mb-1">After</div>
+      <pre class="bg-green-950/30 border border-green-800/50 rounded max-h-96 overflow-y-auto"><code class="language-${escapeHtml(lang)}">${escapeHtml(fr.afterCode)}</code></pre></div>`;
+  }
+  const regTest = fr.regressionTest && fr.regressionTest.trim()
+    ? `<div class="mt-3"><div class="text-xs font-semibold text-slate-300 mb-1">&#129514; Regression test to add:</div>
+       <div class="bg-slate-900 p-3 rounded text-xs font-mono text-slate-300">${escapeHtml(fr.regressionTest)}</div></div>` : '';
+  const blastClass = { Low:'chip-low', Medium:'chip-med', High:'chip-high' };
+  let blastChip = '';
+  if (fr.blastRadius) {
+    const lvl = fr.blastRadius.split(/[\s—-]/)[0];
+    blastChip = `<span class="chip ${blastClass[lvl]||'chip-blue'}">Blast: ${escapeHtml(fr.blastRadius)}</span>`;
+  }
+  const effortChip = fr.estimatedEffort ? `<span class="chip chip-blue">Effort: ${escapeHtml(fr.estimatedEffort)}</span>` : '';
+  body = `
+    <div class="text-sm text-slate-300">${proseWithCode(fr.proposedChange || fr.summary || '')}</div>
+    ${codeBlock}
+    ${regTest}
+    <div class="mt-3 flex flex-wrap gap-2">${blastChip}${effortChip}</div>`;
+  return `<details open><summary>&#128736;&#65039; Fix Recommendation</summary>${body}</details>`;
+}
+
+function renderCrossRefs(item) {
+  let body;
+  if (item.crossRefs && item.crossRefs.length) {
+    const relClass = {
+      'root-cause':'xref-root-cause', 'same-class':'xref-same-class',
+      'depends-on':'xref-depends-on', 'blocks':'xref-blocks'
+    };
+    body = `<div class="space-y-2">` + item.crossRefs.map(cr => `
+      <div class="text-sm text-slate-300">
+        <a href="#issue-${escapeHtml(cr.targetId)}" class="xref-link ${relClass[cr.relationship]||'xref-same-class'}" data-target="${escapeHtml(cr.targetId)}">${escapeHtml(cr.targetId)}: ${escapeHtml(cr.relationship)}</a>
+        <span class="italic ml-2 text-slate-400">${escapeHtml(cr.note)}</span>
+      </div>`).join('') + `</div>`;
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">No related findings. This finding stands alone.</div>`;
+  }
+  return `<details open><summary>&#128279; Cross-references</summary>${body}</details>`;
+}
+
+function renderEpistemicTags(item) {
+  const tags = [item.epistemicLabel];
+  if (item.defectType) tags.push(item.defectType);
+  if (item.verificationVerdict) tags.push('[' + item.verificationVerdict.replace(/^VR_/, 'VR_') + ']');
+  const chipClass = Object.assign({}, EPI_CHIP, EPI_GENERIC_CHIP);
+  const body = `<div class="flex flex-wrap gap-2">` + tags.map(t => {
+    const cls = chipClass[t] || 'bg-slate-700 text-slate-300';
+    const tip = EPI_TOOLTIP[t] || '';
+    return `<span class="chip ${cls}" title="${escapeHtml(tip)}">${escapeHtml(t)}
+      <span class="info-icon cursor-pointer" data-tip="${escapeHtml(tip)}">&#8505;&#65039;</span></span>`;
+  }).join('') + `</div>`;
+  return `<details open><summary>&#127991;&#65039; Epistemic Tags</summary>${body}</details>`;
+}
+
+function renderPriorRuns(item) {
+  let body;
+  if (item.priorRuns && item.priorRuns.length) {
+    body = `<div class="bg-slate-900/50 rounded-lg overflow-hidden text-sm">
+      <table class="w-full"><thead class="bg-slate-800 text-slate-300"><tr>
+        <th class="text-left px-3 py-1.5">Run</th><th class="text-left px-3 py-1.5">Severity</th>
+        <th class="text-left px-3 py-1.5">Rating</th><th class="text-left px-3 py-1.5">Note</th>
+      </tr></thead><tbody class="divide-y divide-slate-800">` + item.priorRuns.map(r => `
+        <tr><td class="px-3 py-1.5 font-mono text-xs">${escapeHtml(r.runLabel)}</td>
+        <td class="px-3 py-1.5"><span class="px-2 py-0.5 rounded text-xs font-bold ${SEV_CHIP[r.severity]||'bg-slate-700 text-slate-300'}">${escapeHtml(r.severity)}</span></td>
+        <td class="px-3 py-1.5"><span class="chip chip-blue">${escapeHtml(r.rating)}</span></td>
+        <td class="px-3 py-1.5 text-slate-400">${escapeHtml(r.note)}</td></tr>`).join('') + `</tbody></table></div>`;
+  } else {
+    body = `<div class="text-sm text-slate-500 italic">No prior-run data available (this is a single-run review, not a meta-comparison).</div>`;
+  }
+  return `<details open><summary>&#128202; Prior Runs</summary>${body}</details>`;
+}
+
+/* ============================ CARD LISTENERS ============================ */
+function attachCardListeners() {
+  document.querySelectorAll('.issue-card').forEach(card => {
+    card.addEventListener('toggle', () => {
+      if (card.open) history.replaceState(null, '', '#' + card.id);
+    });
+  });
+  document.querySelectorAll('.raised-by-chip').forEach(chip => {
+    chip.addEventListener('click', (e) => {
+      e.preventDefault(); e.stopPropagation();
+      const pid = chip.getAttribute('data-pid');
+      if (pid) setReviewerFilter(pid);
+    });
+  });
+  document.querySelectorAll('.xref-link').forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const targetId = link.getAttribute('data-target');
+      const target = document.getElementById('issue-' + targetId);
+      if (target) {
+        target.open = true;
+        target.scrollIntoView({ behavior:'smooth', block:'start' });
+        target.classList.add('issue-highlight');
+        setTimeout(() => target.classList.remove('issue-highlight'), 2000);
+      }
+    });
+  });
+  document.querySelectorAll('.info-icon').forEach(icon => {
+    icon.addEventListener('click', (e) => {
+      e.preventDefault(); e.stopPropagation();
+      alert(icon.getAttribute('data-tip'));
+    });
+  });
+}
+
+/* ============================ REVIEWER FILTER ============================ */
+function setReviewerFilter(pid) {
+  if (filters.reviewer === pid) { filters.reviewer = null; }
+  else { filters.reviewer = pid; }
+  updateReviewerBanner();
+  updateGalleryHighlights();
+  renderItems(applyFilters());
+  if (filters.reviewer) {
+    document.getElementById('action-items-section').scrollIntoView({ behavior:'smooth', block:'start' });
+  }
+}
+function updateReviewerBanner() {
+  const banner = document.getElementById('reviewer-filter-banner');
+  const text = document.getElementById('reviewer-filter-text');
+  if (filters.reviewer) {
+    const p = personaById(filters.reviewer);
+    text.textContent = `Filtered to items raised by ${p ? p.name : filters.reviewer}`;
+    banner.classList.remove('hidden');
+  } else {
+    banner.classList.add('hidden');
+  }
+}
+function updateGalleryHighlights() {
+  document.querySelectorAll('.persona-card').forEach(c => {
+    if (c.getAttribute('data-pid') === filters.reviewer) {
+      c.classList.add('ring-2','ring-yellow-400');
+    } else {
+      c.classList.remove('ring-2','ring-yellow-400');
+    }
+  });
+}
+function clearAllFilters() {
+  filters = { severity:'all', tier:'all', verdict:'all', epistemic:'all', reviewer:null, search:'' };
+  sortBy = 'severity';
+  document.getElementById('filter-severity').value = 'all';
+  document.getElementById('filter-tier').value = 'all';
+  document.getElementById('filter-verdict').value = 'all';
+  document.getElementById('filter-epistemic').value = 'all';
+  document.getElementById('sort-by').value = 'severity';
+  document.getElementById('search-box').value = '';
+  updateReviewerBanner();
+  updateGalleryHighlights();
+  renderItems(applyFilters());
+}
+
+/* ============================ PANEL GALLERY ============================ */
+function renderPersonaCards() {
+  const gallery = document.getElementById('panel-gallery');
+  // Sub-group A — Panel Reviewers
+  const reviewerCards = reviewData.personas.map(p => {
+    const color = COLOR_MAP[p.avatar_color] || '#64748b';
+    const phaseBadges = p.phases_active.map(ph =>
+      `<span class="px-1.5 py-0.5 rounded text-[10px] bg-slate-800 text-slate-400">Phase ${ph}</span>`).join(' ');
+    return `<div class="persona-card card bg-slate-900 border border-slate-800 rounded-lg p-4 cursor-pointer hover:border-slate-600 transition-all" data-pid="${p.id}">
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center justify-center w-10 h-10 rounded-full text-sm font-bold text-white" style="background:${color}">${initials(p.name)}</span>
+        <div>
+          <div class="font-semibold text-white">${escapeHtml(p.name)}</div>
+          <div class="text-xs text-slate-400">${escapeHtml(p.role)}</div>
+        </div>
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3 text-xs text-slate-300">
+        <span>&#127919; ${p.agreement_intensity}%</span>
+        <span>&#129504; ${escapeHtml(p.reasoning_strategy)}</span>
+        <span>&#128203; ${p.items_raised.length} items raised</span>
+      </div>
+      <div class="flex flex-wrap gap-1 mt-2">${phaseBadges}</div>
+      <div class="text-xs text-slate-500 italic mt-2">${escapeHtml(p.domain_focus)}</div>
+    </div>`;
+  }).join('');
+
+  // Sub-group C — Support Agents
+  const supportCards = reviewData.supportAgents.map(a => {
+    return `<div class="card bg-slate-900 border border-slate-800 rounded-lg p-3" title="${escapeHtml(a.role)}">
+      <div class="flex items-center gap-2">
+        <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold text-white" style="background:${COLOR_MAP.zinc}">${initials(a.name)}</span>
+        <div>
+          <div class="text-sm font-semibold text-white">${escapeHtml(a.name)}</div>
+          <div class="text-[11px] text-slate-400 leading-tight">${escapeHtml(a.role.length > 90 ? a.role.slice(0,90)+'…' : a.role)}</div>
+        </div>
+      </div>
+      <div class="mt-2"><span class="px-1.5 py-0.5 rounded text-[10px] bg-slate-800 text-slate-400">${escapeHtml(a.phase)}</span></div>
+    </div>`;
+  }).join('');
+
+  gallery.innerHTML = `
+    <div class="mb-6">
+      <h3 class="text-sm font-semibold text-slate-300 mb-3">Panel Reviewers <span class="text-slate-500">(${reviewData.personas.length})</span></h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">${reviewerCards}</div>
+      <p class="text-xs text-slate-500 mt-2">Click a reviewer card to filter the Action Items list to items they raised; click again to clear.</p>
+    </div>
+    <div class="border-t border-slate-800 pt-6 mb-6">
+      <h3 class="text-sm font-semibold text-slate-300 mb-3">Verification Specialists</h3>
+      <p class="text-sm text-slate-500 italic">No Phase 13 verification specialists were dispatched — this was a pure-documentation review and claim verification was performed directly by the orchestrator (Phases 8–11).</p>
+    </div>
+    <div class="border-t border-slate-800 pt-6">
+      <h3 class="text-sm font-semibold text-slate-300 mb-3">Support Agents</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">${supportCards}</div>
+      <p class="text-xs text-slate-500 mt-2">Hover a card for the full role description.</p>
+    </div>`;
+
+  gallery.querySelectorAll('.persona-card').forEach(c => {
+    c.addEventListener('click', () => setReviewerFilter(c.getAttribute('data-pid')));
+  });
+  updateGalleryHighlights();
+}
+
+/* ============================ SCORE TABLE ============================ */
+function renderScoreTable() {
+  const tbody = document.getElementById('score-table-body');
+  const scoreColor = (s) => s >= 7 ? 'text-green-400' : s >= 4 ? 'text-yellow-400' : 'text-red-400';
+  tbody.innerHTML = reviewData.scoreTable.map(r => {
+    const delta = r.final - r.initial;
+    const deltaStr = delta === 0 ? '0' : (delta > 0 ? '+' : '') + delta;
+    return `<tr class="hover:bg-slate-800/40">
+      <td class="px-4 py-2 font-semibold text-white">${escapeHtml(r.reviewer)}
+        <span class="ml-2 px-1.5 py-0.5 rounded text-[10px] bg-slate-800 text-slate-400">&#127919; ${r.intensity}%</span></td>
+      <td class="px-4 py-2 text-slate-400 text-xs">${escapeHtml(r.persona)}</td>
+      <td class="px-4 py-2 text-center font-bold ${scoreColor(r.initial)}">${r.initial}</td>
+      <td class="px-4 py-2 text-center font-bold ${scoreColor(r.final)}">${r.final}</td>
+      <td class="px-4 py-2 text-center text-slate-400">${deltaStr}</td>
+      <td class="px-4 py-2 text-slate-300 text-xs">${escapeHtml(r.recommendation)}</td>
+    </tr>`;
+  }).join('');
+}
+
+/* ============================ CHARTS ============================ */
+function initCharts() {
+  if (typeof Chart === 'undefined') {
+    document.querySelectorAll('canvas').forEach(c => {
+      const wrap = c.parentElement;
+      wrap.innerHTML = '<div class="flex items-center justify-center h-full text-xs text-slate-500">Charts unavailable (CDN unreachable)</div>';
+    });
+    return;
+  }
+  Chart.defaults.color = '#94a3b8';
+  Chart.defaults.borderColor = 'rgba(51,65,85,0.4)';
+
+  // Score gauge (doughnut)
+  try {
+    new Chart(document.getElementById('chart-score'), {
+      type: 'doughnut',
+      data: { datasets: [{ data: [5,5], backgroundColor: ['#f97316','#1e293b'], borderWidth: 0 }] },
+      options: { responsive: true, maintainAspectRatio: false, cutout: '72%',
+        plugins: { legend: { display: false }, tooltip: { enabled: false } } }
+    });
+  } catch(e) {}
+
+  // Confidence distribution — grouped bar by reviewer (per-finding confidence)
+  // No Phase 13 verification confidence available; show items-raised counts per reviewer instead, by severity.
+  try {
+    const reviewers = reviewData.personas.map(p => p.name);
+    const p1 = [], p2 = [], p3 = [];
+    reviewData.personas.forEach(p => {
+      let c1 = 0, c2 = 0, c3 = 0;
+      p.items_raised.forEach(id => {
+        const it = reviewData.actionItems.find(a => a.id === id);
+        if (!it) return;
+        if (it.severity === 'P1') c1++;
+        else if (it.severity === 'P2') c2++;
+        else if (it.severity === 'P3') c3++;
+      });
+      p1.push(c1); p2.push(c2); p3.push(c3);
+    });
+    new Chart(document.getElementById('chart-confidence'), {
+      type: 'bar',
+      data: {
+        labels: reviewers,
+        datasets: [
+          { label: 'P1', data: p1, backgroundColor: '#f97316' },
+          { label: 'P2', data: p2, backgroundColor: '#eab308' },
+          { label: 'P3', data: p3, backgroundColor: '#64748b' }
+        ]
+      },
+      options: { responsive: true, maintainAspectRatio: false,
+        scales: { x: { stacked: false, ticks: { font: { size: 9 } } }, y: { beginAtZero: true, ticks: { precision: 0 } } },
+        plugins: { legend: { position: 'bottom', labels: { boxWidth: 10, font: { size: 10 } } },
+          title: { display: true, text: 'Action items raised, by reviewer & severity', font: { size: 10 } } } }
+    });
+  } catch(e) {}
+
+  // Severity breakdown — bar
+  try {
+    new Chart(document.getElementById('chart-severity'), {
+      type: 'bar',
+      data: {
+        labels: ['P0','P1','P2','P3'],
+        datasets: [{ label: 'Action items', data: [0,4,8,1],
+          backgroundColor: ['#ef4444','#f97316','#eab308','#64748b'] }]
+      },
+      options: { responsive: true, maintainAspectRatio: false,
+        scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
+        plugins: { legend: { display: false } } }
+    });
+  } catch(e) {}
+
+  // Epistemic label breakdown — horizontal bar
+  try {
+    const labelCounts = {};
+    reviewData.actionItems.forEach(i => {
+      labelCounts[i.epistemicLabel] = (labelCounts[i.epistemicLabel] || 0) + 1;
+    });
+    const labels = Object.keys(labelCounts);
+    const colorByLabel = {
+      '[VERIFIED]':'#22c55e', '[CONSENSUS]':'#3b82f6', '[SINGLE-SOURCE]':'#eab308',
+      '[UNVERIFIED]':'#64748b', '[DISPUTED]':'#ef4444'
+    };
+    new Chart(document.getElementById('chart-epistemic'), {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{ label: 'Action items', data: labels.map(l => labelCounts[l]),
+          backgroundColor: labels.map(l => colorByLabel[l] || '#64748b') }]
+      },
+      options: { indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+        scales: { x: { beginAtZero: true, ticks: { precision: 0 } } },
+        plugins: { legend: { display: false } } }
+    });
+  } catch(e) {}
+}
+
+/* ============================ COLLAPSIBLE SECTIONS ============================ */
+function setupToggles() {
+  document.querySelectorAll('.toggle-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const t = document.getElementById(btn.getAttribute('data-target'));
+      if (t) t.classList.toggle('hidden');
+    });
+  });
+  const galleryToggle = document.getElementById('gallery-toggle');
+  galleryToggle.addEventListener('click', () => {
+    const g = document.getElementById('panel-gallery');
+    g.classList.toggle('hidden');
+    galleryToggle.textContent = g.classList.contains('hidden') ? 'Expand' : 'Collapse';
+  });
+  const scoreToggle = document.getElementById('score-toggle');
+  scoreToggle.addEventListener('click', () => {
+    const b = document.getElementById('score-body');
+    b.classList.toggle('hidden');
+    scoreToggle.textContent = b.classList.contains('hidden') ? 'Expand' : 'Collapse';
+  });
+  const consensusToggle = document.getElementById('consensus-toggle');
+  consensusToggle.addEventListener('click', () => {
+    const b = document.getElementById('consensus-body');
+    b.classList.toggle('hidden');
+    consensusToggle.textContent = b.classList.contains('hidden') ? 'Expand' : 'Collapse';
+  });
+}
+
+/* ============================ FILTER BAR ============================ */
+function setupFilterBar() {
+  document.getElementById('filter-severity').addEventListener('change', e => { filters.severity = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('filter-tier').addEventListener('change', e => { filters.tier = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('filter-verdict').addEventListener('change', e => { filters.verdict = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('filter-epistemic').addEventListener('change', e => { filters.epistemic = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('sort-by').addEventListener('change', e => { sortBy = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('search-box').addEventListener('input', e => { filters.search = e.target.value; renderItems(applyFilters()); });
+  document.getElementById('expand-all').addEventListener('click', () => {
+    document.querySelectorAll('.issue-card:not(.hidden)').forEach(d => d.open = true);
+  });
+  document.getElementById('collapse-all').addEventListener('click', () => {
+    document.querySelectorAll('.issue-card:not(.hidden)').forEach(d => d.open = false);
+  });
+  document.getElementById('clear-reviewer-filter').addEventListener('click', () => setReviewerFilter(filters.reviewer));
+}
+
+/* ============================ KEYBOARD NAV ============================ */
+function setupKeyboardNav() {
+  const container = document.getElementById('issues-container');
+  container.addEventListener('keydown', (e) => {
+    const cards = Array.from(document.querySelectorAll('.issue-card:not(.hidden)'));
+    if (cards.length === 0) return;
+    const active = document.activeElement;
+    let idx = cards.indexOf(active);
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      idx = idx < 0 ? 0 : Math.min(idx + 1, cards.length - 1);
+      cards[idx].focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      idx = idx < 0 ? 0 : Math.max(idx - 1, 0);
+      cards[idx].focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault(); cards[0].focus();
+    } else if (e.key === 'End') {
+      e.preventDefault(); cards[cards.length - 1].focus();
+    }
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+      e.preventDefault();
+      document.getElementById('search-box').focus();
+    }
+  });
+}
+
+/* ============================ DEEP LINKING ============================ */
+function handleDeepLink() {
+  const hash = window.location.hash;
+  const m = hash.match(/^#issue-(.+)$/);
+  if (m) {
+    const id = m[1];
+    if (reviewData.actionItems.find(a => a.id === id)) {
+      const el = document.getElementById('issue-' + id);
+      if (el) {
+        el.open = true;
+        setTimeout(() => {
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          el.classList.add('issue-highlight');
+          setTimeout(() => el.classList.remove('issue-highlight'), 2000);
+        }, 100);
+      }
+    }
+  }
+}
+
+/* ============================ PRISM ============================ */
+function setupPrism() {
+  try {
+    if (window.Prism && Prism.plugins && Prism.plugins.autoloader) {
+      Prism.plugins.autoloader.languages_path = 'https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/';
+    }
+  } catch(e) {}
+}
+
+/* ============================ INIT ============================ */
+document.addEventListener('DOMContentLoaded', () => {
+  setupPrism();
+  renderPersonaCards();
+  renderScoreTable();
+  renderItems(applyFilters());
+  setupToggles();
+  setupFilterBar();
+  setupKeyboardNav();
+  initCharts();
+  handleDeepLink();
+  try { if (window.Prism) Prism.highlightAll(); } catch(e) {}
+});
+</script>
+</body>
+</html>

--- a/docs/reviews/2026-05-14-readme/review_panel_report.md
+++ b/docs/reviews/2026-05-14-readme/review_panel_report.md
@@ -1,0 +1,114 @@
+# Review Panel Report
+
+**Work reviewed:** `README.md` (671 lines)  |  **Date:** 2026-05-14
+**Panel:** 4 reviewers + Completeness Audit + Supreme Judge
+**Verdict:** REVISE — substantial edit needed  |  **Confidence:** Medium-High
+**Auto-detected signals:** None — documentation base set used
+**Review mode:** Exhaustive (auto-detected: pure documentation)
+**Data flow trace:** Skipped (pure documentation — no code data transforms)
+
+## Executive Summary
+
+The README is factually careful where it counts — install commands, marketplace
+handles, slash commands, the "401 tests" claim, and spot-checked anchors all
+verify cleanly against the repo — and it is exhaustively thorough. But three
+problems pull the score to **5/10**: (1) the version/release story is incoherent
+and actively misleads every current user, (2) the document is roughly a third too
+long and consistently serves the maintainer and changelog over the newcomer, and
+(3) it never shows what a review actually produces. None of the defects are hard
+to fix; their volume is the problem. All four reviewers independently anchored on
+the version/release issue — score spread was only 2.0, and all four reviewers run
+on the same base model, so treat the convergence with mild caution.
+
+## Scope & Limitations
+
+Reviewed: the text of `README.md`, cross-checked against `SKILL.md`, `CHANGELOG.md`,
+`package.json`, `.claude-plugin/*.json`, `docs/research-foundations.md`, and git
+tags. Not evaluated: the rendered GitHub appearance, image/GIF contents, or whether
+the documented product behaviour is itself correct. Structural limitation: all four
+reviewers are Claude instances — shared model bias is possible.
+
+Epistemic labels used: `[VERIFIED]` (confirmed against source), `[CONSENSUS]`
+(3+ reviewers independently), `[SINGLE-SOURCE]` (one reviewer, unrefuted),
+`[DISPUTED]` (reviewers split).
+
+## Score Summary
+
+| Reviewer | Persona | Intensity | Score | Recommendation |
+|---|---|---|---|---|
+| Clarity Editor | Communicates clearly to its audience? | 60% | 5.5/10 | Cut ~⅓; split reader vs. maintainer content |
+| Technical Accuracy | Every claim correct vs. the repo? | 30% | 4/10 | Fix phase table, release story, label glossary |
+| Completeness Checker | What's missing the reader needs? | 40% | 6/10 | Operationally exhaustive but evaluator-hostile |
+| Devil's Advocate | Does it persuade or mislead? | 20% | 4.5/10 | Documents unreleased versions; vanity metrics |
+| **Judge** | **Final** | — | **5/10** | **REVISE before relying on it for onboarding** |
+
+## Consensus Points (judge-confirmed)
+
+- **Version/release story is broken** — all four reviewers, independently. `package.json`
+  and both manifests declare `3.3.0`; the only git tags that exist are `v2.10.0,
+  v2.16.5, v3.0.0, v3.1.0`. The "Updating" section tells users to verify their
+  install against "the latest GitHub release" — which resolves to `v3.1.0`, so every
+  correctly-installed v3.3.0 user concludes their install is wrong. The release badge
+  renders `v3.1.0` while the prose says v3.3; hero images are pinned to the `v3.1.0`
+  tag. `[VERIFIED][CONSENSUS]`
+- **Too long, wrong audience** — the README mixes user docs, contributor docs, and
+  design-history/author-archaeology in 671 lines; inline `(v2.16.3)`-style version
+  attributions read as changelog bookkeeping, not user documentation. `[CONSENSUS]`
+- **Migration / stale-state cleanup is bloated and duplicated** — the same "remove old
+  marketplace name, delete orphan dirs, remove loose clones, reinstall" procedure
+  appears in 4–5 non-identical places (~30% of the file is migration/troubleshooting).
+  `[CONSENSUS]`
+
+## Disagreement Points (with judge rulings)
+
+- **Devil's Advocate rated the version/release issue P0; judge dampened to P1.**
+  Reasoning: the README can be made fully correct without a release-process change
+  (re-point the verify step, fix the badge, re-pin images). The untagged-release gap
+  itself is a repo-process issue outside README scope. Still ranked the #1 action item.
+- **"Credibility theater" / "vanity metrics" / "one model talking to itself" (DA).**
+  Partially upheld. The README *does* disclose the shared-base-model limitation, so it
+  is not dishonest — but the disclosure is buried at line 381 while the top of the doc
+  sells "independent reviewers." Ruling: P2 — move the limitation up, soften
+  "independent." The only hard factual defect in the research claims is the
+  "peer-reviewed" qualifier (AutoGen has no venue). The 9-paper count is accurate.
+- **Grandiose-naming finding (DA F10)** — reviewer self-identified as weakest;
+  downgraded to P3. **Output-files-explained-3× (Clarity F15)** — reviewer
+  self-identified as weakest; merged into the duplication finding, not carried separately.
+
+## Completeness Audit Findings
+
+- `docs/archive/review_panel_report.md` is a real, full sample report (6,920 bytes)
+  that exists in-repo and is **never linked** — the README shows output only as GIFs.
+  `[VERIFIED]`
+- The "How It Works" table is two releases stale: SKILL.md defines **Phase 13.5**
+  (Pre-Judge Verification Gate, v3.1.0) and **Phase 14.5** (Post-Judge Verification
+  Gate, v3.2.0); neither appears in the README's headline table. `[VERIFIED]`
+- The epistemic-labels glossary omits `[JUDGE-HALLUCINATED]` and `[COMPRESSED]`, both
+  real shipped labels. `[VERIFIED]`
+- A prior README restructure attempt is archived at
+  `docs/archive/2026-04-27-readme-restructure-rejected/` — read why it was rejected
+  before attempting another.
+
+## Action Items (severity + epistemic labels)
+
+| # | Severity | Action |
+|---|---|---|
+| 1 | **P1** `[VERIFIED][CONSENSUS]` | Fix the version/release story: tag `v3.2.0`/`v3.3.0`, **or** re-point the "Updating" verify step at `package.json`/`CHANGELOG.md` (not GitHub releases) + note releases may lag `main`; bump the `(e.g. 3.1.0)` example to `3.3.0`; re-pin the three hero-image URLs to a current tag or `main`. |
+| 2 | **P1** `[VERIFIED]` | Add Phase 13.5 and Phase 14.5 rows to the "How It Works" table; reconcile the "sequential integers 1–16" prose. |
+| 3 | **P1** `[CONSENSUS]` | Cut ~⅓ of the length and split audiences — move migration/stale-state/deep troubleshooting to `MIGRATION.md` + `TROUBLESHOOTING.md`; move design-history to `HOW_WE_BUILT_THIS.md`. Target ~250–350 lines. |
+| 4 | **P1** `[VERIFIED]` | Add a text sample of a real report (Action Items table + one judged disagreement) in a `<details>` block; link `docs/archive/review_panel_report.md`. |
+| 5 | **P2** `[CONSENSUS]` | Strip inline `(vX.Y)` attributions from reader-facing prose; describe features in present tense. |
+| 6 | **P2** `[SINGLE-SOURCE]` | Slim the opening: H1, one-sentence tagline, one hero image, one "Claude Code only" note, then Quick Start. |
+| 7 | **P2** `[SINGLE-SOURCE]` | Surface "When to use / When NOT to use" near the top (from SKILL.md); add a one-line cost-and-fit statement under the hero. |
+| 8 | **P2** `[VERIFIED]` | Change "9 peer-reviewed papers" → "9 research papers/projects"; separate architecture-mapped papers from inspirational ones. |
+| 9 | **P2** `[VERIFIED]` | Add `[JUDGE-HALLUCINATED]` and `[COMPRESSED]` to the epistemic-labels glossary; sync the Quick Start mini-list with the full table. |
+| 10 | **P2** `[SINGLE-SOURCE]` | Add a "Support" section; expand "Contributing" with a real dev on-ramp. |
+| 11 | **P2** `[SINGLE-SOURCE]` | Move the "same base model" limitation up into "Why Use a Panel"; reframe "independent reviewers" as "structured multi-stance self-critique." |
+| 12 | **P2** `[SINGLE-SOURCE]` | Consolidate Prerequisites into one place (incl. Node ≥18, currently only in a troubleshooting footnote). |
+| 13 | **P3** `[SINGLE-SOURCE]` | Move the Vocabulary glossary up; add a "finding looks wrong" troubleshooting entry; note outputs aren't renameable; define or drop "Schliff optimization (75 → 86)"; reconcile "Runs only on Claude Code surfaces" vs. the Agent SDK being supported. |
+
+## Detailed Reviews
+
+Full verbatim reviewer output, the judge ruling, and verification notes are in the
+companion process log: `review_panel_process.md`. Per-reviewer state files are under
+`state/`.

--- a/docs/reviews/2026-05-14-readme/state/phase_14_judge_ruling.md
+++ b/docs/reviews/2026-05-14-readme/state/phase_14_judge_ruling.md
@@ -1,0 +1,71 @@
+# Phase 14 — Supreme Judge Ruling
+
+**Work reviewed:** `README.md` (671 lines)
+**Panel:** Clarity Editor, Technical Accuracy Reviewer, Completeness Checker, Devil's Advocate + Completeness Audit + Verification
+**Review mode:** Exhaustive (pure documentation)
+**Date:** 2026-05-14
+
+## Step 0 — Verification review
+
+Independently confirmed against the repo:
+
+- **Remote git tags:** only `v2.10.0, v2.16.5, v3.0.0, v3.1.0` exist. No `v3.2.0`/`v3.3.0`. `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` all declare `3.3.0`. → version/release finding **[VERIFIED]**.
+- **SKILL.md** Process Overview includes `Phase 13.5` (v3.1.0) and `Phase 14.5` (v3.2.0); README "How It Works" table lists only integer phases 1–16. → stale-table finding **[VERIFIED]**.
+- **`docs/archive/review_panel_report.md`** exists (6,920 bytes) and is never linked from the README. → "no text sample" finding **[VERIFIED]**.
+- **`docs/research-foundations.md`** has exactly 9 paper rows (count correct) but lists **AutoGen** with venue `—`. → "9 peer-reviewed papers" qualifier **[VERIFIED] inaccurate**; "9 papers" count **accurate**.
+- **`.github/workflows/test.yml`** exists; `npm test` → 401/401 pass. → Tests badge + "401 tests" **accurate**.
+- Inline `(vX.Y)` version attributions appear throughout reader-facing prose (10+ confirmed instances). → **[VERIFIED]**.
+- Install handles, marketplace name, slash commands, all six `npm run test:*` scripts, and spot-checked anchors → **accurate**.
+
+## Step 0.5 — Severity dampening
+
+- Devil's Advocate rated the version/release finding **P0**. Dampened to **P1**: the README itself can be made fully correct without a release-process change (point the verify step at `package.json`/`CHANGELOG`, fix the badge, re-pin images). The underlying untagged-release gap is a repo-process issue outside README scope. Still ranked **#1 priority**.
+- Devil's Advocate F10 (grandiose naming) — self-identified as weakest; reduced to **P3**. F3/F5 (credibility theater / vanity metrics) retain a verified factual core ("peer-reviewed" overclaim) at **P2**; the framing critique is advisory **[SINGLE-SOURCE]**.
+- Clarity F15 (output files explained 3×) — reviewer self-identified as least defensible; merged into F2/F5 duplication finding, not carried as a separate item.
+
+## Step 1–3 — Consensus and disagreement
+
+**Strong consensus (3–4 reviewers, independently):**
+1. Version/release story is incoherent and actively misleads current users — *all four reviewers*.
+2. README is too long and serves the maintainer/changelog over the newcomer — Clarity (whole review), DA F7/F9, Completeness (lopsided).
+3. Inline `(vX.Y)` version-attribution noise in reader-facing prose — Clarity F3, DA F7.
+4. Migration / stale-state cleanup content is bloated and duplicated across 4–5 locations — Clarity F5, DA F6.
+
+**Single-source but verified (no reviewer refuted):**
+- Stale "How It Works" phase table — Technical P1-1.
+- No text sample of a real report; a real one sits unlinked in `docs/archive/` — Completeness P1-1.
+- Epistemic-labels glossary omits `[JUDGE-HALLUCINATED]`/`[COMPRESSED]` — Technical P2-11.
+- "When NOT to use" buried in SKILL.md — Completeness P1-3.
+- No support channel; thin Contributing — Completeness P1-4/P1-5.
+
+**Disputed / judgment (judge ruling):** DA's "credibility theater" and "one model talking to itself" framing — *partially upheld*. The README **does** disclose the shared-base-model limitation (Known Limitations), so it is not dishonest; but the disclosure is buried at line 381 while the top of the doc leans on "independent reviewers." Ruling: valid **P2** — move the limitation up and soften "independent" to "structured multi-stance self-critique." The research-grounding is legitimate to cite; the only hard defect is the "peer-reviewed" qualifier.
+
+## Step 4–5 — Score
+
+Reviewer scores: 5.5 / 4 / 6 / 4.5 → mean **5.0/10**. Spread 2.0 (moderate convergence — the version/release problem anchored every reviewer). No correlated-bias override needed, but noted: all four are the same base model.
+
+## Step 6–7 — Final verdict
+
+**Verdict: REVISE — substantial edit needed before this serves as the primary onboarding doc. Score 5/10. Confidence: Medium-High.**
+
+The README is factually careful where it counts (commands, counts, anchors all verify) and exhaustively thorough — but it is two releases stale on its central version story, roughly a third too long, and consistently prioritises maintainer/changelog content over the newcomer's path to first run. None of the defects are hard to fix; the volume of them is the problem.
+
+## Step 8 — Action items (severity + epistemic labels)
+
+1. **[P1][VERIFIED][CONSENSUS]** Fix the version/release story. Either tag `v3.2.0`/`v3.3.0`, or: change the "Updating" verify step to compare against `package.json`/`CHANGELOG.md` (not GitHub releases) and note releases may lag `main`; bump the `(e.g. 3.1.0)` example to `3.3.0`; re-pin the three hero-image URLs to a current tag or `main`. *Defect type: [EXISTING_DEFECT] — current instructions misfire for every v3.3.0 user.*
+2. **[P1][VERIFIED][SINGLE-SOURCE]** Update the "How It Works" table — add Phase 13.5 (Pre-Judge Verification Gate) and Phase 14.5 (Post-Judge Verification Gate); reconcile the "sequential integers 1–16" prose.
+3. **[P1][CONSENSUS]** Cut length ~⅓ and split audiences. Move migration / stale-state cleanup / deep troubleshooting to `MIGRATION.md` + `TROUBLESHOOTING.md` (or collapse to one canonical recipe with cross-links); move design-history/author-archaeology to `HOW_WE_BUILT_THIS.md`. Target ~250–350 lines for the README.
+4. **[P1][VERIFIED]** Add a text sample of a real report — lift ~15 lines (Action Items table + one judged disagreement) from `docs/archive/review_panel_report.md` into a `<details>` block, and link that file.
+5. **[P2][CONSENSUS]** Strip inline `(vX.Y)` attributions from How It Works / Features / Quick Start / Bundled skills. Describe features in present tense; leave history to the Version History table + CHANGELOG.
+6. **[P2][SINGLE-SOURCE]** Slim the opening — H1, one-sentence tagline, one hero image, one "Claude Code only" note, then Quick Start. Move the bundled-skills blockquote and surfaces detail into their existing sections.
+7. **[P2][SINGLE-SOURCE]** Surface "When to use / When NOT to use" near the top (source it from SKILL.md's list) and add a one-line cost-and-fit statement under the hero ("~$3–$20 per run, 6–15 min; for high-stakes reviews, not routine checks").
+8. **[P2][VERIFIED]** Fix "9 peer-reviewed papers" → "9 research papers/projects" (AutoGen has no venue); in Research Foundations, separate "mechanisms mapped to architecture" from "papers that informed thinking."
+9. **[P2][VERIFIED]** Add `[JUDGE-HALLUCINATED]` and `[COMPRESSED]` to the epistemic-labels glossary; sync the Quick Start mini-list with the full table.
+10. **[P2][SINGLE-SOURCE]** Add a "Support" section (GitHub Issues link + "include content type & size"); expand "Contributing" with a dev on-ramp (clone location, `npm test` + Node ≥18, where SKILL.md lives, `release-check.sh`).
+11. **[P2][SINGLE-SOURCE]** Move the "same base model" limitation up into "Why Use a Panel"; reframe "independent reviewers" as "structured multi-stance self-critique" — keep it honest, it's still a real benefit.
+12. **[P2][SINGLE-SOURCE]** Consolidate Prerequisites into one place (Claude Code v1.0+, supported surface, Pro/Max or API, Node ≥18 for tests/manual clone, OS). Node ≥18 currently only appears in a troubleshooting footnote.
+13. **[P3][SINGLE-SOURCE]** Move the Vocabulary glossary up (or add an early pointer); add a Troubleshooting entry for "a finding looks wrong" tying to epistemic labels + `HUMAN REVIEW RECOMMENDED`; note output filenames/location are not configurable; define or drop "Schliff optimization (75 → 86)"; reconcile "Runs only on Claude Code surfaces" with the Agent SDK being listed as supported.
+
+## Step 9 — Meta-observation
+
+The README's weaknesses are a mirror of the project's strengths: the same completionist instinct that produced a 16-phase verification pipeline produced a README that documents every phase, every rename, and every version bump. The fix is not more writing — it is subtraction and audience discipline. Notably, a previous restructure attempt is archived at `docs/archive/2026-04-27-readme-restructure-rejected/`; whoever revises should read why that one was rejected before starting.

--- a/docs/reviews/2026-05-14-readme/state/reviewer_clarity-editor_phase_3.md
+++ b/docs/reviews/2026-05-14-readme/state/reviewer_clarity-editor_phase_3.md
@@ -1,0 +1,125 @@
+# Phase 3 — Independent Review: Clarity Editor
+
+**Reviewer:** Clarity Editor
+**Persona:** Evaluates whether the document communicates clearly to its intended audience. First-principles reasoning — question every assumption, ask "would a first-time reader actually understand this?"
+**Agreement intensity:** 60%
+**Target:** `/home/user/agent-review-panel/README.md` (671 lines)
+**Mode:** Exhaustive (pure documentation)
+
+---
+
+## Score: 5.5 / 10
+
+The README is information-dense, factually careful, and well-cross-linked — a maintainer who knows the project will find it thorough. But it badly over-serves the maintainer at the newcomer's expense. It is far too long, the opening block is bloated, version-attribution noise (`(v2.16.3)`, `(v2.14)`) is scattered through reader-facing prose, and core points (the "two skills" pitch, install commands, migration/troubleshooting recipes) are repeated three to five times each. A first-time reader hits four dense blockquotes and three GIFs before reaching Quick Start, and the install section alone runs ~140 lines. It communicates *completely* but not *clearly*.
+
+---
+
+## Findings
+
+### F1 — [P1] Opening block is overloaded; reader hits 4 blockquotes + 3 images before Quick Start
+**Section:** Lines 1–33 (badges, hero, intro, blockquotes, Contents)
+**What's wrong:** Before a newcomer reaches a single actionable instruction (Quick Start at line 35), they must wade through: 3 badge lines, an H1, a 5-line bold tagline (line 7), a one-line plugin description (line 9), a 4-line blockquote about bundled skills + supported surfaces (lines 11–13), three stacked hero images/GIFs (lines 15–19), an italic caption (line 21), and a 10-line Contents list. That is roughly 33 lines of preamble. First-principles test: a reader who has "never heard of this" needs *what it is* and *how to start* — they get what it is four times over and how to start nowhere on screen one.
+**Why it matters:** The opening must earn attention efficiently. The current opening buries the value proposition under its own thoroughness and delays the payoff.
+**Fix:** Cut to: H1, one-sentence tagline, one hero image, one-line "Runs only on Claude Code surfaces" note, then Quick Start. Move the bundled-skills blockquote and the surfaces detail into their existing dedicated sections (they already exist — see F4). Demote two of the three GIFs to the HTML/How-It-Works sections where they are contextually relevant.
+
+### F2 — [P1] The "two skills bundled" point is stated at least five times
+**Sections:** Line 11 (intro blockquote), line 79 (Quick Start blockquote), lines 425–434 (Bundled skills section — the canonical home), line 436 (v3.0 layout blockquote), plus line 11/13 split. Also echoed in the Vocabulary table line 563.
+**What's wrong:** The single fact "one install gets you both skills" is repeated in the intro, in Quick Start, in its own section, and in the v3.0 callout. Each repetition is phrased slightly differently ("bundles two skills", "ships two skills", "one plugin bundling both skills"), which actively makes a careful reader wonder if there is a distinction.
+**Why it matters:** Genuine duplication inflates length and erodes trust — readers re-read to check whether a restatement carries new information.
+**Fix:** State it once in the intro in a single short clause ("one plugin, two skills — details below"), and once fully in the `Bundled skills` section. Delete the line 79 blockquote and fold the line 436 layout-history note into the Migration section.
+
+### F3 — [P1] Version-attribution tags litter reader-facing prose
+**Sections:** Line 93 `(new in v2.15)`, line 251 `(v2.16.4 disk-reading architecture)` / `(v2.14 cleanup)`, lines 256–270 table `*(v2.14, code only)*`, `*(v2.16.3)*`, `*(v2.15)*`, line 282 `(v2.16.3)`, line 419 `v2.14/v2.15`, line 431 `(v3.0.0)`, line 432 `(v2.0.1)`.
+**What's wrong:** A new user reading "How It Works" or "Features" does not care which release introduced a phase — that is changelog/maintainer information. The `(v2.16.3)` style annotations interrupt the reading flow and assume the reader has a mental model of the version timeline they do not have.
+**Why it matters:** Audience mismatch. This is maintainer bookkeeping presented as user documentation. It also dates the prose — a reader cannot tell if `(v2.15)` means "recent" or "ancient."
+**Fix:** Strip all `(vX.Y)` parentheticals from How It Works, Features, Quick Start, and Bundled skills. The CHANGELOG and the Version History table already carry this information for anyone who wants it.
+
+### F4 — [P1] Installation section is ~140 lines and mixes five distinct audiences
+**Section:** Lines 97–233 (`## Installation` through end of Cursor subsection)
+**What's wrong:** This single section serves: (a) newcomers who just need the two install commands (already in Quick Start), (b) people picking a surface, (c) people updating, (d) people debugging stale clones, (e) developers doing manual clones, (f) Cursor experimenters. The `Updating to the latest version` subsection (lines 129–189) alone is 60 lines with three nested `<details>` and a full clean-reinstall fallback — that is troubleshooting content, not installation.
+**Why it matters:** Findability collapses. A reader who just wants "how do I update" must scroll past surface-support tables and "why the marketplace path" essays. The section's length makes the whole README feel heavier than it is.
+**Fix:** Keep Installation to: Requires Claude Code (trimmed), the marketplace recommendation (a cross-link to Quick Start + the one load-bearing `@marketplace-name` callout), and a short Manual Clone subsection. Move `Updating to the latest version` and its stale-clone debugging into Troubleshooting, where the stale-clone content *already partially lives* (lines 524–532) — that is itself a duplication (see F6).
+
+### F5 — [P1] Migration and stale-state cleanup recipes are duplicated across three locations
+**Sections:** Quick Start "Upgrading from v2.x?" `<details>` (lines 61–77), `Updating to the latest version` stale-clone block (lines 156–168), `Migration from previous marketplaces` section (lines 447–510) including its own nested "Plugin install isn't working" `<details>` (lines 485–510), and Troubleshooting "Old version keeps loading" (lines 524–532) and "Migration / install state" (lines 550–552).
+**What's wrong:** The same cleanup procedure — remove old marketplace name, delete orphan dirs with trailing whitespace, remove loose `~/.claude/skills/` clones, reinstall — appears as: a paste-to-Claude prompt (Quick Start), a manual bash recipe (Migration `<details>`), a partial recipe (Updating), and a pointer-back (Troubleshooting twice). Five touchpoints for one procedure.
+**Why it matters:** This is the most severe genuine duplication in the document. A reader who hits the problem finds four overlapping-but-not-identical recipes and cannot tell which is authoritative. The maintenance burden also guarantees they will drift apart over time.
+**Fix:** One canonical Migration section with the full manual recipe and the optional paste-to-Claude prompt as a `<details>`. Everywhere else (Quick Start, Updating, Troubleshooting) becomes a one-line cross-link to it. Net deletion of ~60–80 lines.
+
+### F6 — [P1] Hero images pinned to `v3.1.0` while the project is v3.3.0 — and that tag may not even exist
+**Section:** Lines 15, 17, 19 (`raw.githubusercontent.com/.../v3.1.0/docs/...`)
+**What's wrong:** The three hero images/GIFs are pinned to the `v3.1.0` git tag URL. Per `package.json` the current version is `3.3.0`. Worse, per the context brief the only remote tags that exist are v2.10.0, v2.16.5, v3.0.0, v3.1.0 — there is no v3.3.0 tag at all, and the README's own badges (line 1) point at "latest release." So the document simultaneously claims to be a v3.3.0 product, shows v3.1.0-era hero art, and links a release badge that resolves to something older than the stated version.
+**Why it matters:** From a clarity lens this is an audience-trust problem: a reader who clicks the release badge and sees v3.1.0 (or 404s on a v3.3.0 link elsewhere) will distrust the rest of the doc. The hero images are the *first* visual a newcomer sees; pinning them to a stale tag means onboarding screenshots can silently lag the product.
+**Fix:** Pin hero image URLs to a tag that actually exists and matches a real release, or use `main` if the images are expected to track head. Reconcile the version story: either tag v3.3.0 or stop claiming v3.3.0 in `package.json`/headers. (Cross-domain with the version-consistency reviewer, but flagged here because the *reader-facing* inconsistency is a clarity defect.)
+
+### F7 — [P2] Jargon used before it is defined; the defining table is at the very bottom
+**Sections:** "reviewer", "panel", "judge", "subagent", "skill", "plugin" used freely from line 7 onward; the Vocabulary table that defines them is at lines 558–567, ~550 lines later.
+**What's wrong:** First-principles: a newcomer reading line 7 meets "AI reviewers", "a judge", line 9 "plugin", line 11 "skills", line 101 "subagent". The README explicitly says (line 558) "This README uses these words consistently" and then provides the glossary as the second-to-last content section. The reader who needed it has already finished or given up.
+**Why it matters:** Terms that carry precise, non-obvious distinctions (especially "agent/subagent is *not* a synonym for reviewer or skill", line 565) are load-bearing, but the disambiguation arrives after every place it was needed.
+**Fix:** Move the Vocabulary table up — either right after the intro or as the first subsection of "How It Works." At minimum, add a one-line "see Vocabulary" pointer near the top.
+
+### F8 — [P2] "How It Works" opens with a dense meta-paragraph about phase *numbering* instead of the pipeline
+**Section:** Lines 250–251
+**What's wrong:** The first thing a reader gets under "How It Works" is: "16 top-level phases + optional multi-run merge, numbered as sequential integers... Phase 15 is a parent step with three sub-steps... The v2.14 cleanup retired purely artifactual intermediate decimals like the old Phase 4.55; the load-bearing 15.x sub-steps are deliberate." This is a paragraph defending a renumbering decision to someone who remembers the old numbering — i.e., the maintainer. A newcomer does not know there was an old Phase 4.55 and does not care.
+**Why it matters:** The section's job is to explain how the panel works. It instead opens with internal-history justification, burying the lede (the actual phase table at line 253).
+**Fix:** Delete the meta-paragraph or reduce it to one sentence ("The pipeline runs 16 phases; Phase 15 has three output sub-steps."). Lead with the table.
+
+### F9 — [P2] The Features section is a wall of bold-prefixed bullets that doubles as a changelog
+**Section:** Lines 272–322
+**What's wrong:** ~50 lines of bullets, many 4–6 lines long (e.g., the "Data Flow Trace" bullet at line 288, the "Multi-Run Union Protocol" bullet at line 318), heavy bold-text density ("**External domain claims**", "**Live-State Claim Discipline:**", "**Force opus on all launches:**"). Several bullets read as changelog entries — "Force opus on all launches" (line 289) even explains the *bug it fixed* and what VoltAgent agents "silently fell through to," which is pure release-note material.
+**Why it matters:** Tone and density. When everything is bold, nothing is. The reader cannot skim for what the tool *does for them* versus what the maintainer *fixed*. Marketing density actively reduces information transfer.
+**Fix:** Cut each bullet to one or two lines describing the user-visible behavior. Move the "why we built it / what it fixed" narrative to CHANGELOG. Reduce bold to the feature name only.
+
+### F10 — [P2] The bold tagline at line 7 tries to do too much in one sentence
+**Section:** Line 7
+**What's wrong:** A single bolded sentence packs: the 4–6 reviewer concept, independence, debate, the judge, *and* names all three output artifacts with their exact filenames in backticks. It is a paragraph compressed into one breath, entirely in bold.
+**Why it matters:** The hero sentence should land one clear idea. Exact output filenames are detail, not pitch — and they are repeated at lines 90–94 and 298–313 anyway.
+**Fix:** Tagline = the one idea: "4–6 AI reviewers independently evaluate your code, plan, or docs, debate their findings, and a judge resolves disagreements." Drop the filenames here; they are covered three more times below.
+
+### F11 — [P2] Install commands appear in full at least four times
+**Sections:** Lines 40–42 (Quick Start, shell), lines 54–56 (Quick Start, REPL `<details>`), lines 461–462 (Migration), lines 505–506 (Migration `<details>`), plus the v3.0 CHANGELOG-style block is mirrored. Update variants add more (lines 133–136, 142–144), uninstall adds more (lines 610–615).
+**What's wrong:** The exact `marketplace add` + `install` pair recurs verbatim. Some recurrences are justified (uninstall is genuinely different), but the migration section re-prints the fresh-install pair that Quick Start already owns.
+**Why it matters:** Reinforces the overall sense that the README says everything several times. A reader copy-pasting cannot be sure two visually-similar blocks are identical.
+**Fix:** Quick Start owns the canonical install block. Migration ends with "...then run the standard install (see Quick Start)" rather than reprinting it.
+
+### F12 — [P3] Contents list is itself long and annotated, adding to preamble weight
+**Section:** Lines 23–32
+**What's wrong:** The Contents list has a parenthetical gloss on nearly every entry ("— install + first-run verification", "— the 16-phase pipeline"). Useful in principle, but it adds ~10 lines to an already-bloated opening (see F1).
+**Why it matters:** Minor, but every line before Quick Start is a line a newcomer pays for.
+**Fix:** Either keep the Contents list terse (no glosses) or move it below Quick Start. A README this structured arguably does not need a hand-maintained TOC at all — GitHub renders one automatically.
+
+### F13 — [P3] Three near-identical `<details>` "REPL-form equivalent" blocks
+**Sections:** Lines 48–59, 138–146, 179–189, 465–477; plus inline REPL note at line 615
+**What's wrong:** The "if you're inside a Claude Code session, use `/plugin` instead of `claude plugin`" pattern is explained once (lines 48–59, well) and then re-instantiated as a `<details>` block four more times.
+**Why it matters:** Minor duplication, but it pads several sections and the rule ("swap `claude plugin` for `/plugin`") is simple enough to state once.
+**Fix:** Explain the shell-form/REPL-form equivalence once in Quick Start. Elsewhere, show only the shell form with a one-line reminder, or drop the redundant `<details>` blocks.
+
+### F14 — [P3] "Why the plugin is named roundtable" is an internal-debate artifact
+**Section:** Lines 438–445 (`<details>`)
+**What's wrong:** This `<details>` answers a question approximately zero new users are asking, and the answer recapitulates a naming debate (collective noun, slash-command readability) that is really CHANGELOG/HOW_WE_BUILT_THIS material.
+**Why it matters:** Audience mismatch — it serves the maintainer's desire to document a decision, not the reader.
+**Fix:** Move to HOW_WE_BUILT_THIS.md or delete. If kept, compress to one sentence.
+
+### F15 — [P3] Output-files content is explained three separate times at three depths
+**Sections:** Lines 90–94 (Quick Start "What you get"), lines 298–313 (Features "Output"), lines 554–595 (Reading the Report)
+**What's wrong:** The three output files and the 10-section HTML card are described in Quick Start, then again in much greater depth in Features, then the report-reading vocabulary in "Reading the Report." There is a defensible progression here (teaser → detail → how-to-read), but the Features version and the Quick Start version overlap heavily without a clear division of labor.
+**Why it matters:** Less severe than F5/F2, but contributes to total length and the "didn't I just read this?" effect.
+**Fix:** Quick Start = one-line teaser per file. Features = the 10-section card detail. Reading the Report = vocabulary/severity/labels only. Remove the overlap where Quick Start and Features both enumerate card sections.
+
+---
+
+## Top 3 Most Defensible Findings
+
+1. **F5 — Migration/cleanup recipes duplicated across five locations.** This is concretely verifiable by line number, it is the largest single block of genuine duplication, and the recipes are *not* identical — which is exactly the failure mode that confuses readers and rots over time.
+2. **F1 — Overloaded opening / ~33 lines before Quick Start.** Directly checkable by counting lines 1–34. The newcomer-onboarding cost is immediate and unambiguous.
+3. **F3 — Version-attribution tags in reader-facing prose.** Every cited `(vX.Y)` is a literal string in the file; the audience-mismatch argument (changelog content in user docs) is hard to rebut.
+
+## Least Defensible Finding (self-critique)
+
+**F15 — Output files explained three times.** This is the weakest because there *is* a legitimate teaser → detail → how-to-read progression, and a reader benefits from seeing outputs previewed early and detailed later. My duplication complaint partly overlaps with the more clearly-wrong F2 and F5. A maintainer could reasonably argue the three passes serve three different reading moments, and they would be substantially right. I'd accept this being downgraded to a nit or merged into F2.
+
+---
+
+## Verdict
+
+A meticulously thorough README that documents everything at least once and the hard parts four or five times — it needs roughly a third cut, a slimmed opening, and a hard separation of reader content from maintainer/changelog content.

--- a/docs/reviews/2026-05-14-readme/state/reviewer_completeness-checker_phase_3.md
+++ b/docs/reviews/2026-05-14-readme/state/reviewer_completeness-checker_phase_3.md
@@ -1,0 +1,115 @@
+# Phase 3 — Independent Review: Completeness Checker
+
+**Reviewer:** Completeness Checker (agreement intensity 40%, exhaustive mode, checklist verification)
+**Target:** `/home/user/agent-review-panel/README.md` (671 lines)
+**Date:** 2026-05-14
+
+## Score: 6/10 (completeness)
+
+The README is long and covers install/migration/troubleshooting in exhaustive depth. But it is lopsided: operational mechanics are over-documented while several things a *first-time evaluator* needs are missing or buried — no text sample of an actual report, no surfaced "when NOT to use," a thin contributing section, no support channel, and a release story that is silently broken (plugin says v3.3.0; zero git tags exist; the README's own verification steps point users at a "latest release" that does not exist).
+
+---
+
+## Findings
+
+### P1-1 — No text sample of an actual report or finding
+**Gap:** The README describes the three output files extensively (sections at lines 90-95, 298-314) and links to demo GIFs, but never shows a single finding, action-item row, or `review_panel_report.md` snippet *as text*. A reader cannot tell what they will actually receive. The GIFs are images (not copy-pasteable, not accessible, not indexed by search), and `docs/archive/review_panel_report.md` is a real sample that exists in-repo but is **never linked**.
+**Where it should live:** New collapsible block in "Quick Start" under "What you get," or a "Sample Output" subsection before "How It Works."
+**Why a reader needs it:** This is the single biggest "should I run this?" question. Worked output is the most persuasive content a tool README can have, and one already exists unlinked in the repo.
+**Fix:** Add a `<details>` block with ~15 lines of a real Action Items table + one disagreement-with-judge-ruling excerpt, lifted from `docs/archive/review_panel_report.md`. Link that file explicitly: "See a full real report: [docs/archive/review_panel_report.md]."
+
+### P1-2 — Release/versioning story is broken and unactionable
+**Gap:** `package.json` and `.claude-plugin/plugin.json` declare v3.3.0; the Version History table documents v3.1/v3.2/v3.3. But `git tag` returns **zero tags** — there is no v3.2.0 or v3.3.0 (or any) GitHub release. Meanwhile the README tells users (lines 148-152, 479-483) to verify their install by comparing the cache directory name against "the [latest GitHub release]" and `gh release view`. Those checks will report a mismatch or fail for every user on v3.2+.
+**Where it should live:** "Updating to the latest version" (lines 129-154) and the release badge at line 1.
+**Why a reader needs it:** A user following the documented verification flow will conclude their install is broken when it is not. This is an actively misleading instruction.
+**Fix:** Either cut releases for v3.2.0/v3.3.0, or change the verification instruction to compare against `package.json` / `.claude-plugin/plugin.json` version (or `CHANGELOG.md` top entry) instead of GitHub releases, and note that releases may lag `main`.
+
+### P1-3 — "When NOT to use" is not surfaced; it's buried in SKILL.md
+**Gap:** `skills/agent-review-panel/SKILL.md` has a strong, specific "When NOT to Use This Skill" section (single code review, quick sanity checks, bug fixes, "what do you think?", etc.). The README only has scattered fragments — line 377 ("Not for quick code reviews...") and line 13. There is no consolidated decision section near the top, and SKILL.md's list is never linked.
+**Where it should live:** A short "When to use / When not to use" block right after the hero/intro, or folded into "Why Use a Panel."
+**Why a reader needs it:** Cost is $3-$20 per run. Telling someone clearly *not* to run it for a quick review saves them money and a bad first impression. The content already exists; it just needs surfacing.
+**Fix:** Add a two-column "Use it for / Don't use it for" block up high, sourced verbatim from SKILL.md's list.
+
+### P1-4 — No support channel / "where to get help" section
+**Gap:** Nowhere does the README say where to report a bug, ask a question, or get help. "Contributing" (line 605) says "open an issue to discuss before submitting large PRs" and Troubleshooting (line 548) says "file an issue" once, in passing — but there is no Support/Help section, no link to GitHub Issues, no Discussions, no issue-template pointer.
+**Where it should live:** A dedicated "Support" section near the end (before or after Contributing).
+**Why a reader needs it:** When a review hangs or produces a wrong finding, the user needs an obvious, findable path to report it. Right now they have to infer it.
+**Fix:** Add a "Support" section: link to GitHub Issues with a one-line "include content type + size" guidance, and Discussions if enabled.
+
+### P1-5 — Contributing section too thin for a contributor to actually start
+**Gap:** "Contributing" (lines 597-605) lists *what* help is wanted but nothing about *how*: no dev setup, no "clone and run `npm test`" pointer (tests are documented in a separate section at 405-423 but not linked from Contributing), no Node version requirement restated here, no PR process, no pointer to where `SKILL.md` lives or how the skill/manifest layout works, no mention of `scripts/release-check.sh` or the manifest invariants a PR must not break.
+**Where it should live:** Expand "Contributing."
+**Why a reader needs it:** A would-be contributor (the README explicitly solicits Cursor adaptation and new signal groups) has no on-ramp.
+**Fix:** Add: "Dev setup: clone (not into `~/.claude/skills/`), `npm test` (requires Node ≥18), edit `skills/agent-review-panel/SKILL.md`, run `scripts/release-check.sh` before release. PRs: open an issue first for large changes." Link the Tests section and `HOW_WE_BUILT_THIS.md`.
+
+### P2-6 — Output customization (filenames / location) not documented as configurable — because it isn't, but that's not stated
+**Gap:** The README states output filenames are fixed (`review_panel_report.md` etc.) and land in the session cwd, overwriting prior files (lines 386, 521). What it never answers: *can I change the filename or directory?* A reader wanting to keep a history of reviews, or run two reviews, has no guidance beyond "run one panel at a time per directory."
+**Where it should live:** "Known Limitations → Output location" or "Configuration / Modes."
+**Why a reader needs it:** Overwrite-by-default with no rename option is a real workflow constraint; users need to know to manually copy/rename outputs between runs.
+**Fix:** State explicitly: "Output filenames and location are not configurable. To keep multiple reviews, rename or move the three `review_panel_*` files (or `cd` to a fresh directory) before the next run."
+
+### P2-7 — Failure mode: "the panel produced a wrong finding" is not addressed
+**Gap:** Troubleshooting covers install/loading/HTML/hang failures, but not the most consequential failure: *the review itself is wrong.* The CHANGELOG's own v3.3.0 entry describes a real false-P0 incident. The epistemic-label system (lines 576-593) is the tool for acting on uncertain findings, but the README never says "if a finding looks wrong, check its epistemic label and defect type; `[STATIC-INFERENCE]`/`[UNVERIFIED]`/`[DISPUTED]` findings are the ones to scrutinize; `HUMAN REVIEW RECOMMENDED` flags low-judge-confidence verdicts."
+**Where it should live:** New Troubleshooting entry: "A finding looks wrong or overstated."
+**Why a reader needs it:** Multi-agent reviews *will* sometimes be wrong; the README markets verification heavily but gives no recovery guidance for when verification fails.
+**Fix:** Add a Troubleshooting entry tying the symptom to the epistemic-label/defect-type system and the `HUMAN REVIEW RECOMMENDED` flag, with "re-run with `--runs 3` to test finding stability."
+
+### P2-8 — Prerequisites are scattered across four locations and inconsistent
+**Gap:** Requirements appear in at least four places: line 13 (surfaces), lines 99-117 ("Requires Claude Code"), lines 206-208 ("Claude Code version requirement"), lines 399-403 ("Prerequisites"), and line 544 (Node ≥18, only in a Troubleshooting entry). Node version is *not* in the Prerequisites section at all — it only appears in a troubleshooting footnote. OS support is never stated anywhere.
+**Where it should live:** Consolidate into the "Prerequisites" section (line 399).
+**Why a reader needs it:** A reader checking "can I run this?" should find one complete list, not assemble it from five fragments. Node ≥18 is a hard requirement for contributors/manual users and is effectively hidden.
+**Fix:** Make "Prerequisites" the single source: Claude Code v1.0+, a supported surface (link the surfaces list), Claude Pro/Max or API access, Node ≥18 (for tests/manual clone), OS (state "macOS/Linux/Windows — anywhere Claude Code runs" or whatever is true), VoltAgent optional.
+
+### P2-9 — Comparison vs. Claude Code's built-in `/review` is missing
+**Gap:** "Why Use a Panel Instead of a Single Reviewer?" (lines 235-247) compares against ad-hoc "review this code." But Claude Code ships a built-in `/review` command and many readers will already use it. The README never positions itself against that specific, named alternative.
+**Where it should live:** "Why Use a Panel."
+**Why a reader needs it:** The honest question is "I already have `/review` — why pay $10 for this?" Not answering it leaves the value proposition incomplete.
+**Fix:** Add a sentence/row contrasting with built-in single-pass `/review`: panel adds independent multi-persona review, adversarial debate, judge adjudication, verification layer, and epistemic labeling — at higher cost/latency; use `/review` for routine, the panel for high-stakes.
+
+### P2-10 — Cost section omits what drives cost and has an unverifiable pricing basis
+**Gap:** The cost table (lines 369-377) gives dollar figures "at current Opus pricing" but never states the assumed per-token rate, so the numbers can't be checked or updated by the reader. It mentions reviewer count auto-scales 4-6 but doesn't connect that to the cost ranges. It also doesn't mention that `deep` mode and VoltAgent specialist agents add cost, or that the Multi-Run Union `--runs 3` triples it (the table says "3× base" but that's easy to miss).
+**Where it should live:** "Cost & Performance."
+**Why a reader needs it:** "~$10" is meaningless without the rate; pricing changes and the reader needs to recompute.
+**Fix:** State the assumed rate ("assumes Opus at $X/$Y per Mtok input/output, as of 2026-05") and a one-line "what drives cost: reviewer count (signal density), content size, debate rounds, `deep` mode, `--runs N` multiplier."
+
+### P3-11 — Privacy/security is one bullet; no consolidated statement, no telemetry/data-retention answer
+**Gap:** "Privacy & network" (line 385) covers outbound HTTPS from deep-research/Phase-11 and defers data handling to "Claude Code's standard data-handling policy" — but doesn't link that policy, doesn't state whether the plugin itself collects any telemetry/analytics (it appears not to — worth saying so explicitly), and doesn't address data retention of the output files (they're local, but that's only implied).
+**Where it should live:** Either expand the "Privacy & network" bullet or add a short "Privacy" section.
+**Why a reader needs it:** Anyone reviewing proprietary code needs an explicit, linkable answer. "Subject to Claude Code's policy" with no link is a dead end.
+**Fix:** Add: link to Anthropic/Claude Code data-handling docs; state "the plugin sends no telemetry of its own"; state "all three output files are written locally and never transmitted by the plugin"; reaffirm deep/web-verify modes are the only outbound calls and are skippable.
+
+### P3-12 — Accessibility / non-terminal users not addressed for the primary content (the GIFs)
+**Gap:** The README's main illustrations of *what the tool produces* are three animated GIFs (lines 15-19). There is no text alternative to the demo content itself (alt text exists but only names the image, doesn't convey the content). The HTML report's own accessibility is described (keyboard nav, print CSS), but the README's presentation of its value is image-only.
+**Where it should live:** Pair with the fix for P1-1 (text sample doubles as the accessible alternative).
+**Why a reader needs it:** Screen-reader users, users on slow/metered connections, and users viewing on platforms that don't autoplay GIFs get none of the demo's value.
+**Fix:** Adding the text report sample (P1-1) resolves this; also ensure GIF alt text is descriptive.
+
+### P3-13 — Licensing of *outputs* and bundled-CDN libraries not stated together
+**Gap:** The repo is MIT (line 658). The HTML report bundles Tailwind/Chart.js/Prism.js via CDN — line 540 notes in passing they're "MIT-licensed," but this is in a Troubleshooting entry, not the License section. Nothing states the *output files you generate* are yours to use freely (obvious, but worth one line for anyone reviewing client code).
+**Where it should live:** "License" section.
+**Why a reader needs it:** A user generating reports for a client wants explicit confirmation there are no strings on the output.
+**Fix:** Add to License: "Reports you generate are yours. The HTML dashboard loads Tailwind, Chart.js, and Prism.js from CDN — all MIT-licensed."
+
+### P3-14 — No "uninstall also clears state" guidance / migration leftovers
+**Gap:** "Uninstalling" (lines 607-620) covers the marketplace/clone uninstall commands but doesn't mention the `~/.claude/plugins/marketplaces/`, `~/.claude/plugins/cache/`, or `~/.claude/skills/` leftovers that the *Migration* and *Troubleshooting* sections spend dozens of lines cleaning up. A user who uninstalls and later reinstalls hits the exact stale-state problem the README documents elsewhere.
+**Where it should live:** "Uninstalling."
+**Why a reader needs it:** Consistency — the README treats stale state as a major hazard everywhere except the one section where the user is actively removing the plugin.
+**Fix:** Add a "Clean uninstall (remove all cached state)" note pointing to the same paths as the Migration cleanup recipe.
+
+---
+
+## Top 3 Most Defensible
+
+1. **P1-2 (broken release/versioning story)** — Objectively verifiable: `git tag` is empty, plugin is v3.3.0, and the README explicitly instructs users to verify against GitHub releases. Not an opinion.
+2. **P1-1 (no text report sample)** — A real sample (`docs/archive/review_panel_report.md`) exists in-repo and is unlinked; the README shows output only as GIFs. Concrete, easy to confirm, easy to fix.
+3. **P1-3 (when-NOT-to-use buried)** — SKILL.md has the content; the README doesn't surface or link it. The brief explicitly flagged this and it checks out.
+
+## Least Defensible
+
+1. **P3-12 (accessibility of GIFs)** — Real but largely subsumed by P1-1; on its own it's a stretch to call a separate finding.
+2. **P3-13 (output licensing)** — Mostly obvious from MIT; one line of polish, low reader impact.
+3. **P3-11 (telemetry/data retention)** — The README does address privacy/network; the gap is depth and a missing link, not absence. A reasonable maintainer could call the existing bullet "sufficient."
+
+## Verdict
+
+Operationally exhaustive but evaluator-hostile: the README never shows what a report looks like, buries "when not to use," lacks a support channel, and ships verification instructions that point at GitHub releases which don't exist.

--- a/docs/reviews/2026-05-14-readme/state/reviewer_devils-advocate_phase_3.md
+++ b/docs/reviews/2026-05-14-readme/state/reviewer_devils-advocate_phase_3.md
@@ -1,0 +1,177 @@
+# Phase 3 — Independent Review: Devil's Advocate
+
+**Reviewer:** Devil's Advocate
+**Persona:** Challenge everything. Skeptical of framing, credibility claims, and whether the README would persuade or mislead a real reader. Agreement intensity 20%.
+**Reasoning strategy:** Analogical — compare against known README failure patterns (overclaiming, vanity metrics, credibility theater, docs that serve the author's ego).
+**Mode:** Exhaustive.
+**Target:** `/home/user/agent-review-panel/README.md` (671 lines)
+
+---
+
+## Score: 4.5 / 10
+
+A technically dense, carefully written README that is nonetheless a credibility liability. It documents software that was never released under the version it claims, leans hard on vanity metrics and academic citations to manufacture authority, and buries the single most important fact a buyer needs — this is expensive and it's one model talking to itself — under 380 lines of self-admiring machinery and migration debris. It is well-edited prose in service of a fundamentally over-marketed artifact.
+
+---
+
+## Findings
+
+### F1 — [P0] The README documents two releases that do not exist
+
+**Location:** Lines 622–654 (Version History table — v3.2, v3.3 rows), line 9 / badges, plus every `(v3.2)`/`(v3.3)` inline reference; cross-ref `.claude-plugin/plugin.json` `"version": "3.3.0"`.
+
+**Problem:** The plugin self-reports `3.3.0` and the README's Version History table lists v3.2 and v3.3 with detailed, confident highlights ("Phase 14.5 re-verifies judge-introduced P0/P1...", "Live-State Claim Discipline... Wired into Phases 3/5/6/11/14"). But no `v3.2.0` or `v3.3.0` git/GitHub release tag exists — the latest tag is v3.1.0, and the hero images on lines 15/17/19 are pinned to `v3.1.0`. The README is describing software as shipped-and-versioned that was never actually cut as a release.
+
+**Why it matters:** This is the analogical twin of the classic "changelog written ahead of the release" failure — except here it has escaped into the marketing surface. A user who runs the update flow on line 152 (`gh release view`) will find v3.1.0 and conclude either (a) their install is broken, or (b) the README lies. Both are trust-destroying. The whole product is *about* verification and epistemic honesty; shipping a README whose central version claim fails its own falsification check (F1 is itself falsifiable by one `git tag` command no one ran) is self-refuting. The `[GitHub release]` badge on line 1 will render `v3.1.0` while the prose says 3.3 — a visible contradiction on first scroll.
+
+**Fix:** Either (a) actually tag and publish v3.2.0 and v3.3.0 so reality matches the README, or (b) revert the README and `plugin.json` to v3.1.0 and move the v3.2/v3.3 rows into an "Unreleased" section of CHANGELOG.md only. Do not ship a README that describes untagged versions as released. Re-pin hero images to whatever the actual latest tag is.
+
+---
+
+### F2 — [P1] Cost honesty is real but buried 360+ lines deep
+
+**Location:** Cost & Performance, lines 364–377. First mention of a dollar figure anywhere is line 369.
+
+**Problem:** This tool costs **$3–$20 per single run** and `3× base` for multi-run — i.e. up to ~$60 for one `--runs 3` code review. That is genuinely a lot for a code review. The README's hero section (lines 1–21), Quick Start, Installation, Why-Use-a-Panel, How It Works, and Features — roughly 360 lines — sell the machinery enthusiastically without once saying "this is expensive." The cost table is honest *when you reach it*, but placement is a soft form of dishonesty: the reader is fully sold before they learn the price.
+
+**Why it matters:** Compare to the standard SaaS dark-pattern of pricing-below-the-fold. A README for a paid-per-run tool should treat cost as a headline parameter, not a late-chapter footnote. The "Not for: quick code reviews" disclaimer (line 377) is the single most useful sentence for a prospective user's decision and it's invisible from the top.
+
+**Fix:** Put a one-line cost-and-fit statement in or immediately under the hero block: e.g. "Each run costs roughly $3–$20 in Opus tokens and takes 6–15 min; built for high-stakes reviews, not routine checks." Keep the detailed table where it is.
+
+---
+
+### F3 — [P1] "Grounded in 9 research papers" is credibility theater, not load-bearing methodology
+
+**Location:** Line 3 (badge), line 9, line 390–397 (Research Foundations), `docs/research-foundations.md`.
+
+**Problem:** The README maps 4 of 9 papers to phases (ChatEval→Phase 7, MachineSoM→Phase 4, Trust-or-Escalate→judge confidence, DMAD→reasoning strategies) and explicitly calls these "load-bearing." The other 5 papers (AutoGen, Du et al., DebateLLM, "Talk Isn't Always Cheap", CONSENSAGENT) get no architecture mapping in the README at all — `research-foundations.md` describes them as "inspiration" / "informing" / "failure mode analysis." So the honest count of papers that actually shaped a mechanism is ~4, not 9, and even those mappings are "this phase resembles a pattern from this paper," not "we implemented and benchmarked this paper's method." The badge says "9 papers" because 9 is a more impressive number than 4.
+
+A sharper problem: citing ICLR/ACL papers does not make a tool's *output* better. The papers were "demonstrated on reasoning benchmarks" (research-foundations.md's own caveat); none validate that adversarial debate improves *code/doc review quality* specifically. The README borrows academic authority for a domain transfer the papers don't support. The "12–18%" DMAD figure (line 395) is presented as if it's evidence for *this tool* — it is a number from someone else's benchmark on someone else's task.
+
+**Why it matters:** This is textbook credibility theater — the "as seen in Nature" pattern. It will impress non-experts and irritate anyone who reads the cited papers. It also creates an unfalsifiable claim: "grounded in research" can never be disproven, so it does no work except signaling.
+
+**Fix:** Demote the badge or change it to "4 papers mapped to architecture." In Research Foundations, clearly separate "mechanisms we implemented from paper X" from "papers that informed our thinking." Drop the borrowed "12–18%" unless this tool reproduced it. Add one honest sentence: "These papers validate multi-agent debate on reasoning benchmarks; we have not independently benchmarked review quality."
+
+---
+
+### F4 — [P1] The core limitation — all reviewers are one model talking to itself — is real but under-weighted and contradicted by the framing
+
+**Location:** Known Limitations line 381 (the honest version); contradicted by line 9, the whole "Why Use a Panel" section (235–247), "adversarial," "independent reviewers that genuinely engage."
+
+**Problem:** Line 381 honestly says: "All reviewers are Claude instances. Unanimous agreement may reflect shared model biases." Good. But the entire top of the README is built on the opposite impression — "4–6 AI reviewers independently evaluate," "they debate each other," "genuinely engage," "independent reviewers." A reader reaches line 235's dialogue ("Risk Assessor: Disagree...") and is invited to believe two minds are arguing. They are not: it's one model role-playing a disagreement with itself, and a model can role-play a "Round 2: Valid point, I upgrade this" just as easily whether or not the point is valid. The "anti-groupthink safeguards" (291–296) are mitigations for a problem the architecture *guarantees*, dressed up as features.
+
+**Why it matters:** This is the central honesty question for the whole product and the README resolves it in marketing's favor everywhere except one bullet on line 381. The analogical pattern: a vendor whose "independent third-party audit" is performed by a wholly-owned subsidiary — disclosed in the fine print, denied by the brochure.
+
+**Fix:** Move the "same base model" limitation up, ideally into "Why Use a Panel." Reframe the value proposition honestly: this isn't "independent reviewers," it's "structured self-critique that forces one model to take multiple passes from assigned stances." That's still a legitimately useful thing — sell *that*, not a fiction of independence.
+
+---
+
+### F5 — [P1] Vanity metrics are doing persuasion work that quality should do
+
+**Location:** "16-phase pipeline," "401 tests," "127+ specialist agents," "9 papers," "10-section issue cards," "10 signal groups," "55+ prompts."
+
+**Problem:** The README is studded with big numbers presented as quality signals. None of them are. 401 tests of a prompt-orchestration skill mostly assert that strings appear in `SKILL.md` (the README itself admits this on lines 419–423: "asserts SKILL.md declares...", "All 16 top-level phases present in SKILL.md") — they are consistency/lint checks, not evidence the *reviews are good*. "127+ specialist agents" is VoltAgent's count, not this project's work. A "16-phase pipeline" is presented as a selling point but a user does not benefit from 16 phases — they benefit from a good report; 16 phases is the author admiring the size of their own machine. "10-section issue cards" similarly measures elaborateness, not usefulness.
+
+**Why it matters:** Classic vanity-metric pattern (the "10,000 commits" badge). Numbers crowd out the one thing a skeptical buyer wants: evidence the output is actually better than the alternative. The README never shows a single real finding from a real review as evidence of quality — only counts of machinery.
+
+**Fix:** Cut the metrics that don't signal quality, or recontextualize them honestly ("401 structural/consistency tests — they guard against doc-drift, not review quality"). Replace at least one vanity metric with actual evidence: a real before/after, a real finding the panel caught that a single review missed.
+
+---
+
+### F6 — [P1] ~200 lines of migration + troubleshooting + stale-state cleanup is a product smell, not just a doc problem
+
+**Location:** Lines 61–77, 119–189, 447–552 (Migration, Updating, Troubleshooting, multiple "clear stale state" recipes). Roughly 200 of 671 lines (~30%).
+
+**Problem:** Nearly a third of the README is devoted to: undoing old marketplace names (`@wan-huiyan-agent-review-panel`, `@agent-review-panel`, bare `plugin`), removing "orphan directories with trailing whitespace," and detecting "loose-clone shadows." The README has *four* separate places that tell you to `rm -rf` shadowing directories (lines 70, 162–168, 499–502, 527–530). One callout (65–77) is an entire LLM prompt you paste so Claude can clean up the mess the project's own past releases made.
+
+**Why it matters:** A README's migration burden is a mirror of the product's release discipline. This much cleanup scaffolding says the project renamed its marketplace handle at least three times and shipped a layout bug that "silently broke all marketplace installs since 2026-04-07" (line 635). That is the *opposite* of the reliability the tool claims to enforce on others. It also makes the README a maintenance burden — every future rename adds another paragraph — and a worse read for the 90%+ of users who are new and have no stale state.
+
+**Fix:** Move all migration and stale-state content to a separate `MIGRATION.md` / `TROUBLESHOOTING.md`. Keep a 3-line pointer in the README. The product should also stop renaming its handle; if v3.0 is the stable layout, commit to it.
+
+---
+
+### F7 — [P2] Inline version attributions turn the README into a changelog
+
+**Location:** Throughout — `(v2.14, code only)`, `new in v2.15`, `(v2.16.3)`, `(v2.16.4 disk-reading architecture)`, `v3.0+ single-plugin layout`, `pre-v2.16.1`, dozens more.
+
+**Problem:** The body text is littered with version-attribution parentheticals. A new user does not care that the Data Flow Trace arrived in v2.14 or that web-verification is "new in v2.16.3" — they care what the tool does *now*. These attributions serve the *author's* memory of the build history, not the *reader's* understanding. They also rot: every one is a maintenance liability and a chance for drift (and given F1, the drift has already happened).
+
+**Why it matters:** Audience confusion (see F9). A README describes the current state; a CHANGELOG describes history. Mixing them means the README reads like release notes and the reader has to mentally strip version noise to find the actual description. There is already a 46KB CHANGELOG.md — the history has a home.
+
+**Fix:** Strip inline `(vX.Y)` attributions from the README body. Describe features in present tense. Keep version history in the Version History table and CHANGELOG.md only.
+
+---
+
+### F8 — [P2] The README never honestly engages "would a single good prompt do?"
+
+**Location:** "Why Use a Panel Instead of a Single Reviewer?" lines 235–247.
+
+**Problem:** The one section nominally dedicated to justifying the panel's existence is pure advocacy. It strawmans the alternative ("you get one perspective. It won't argue with itself, catch its own blind spots") — but a single well-constructed review prompt *can* be told to argue with itself, enumerate blind spots, and express uncertainty. The honest comparison is "panel vs. a *good* single-reviewer prompt," and the README never makes it. It assumes the panel is worth 4–6× the cost and never tests that assumption against the reader's skepticism.
+
+**Why it matters:** The most important question a $3–$60 tool must answer is "why not the cheap thing?" Dodging it — by comparing only against a deliberately weak single review — is the "competitor comparison chart where we picked the columns" pattern. A skeptical reader notices and discounts everything else.
+
+**Fix:** Rewrite the section to engage the strongest version of the alternative. State plainly what the panel buys you that a good single prompt can't (parallel independent passes before cross-contamination; structured disagreement artifacts; harder-to-fake blind scoring) and concede where a single prompt is the rational choice (most reviews — which the cost table already implies).
+
+---
+
+### F9 — [P2] Audience is confused — the README serves three masters
+
+**Location:** Whole document.
+
+**Problem:** The README oscillates between three readers: (1) **users** (Quick Start, Usage Examples, Reading the Report); (2) **contributors/developers** (manual clone, Cursor recipes, Tests internals, `release-check.sh` HTML comment on line 123); and (3) **the author documenting their own cleverness** (16-phase table, research mappings, version-history minutiae, "the v2.14 cleanup retired purely artifactual intermediate decimals like the old Phase 4.55" on line 251 — a sentence that exists for no reader on earth except the person who renumbered the phases). At 671 lines it tries to be the user guide, the contributor guide, and the design memoir simultaneously.
+
+**Why it matters:** A document for everyone is a document for no one. The user wanting to decide "should I install this" must wade through `release-check.sh` maintenance comments and Phase 4.55 archaeology. The HOW_WE_BUILT_THIS.md (71KB) already exists as the design-memoir home.
+
+**Fix:** Decide the README is for *users evaluating and running the tool*. Cut developer-internals and author-archaeology to CONTRIBUTING.md / HOW_WE_BUILT_THIS.md. Target ~250–300 lines.
+
+---
+
+### F10 — [P2] "Director's cut," "Supreme Judge," "Panel Gallery" — branded grandiosity inflates a prompt pipeline
+
+**Location:** Lines 92, 268 ("Supreme Judge — Opus arbitrates everything"), 300 ("director's cut"), 313 ("Panel Gallery with avatar cards for every agent"), "roundtable."
+
+**Problem:** The vocabulary is theatrical out of proportion to the artifact. "Supreme Judge" is a single Opus call with a judge-flavored prompt. "Panel Gallery with avatar cards" is decoration. "Director's cut" is a verbatim log. The naming inflates a sequence of prompted LLM calls into something that sounds like an institution.
+
+**Why it matters:** Grandiose internal naming is a tell — it's the author enjoying the world they built. It also sets an expectation the output can't meet: a reader primed by "Supreme Judge" and "adversarial debate" expects rigor the underlying mechanism (one model, role-played stances) cannot structurally deliver (see F4). Over-naming and over-claiming compound.
+
+**Fix:** Keep one or two flavorful names if you must (the product is called "roundtable" — fine), but describe mechanisms plainly: "a judge step (one Opus call)," "a process log," "an agent list." Let the tool be useful without costuming it.
+
+---
+
+### F11 — [P3] "Schliff optimization (75 → 86)" is an undefined number presented as achievement
+
+**Location:** Line 647 (Version History v2.6: "Schliff optimization (75 → 86), reference extraction, A/B validated").
+
+**Problem:** 75 → 86 of *what*? No unit, no scale, no definition anywhere in the README. "A/B validated" against what baseline, measuring what? It's a number that looks like evidence but conveys nothing — the reader is invited to feel improvement happened without being told what improved.
+
+**Why it matters:** Minor, but it's the same pattern as F3/F5 in miniature — numbers as authority-signal rather than information. An undefined metric is worse than no metric.
+
+**Fix:** Define the score and the A/B setup, or remove the parenthetical.
+
+---
+
+### F12 — [P3] The SDK "Works ✅" claim sits oddly against "Runs only on Claude Code surfaces"
+
+**Location:** Line 13 ("Runs only on Claude Code surfaces — CLI, IDE extension, or the Code tab") vs. lines 101/108 (Claude Agent SDK listed under "Works ✅").
+
+**Problem:** The hero callout says "Runs only on Claude Code surfaces" and names three. Then the Installation section adds the Agent SDK as a fourth supported surface. The SDK is not a "Claude Code surface" in the same sense — it's a library on the API. Mild contradiction / scope creep in the headline claim.
+
+**Why it matters:** Small, but a skeptical reader spotting one loose claim re-examines the rest. Precision in the headline matters most.
+
+**Fix:** Make line 13 consistent: "Runs on Claude Code surfaces (CLI, IDE extensions, Desktop Code tab) and the Claude Agent SDK."
+
+---
+
+## Top 3 Most Defensible Findings
+
+1. **F1 (untagged releases)** — This is a verifiable, binary fact: the README and `plugin.json` claim 3.3.0; no v3.2.0/v3.3.0 tag exists; hero images are pinned to v3.1.0. It is not a matter of taste, and for a product whose entire pitch is epistemic verification, shipping an unfalsified version claim is maximally damaging.
+2. **F4 (one model talking to itself)** — Architecturally undeniable; the README itself concedes it on line 381 while contradicting it everywhere else. The critique is just "make the honest bullet match the framing."
+3. **F2 (cost buried)** — Objectively, the first dollar figure is on line 369 of 671, and the "not for routine reviews" guidance is even later. For a paid-per-run tool that is a structural placement problem, not an opinion.
+
+## Least Defensible Finding (genuine self-critique)
+
+**F10 (grandiose naming)** is my weakest. "Supreme Judge" / "Panel Gallery" / "director's cut" are stylistic choices, and plenty of well-regarded tools use playful internal names without harm — the persona's contrarian lens may be over-reading branding as deception. The substantive part of F10 (naming sets expectations the mechanism can't meet) is really just a restatement of F4, so F10 doesn't stand fully on its own. I'd keep it as a P3 nudge but concede a reasonable maintainer could decline it without the README being worse. F11 is also thin — a single undefined number in a history table is genuinely minor — but at least it's a clean, fixable factual gap, whereas F10 is pure taste.
+
+## Verdict
+
+A meticulously edited README that mistakes machinery for merit: it documents unreleased versions, dresses a single model's self-critique as an independent panel, and sells with vanity metrics and borrowed academic authority while hiding the price — credible-sounding, not yet trustworthy.

--- a/docs/reviews/2026-05-14-readme/state/reviewer_technical-accuracy_phase_3.md
+++ b/docs/reviews/2026-05-14-readme/state/reviewer_technical-accuracy_phase_3.md
@@ -1,0 +1,123 @@
+# Technical Accuracy Review — README.md (Phase 3, Independent)
+
+**Reviewer:** Technical Accuracy Reviewer (skepticism 30%)
+**Target:** `/home/user/agent-review-panel/README.md` (671 lines)
+**Date:** 2026-05-14
+**Method:** Claim-by-claim checklist verification against repo files.
+
+## Score: 4/10
+
+The README is well-organized and most *commands* (install handles, marketplace name, slash commands, npm scripts) check out exactly. But the document is materially stale against the actual v3.3.0 state of the repo: the "How It Works" 16-phase table predates Phase 13.5 AND Phase 14.5 (both real, both in SKILL.md), the version story is incoherent because no v3.2.0/v3.3.0 release tag exists yet the README tells users their cache version "should match the latest GitHub release", hero images are pinned to a stale `v3.1.0` tag, and several count claims are off. These are the exact class of bugs (procedural/factual drift that misleads a user) that sink a technical-accuracy score.
+
+---
+
+## Findings
+
+### P1-1 — "How It Works" phase table is stale: missing Phase 13.5 AND Phase 14.5
+**Location:** README lines 249–270 (the `## How It Works` table), also line 27 ("the 16-phase pipeline") and line 251.
+**Claim:** "16 top-level phases ... numbered as sequential integers (Phase 1 through Phase 16)." The table lists phases 1–16 with no 13.5 or 14.5.
+**Contradicting evidence:** `skills/agent-review-panel/SKILL.md` Process Overview (lines 117 and 1110) defines **Phase 14.5: Post-Judge Verification** ("Re-verify judge-introduced P0/P1 against ground truth (v3.2.0)"), and SKILL.md line 1027 defines **Phase 13.5: Pre-Judge Verification Gate (v3.1.0)**. CHANGELOG `[3.2.0]` ("Added — Phase 14.5") and `[3.1.0]` ("Phase 13.5 — Pre-Judge Verification Gate (NEW)") both confirm these are real, shipped phases. The README table reflects neither.
+**Why it matters:** A user reading "How It Works" gets a process model that is two releases out of date and silently omits two verification gates that are core selling points of v3.1/v3.2. The README even cross-links this table from the Tests section (line 420) as authoritative.
+**Fix:** Add two rows to the table: Phase 13.5 (Pre-Judge Verification Gate, v3.1.0) under **Verify**, and Phase 14.5 (Post-Judge Verification Gate, v3.2.0) under **Adjudicate**. Update line 251's "Phase 1 through Phase 16 ... sequential integers" prose to acknowledge the 13.5/14.5 decimals, the way it already acknowledges the 15.x sub-steps.
+
+### P1-2 — Version story is incoherent: badge + "matches latest GitHub release" mislead a v3.3.0 user
+**Location:** README line 1 (`[![GitHub release]]` badge), lines 148–152 ("Verify the update worked" → "It should match the [latest GitHub release]").
+**Claim:** The dynamic release badge and the update-verification text tell the user the installed cache-dir version "should match the latest GitHub release."
+**Contradicting evidence:** `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` all declare `3.3.0`. Known fact (confirmed: `git tag` returns nothing locally; remote tags are only v2.10.0, v2.16.5, v3.0.0, v3.1.0). There is no v3.2.0 or v3.3.0 release. So a correctly-installed v3.3.0 user runs `ls ~/.claude/plugins/cache/.../` sees `3.3.0`, compares to "latest GitHub release" (v3.1.0), and concludes their install is *ahead/broken* — or that they failed to update.
+**Why it matters:** The single most actionable instruction in the Updating section produces a false negative for every current user. The badge will also render `v3.1.0` while the repo is `v3.3.0`.
+**Fix:** Either cut releases v3.2.0 and v3.3.0 (preferred), or change the verify text to "should match the version in `package.json` / `.claude-plugin/plugin.json`" and note that GitHub releases may lag `main`. Line 154's example version "(e.g. `3.1.0`)" should be bumped to `3.3.0`.
+
+### P1-3 — Hero/demo images pinned to stale `v3.1.0` tag
+**Location:** README lines 15, 17, 19 — all three image URLs are `https://raw.githubusercontent.com/wan-huiyan/agent-review-panel/v3.1.0/docs/...`.
+**Claim:** Images served from the `v3.1.0` git tag.
+**Contradicting evidence:** Repo is at v3.3.0 (`package.json` line 3). The image source files exist in the repo at HEAD (`docs/hero-flow.svg`, `docs/demo.gif`, `docs/html-demo.gif` all present — verified via `ls`). Pinning to `v3.1.0` means any visual change made in v3.2.0/v3.3.0 (e.g. the Chart.js wrapper-div fix, Live-State labels in the dashboard) is not reflected, and the pin is two releases stale.
+**Why it matters:** Lower severity than P1-1/P1-2 (images still load), but it is a verifiable inconsistency and the `v3.1.0` tag is the same stale-version symptom as the badge.
+**Fix:** Re-pin to `v3.3.0` once that tag exists, or use `main` / a permalink commit SHA.
+
+### P2-4 — "9 research papers" — verifiable but internally inconsistent venue data
+**Location:** README line 3 (badge "9 papers"), line 9, line 390, line 397.
+**Claim:** "9 peer-reviewed papers."
+**Contradicting evidence:** `docs/research-foundations.md` table does list exactly 9 rows — count is **correct**. BUT the README says "9 **peer-reviewed** papers" (line 390) while `research-foundations.md` lists **AutoGen** with venue "—" (no venue) — AutoGen is a GitHub project / tech report, not peer-reviewed. Also README line 392 calls ChatEval "ICLR 2024" and line 393 "MachineSoM (ACL 2024)" — these match. But README line 11/9 say papers are "on multi-agent debate"; `research-foundations.md` line 13 describes "Talk Isn't Always Cheap" only as "Failure mode analysis" — minor. Core count (9) is accurate; the "peer-reviewed" qualifier is the inaccuracy.
+**Why it matters:** Small, but a skeptical reader who clicks through finds AutoGen has no venue, contradicting "peer-reviewed."
+**Fix:** Change "9 peer-reviewed papers" to "9 research papers/projects" or footnote AutoGen as a non-peer-reviewed reference. (Note also ROADMAP.md line 212 says "Academic Papers (17+)" — a different scope, not a contradiction, but worth a glance.)
+
+### P2-5 — "10 signal groups" list is slightly mislabeled vs. the actual checklist file
+**Location:** README line 276: "10 signal groups (SQL, ML, Terraform, Auth, API, Frontend, Cost, Pipeline, Portability, Repo Hygiene)".
+**Contradicting evidence:** `skills/agent-review-panel/references/signals-and-checklists.md` "## Domain Checklists" lists exactly 10 domain checklists: SQL/Data, Auth/Security, Infrastructure, ML/Statistics, API/Integration, Frontend/UI, Cost/Billing, Data Pipeline/ETL, **Repo/Data Hygiene**, Skill/Docs Portability. The count (10) is **correct**, but the README labels one "Terraform" — the actual group is "Infrastructure" (Terraform is one signal within it), and "Repo Hygiene" is actually "Repo/Data Hygiene". Minor naming drift.
+**Why it matters:** Low — count is right; only two labels are imprecise.
+**Fix:** Change "Terraform" → "Infrastructure" and "Repo Hygiene" → "Repo/Data Hygiene" to match the source file headings.
+
+### P2-6 — VoltAgent "10 signal groups" vs "10 families" conflation risk
+**Location:** README line 317 ("127+ specialist agents"), line 644 ("127+ agents, 10 families"), line 276 ("10 signal groups").
+**Contradicting evidence:** `SKILL.md` line 327: "VoltAgent specialist agents (127+ across 10 **families**)". `plan-review-integrator/SKILL.md` line 77 same. So "127+" and "10 families" are **accurate**. The README correctly uses "families" on line 644. No contradiction found — but flag: README has both "10 signal groups" and "10 families" as distinct 10-counts; a reader could conflate them. Verified they are genuinely different concepts, both legitimately 10.
+**Why it matters:** Not an inaccuracy — verified correct. Documented here only so the panel knows it was checked.
+**Fix:** None required. Optionally disambiguate in prose.
+
+### P3-7 — "401 tests" — accurate, confirmed by running the suite
+**Location:** README lines 407, 409 ("run all 401 tests"), 420.
+**Contradicting evidence / verification:** Ran `npm test`: output `# tests 401 / # pass 401 / # fail 0`. `package.json` `test` script runs the six `tests/*.test.mjs` files. The six `npm run test:*` sub-scripts (triggers, manifest, eval-suite, report, behavioral, golden) **all exist** in `package.json` lines 8–13 and match the README list at lines 411–417 exactly. `scripts/release-check.sh` line 110–118 also greps README for `N tests` and asserts it equals actual.
+**Why it matters:** This claim is **correct** — noted as a positive. (CHANGELOG shows the historical drift: 379→386 in v3.2.0; current is 401, README matches.)
+**Fix:** None. Accurate.
+
+### P3-8 — Commands & install handles — accurate, confirmed
+**Location:** README lines 40–41, 54–55, 124, 134–136, 173–177, 431–434, 611–615.
+**Verification:** `.claude-plugin/marketplace.json` line 3: marketplace `name: "agent-review-panel"`; line 10: plugin `name: "roundtable"`; `source: "./"`. So `roundtable@agent-review-panel` (README) is **correct**. Slash commands `/roundtable:agent-review-panel` and `/roundtable:plan-review-integrator` match the skill dir names (`skills/agent-review-panel/`, `skills/plan-review-integrator/`) and SKILL.md frontmatter `name:` fields. The README marketplace-name callout (lines 123–125) is accurate.
+**Why it matters:** Correct — noted as positive.
+**Fix:** None.
+
+### P2-9 — Stale slash-command form inside SKILL.md frontmatter (cross-ref inconsistency)
+**Location:** README line 88 / line 46 reference `/roundtable:agent-review-panel`; README repeatedly states the namespaced form.
+**Contradicting evidence:** `skills/agent-review-panel/SKILL.md` line 10 frontmatter description still says "or invokes **/agent-review-panel**" (un-namespaced) — and `plan-review-integrator/SKILL.md` line 18 says "invokes **/plan-review-integrator**". The README's `/roundtable:<skill>` claim is the correct one per the plugin model; the SKILL.md files are the stale party. This is technically a SKILL.md bug, but it means the README's own cited authority disagrees with it.
+**Why it matters:** A reader cross-checking SKILL.md sees a different command. The README is right; the skill files need fixing — but the README could note the namespacing explicitly survives this.
+**Fix:** Out of README scope to fix SKILL.md, but flag it. The README is accurate here.
+
+### P2-10 — "new in v2.15" expandable cards — accurate but README double-states the introduction version inconsistently
+**Location:** README line 93 ("new in v2.15"), line 21 & 301 (10-section cards described), line 638 (Version History "v2.15").
+**Verification:** CHANGELOG `[2.15.0]` confirms "Expandable 10-section issue cards." SKILL.md line 1227 lists the 10 sections; the README's 10-section list (lines 302–312) — Narrative, Code Evidence, Raised by, Verification Trail, Debate, Judge Ruling, Fix Recommendation, Cross-references, Epistemic Tags, Prior Runs — matches CHANGELOG `[2.15.0]` exactly. **Accurate.**
+**Why it matters:** Correct — noted positive.
+**Fix:** None.
+
+### P2-11 — Epistemic-labels list: README "Reading the Report" table omits `[JUDGE-HALLUCINATED]` and `[COMPRESSED]`
+**Location:** README lines 578–591 (the "Epistemic labels" table in "Reading the Report").
+**Claim:** The table enumerates the epistemic labels a finding can carry.
+**Contradicting evidence:** `SKILL.md` line 1227 — the canonical Phase 15.1 label list — is: `[VERIFIED] [CONSENSUS] [SINGLE-SOURCE] [UNVERIFIED] [DISPUTED] [WEB-VERIFIED] [WEB-CONTRADICTED] [WEB-INCONCLUSIVE] [JUDGE-HALLUCINATED] [LIVE-VERIFIED] [STATIC-INFERENCE] [STATIC-INFERENCE-CONSENSUS]`. The README table includes VERIFIED, CONSENSUS, SINGLE-SOURCE, DISPUTED, UNVERIFIED, WEB-*, CMD_CONFIRMED/CONTRADICTED, LIVE-VERIFIED, STATIC-INFERENCE, STATIC-INFERENCE-CONSENSUS — but **omits `[JUDGE-HALLUCINATED]`** (a real v3.2.0 label, SKILL.md line 1136/1227) and **omits `[COMPRESSED]`** (real v3.1.0 suffix, SKILL.md lines 1198–1200). Note also: README line 299 (the Quick Start mini-list of labels) DOES omit JUDGE-HALLUCINATED too, and includes the same set — internally consistent with itself but both lists are incomplete vs SKILL.md.
+**Why it matters:** A user who sees `[JUDGE-HALLUCINATED]` on an action item (the headline feature of v3.2.0) finds no entry for it in the README's label glossary.
+**Fix:** Add `[JUDGE-HALLUCINATED]` and `[COMPRESSED]` rows to the "Epistemic labels" table (lines 578–591), and add `[JUDGE-HALLUCINATED]` to the Quick Start list on line 299.
+
+### P2-12 — README line 299 / line 93 attribute `[CMD_CONFIRMED]` etc. inconsistently and the line-299 list contradicts the line-588 table
+**Location:** README line 299 (Quick Start label list) vs lines 578–591 (table).
+**Contradicting evidence:** Line 299's parenthetical list and the lines 578–591 table differ in membership: the table has a `[CMD_CONFIRMED] / [CMD_CONTRADICTED]` row (line 588) that line 299 does **not** list; line 299 lists `[STATIC-INFERENCE-CONSENSUS]` which the table also has. Two label enumerations in the same document with different contents.
+**Why it matters:** Internal inconsistency; a reader can't tell which list is authoritative.
+**Fix:** Make line 299 and the lines 578–591 table list the same set, both synced to SKILL.md line 1227.
+
+### P3-13 — "Phase 15 is a parent step with three sub-steps" — accurate
+**Location:** README line 251, lines 269, 420.
+**Verification:** SKILL.md lines 118–122 confirm Phase 15 parent with 15.1/15.2/15.3 sequential. SKILL.md line 1172 "in strict sequence: Phase 15.1 first, then 15.2, then 15.3." README's "written sequentially per the v2.16.4 disk-reading architecture" matches CHANGELOG `[2.16.4]`. **Accurate.**
+**Fix:** None.
+
+### P2-14 — "Migration" section uninstall commands reference marketplace names that may never have shipped as written
+**Location:** README lines 451–458.
+**Claim:** `claude plugin uninstall agent-review-panel@wan-huiyan-agent-review-panel` and `...@wan-huiyan-plan-review-integrator`.
+**Contradicting evidence:** CHANGELOG `[2.16.1]` says the marketplace was renamed `wan-huiyan-agent-review-panel` → **`plugin`** (not to a `wan-huiyan-plan-review-integrator` marketplace). CHANGELOG `[2.16.0]` confirms `agent-review-panel` → `wan-huiyan-agent-review-panel`. There is no CHANGELOG evidence a marketplace named `wan-huiyan-plan-review-integrator` ever existed — plan-review-integrator was a separate *repo* (`wan-huiyan/plan-review-integrator`, now archived per README line 443), not a marketplace by that name. The uninstall line for it may be uninstalling a handle that never existed.
+**Why it matters:** Could confuse users who never had that install; harmless if the command no-ops, but it's an unverifiable claim presented as fact.
+**Fix:** Verify against actual historical marketplace.json revisions; if `wan-huiyan-plan-review-integrator` was never a marketplace, drop that line or relabel it as the standalone-repo case.
+
+### P3-15 — Anchor links spot-check — all pass
+**Location:** README Contents (lines 25–32) and inline `#anchor` links.
+**Verification:** `#research-foundations` → `## Research Foundations` heading (line 388) ✓ and explicit usage matches. `#requires-claude-code` → `### Requires Claude Code` (line 99) ✓. `#bundled-skills` → `## Bundled skills` (line 425) ✓. `#quick-start` → explicit `<a id="quick-start">` (line 34) ✓. `#updating-to-the-latest-version` → `### Updating to the latest version` (line 129) ✓. `#manual-clone-development--custom-setup` → explicit `<a id>` (line 191) ✓. `#after-install-roundtableagent-review-panel-is-not-recognized` → explicit `<a id>` (line 514) ✓. **All anchors verified present.**
+**Fix:** None.
+
+---
+
+## Top 3 Most Defensible Findings
+1. **P1-1 (stale phase table)** — Directly contradicted by SKILL.md lines 1027 & 1110 and CHANGELOG [3.1.0]/[3.2.0]. Two whole phases missing from the headline "How It Works" table. Unambiguous.
+2. **P1-2 (version story incoherence)** — Three manifest files say 3.3.0; no v3.2.0/v3.3.0 tag exists; the README's verify-instruction produces a guaranteed false negative for every current user.
+3. **P2-11 (epistemic labels table incomplete)** — SKILL.md line 1227 is the canonical list; README's table provably omits `[JUDGE-HALLUCINATED]` and `[COMPRESSED]`, both real shipped labels.
+
+## Top 3 Least Defensible Findings
+1. **P2-6 (VoltAgent 10/10 conflation)** — On inspection, no actual inaccuracy; both counts are correct. Included only as a "checked, clean" note; not a real defect.
+2. **P3-15 (anchors)** — All passed; this is a non-finding, listed for completeness of the checklist.
+3. **P2-14 (migration marketplace name)** — I could not find a marketplace.json revision history to fully confirm `wan-huiyan-plan-review-integrator` never existed; this is a "suspicious, unverified" flag rather than a proven inaccuracy. Stated as such.
+
+## Verdict
+README is structurally solid and its commands/counts mostly verify, but it is two releases stale on the phase model and the version-tracking guidance actively misleads every v3.3.0 user — fix the phase table, the release story, and the epistemic-label glossary before shipping.


### PR DESCRIPTION
## Summary

This PR significantly restructures the project documentation by extracting operational guides from the main README into dedicated files, condensing the README itself, and adding a comprehensive review panel audit of the documentation.

## Key Changes

- **README.md**: Reduced from 324 to 247 lines by removing migration instructions, troubleshooting steps, and detailed version history. Streamlined opening section, condensed feature descriptions, and removed redundant blockquotes. Kept core Quick Start, usage examples, and research foundations.

- **New MIGRATION.md**: Extracted all migration guidance from README into a dedicated file with historical version table and step-by-step cleanup instructions for users upgrading from pre-v3.0 installs.

- **New TROUBLESHOOTING.md**: Extracted troubleshooting section from README with common problems (unrecognized slash commands, missing output files, stale findings) and recovery procedures.

- **New review audit**: Added comprehensive documentation review under `docs/reviews/2026-05-14-readme/`:
  - `review_panel_report.md`: Executive summary identifying version/release incoherence, document length issues, and missing output samples
  - `review_panel_process.md`: Process history and persona profiles
  - `phase_14_judge_ruling.md`: Judge's verification and ruling on findings
  - `state/`: Individual reviewer reports (Clarity Editor, Technical Accuracy, Completeness Checker, Devil's Advocate)

## Notable Details

- The review audit itself documents structural issues in the README (version claims for v3.2.0/v3.3.0 that lack corresponding git tags, "How It Works" table missing Phase 13.5 and 14.5, no text samples of actual output)
- Cross-references between README, MIGRATION.md, and TROUBLESHOOTING.md maintain discoverability
- Documentation is now modular: newcomers see a concise README; users needing migration/troubleshooting are directed to dedicated files

https://claude.ai/code/session_01Jh6ym7oQvpi6kR4kBZHYdw