### PR TITLE
docs: de-stale hero diagram, surface VoltAgent, add pixel-art redesign brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ review actually produces.
 | 4 | P1 [VERIFIED]            | Add a text sample of a real report.       |
 ```
 
-You're reading the v3.3.0 rewrite that lands those findings. The full artifacts live at:
+You're reading the rewrite that lands those findings. The full artifacts live at:
 
 - [`docs/reviews/2026-05-14-readme/review_panel_report.md`](docs/reviews/2026-05-14-readme/review_panel_report.md) — the full markdown report (13 action items)
 - [`docs/reviews/2026-05-14-readme/review_panel_report.html`](docs/reviews/2026-05-14-readme/review_panel_report.html) — the interactive HTML dashboard

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ claude plugin marketplace add VoltAgent/awesome-claude-code-subagents
 claude plugin install voltagent-qa-sec@voltagent-subagents   # backs the core code-review personas
 ```
 
-Add `voltagent-lang`, `voltagent-data-ai`, `voltagent-infra`, … as you need them (10 families, 130+ agents; the `/plugin …` REPL form works too — takes effect next session). Why it's worth it → [Sharper reviews with VoltAgent](#sharper-reviews-with-voltagent-specialists). *(Installs via Claude Code's plugin system; Codex support is unverified.)*
+Add `voltagent-lang`, `voltagent-data-ai`, `voltagent-infra`, … as you need them (10 families, 130+ agents; the `/plugin …` REPL form works too — takes effect next session). Why it's worth it → [Sharper reviews with VoltAgent](#sharper-reviews-with-voltagent-specialists). *(VoltAgent installs through Claude Code's plugin system.)*
 
 **Use:**
 
@@ -135,7 +135,7 @@ By default every reviewer is a *generic* Claude agent wearing a persona prompt (
 - **130+ specialists across 10 families** — `qa-sec` (code review, security, performance, chaos), `lang` (20+ language experts), `data-ai`, `infra`, `core-dev`, and more. Content signals auto-add the right one: SQL → a database optimizer, Terraform → an IaC engineer, React → a frontend specialist. v3.4 added 30 such signal→specialist mappings, roughly doubling coverage.
 - **Install what you review.** `voltagent-qa-sec` backs the core code-review personas; add `voltagent-lang` / `voltagent-data-ai` / `voltagent-infra` for language-, ML-, or infra-heavy work. Commands are in [Quick Start](#quick-start).
 
-> *VoltAgent specialists install through Claude Code's plugin system (CLI / IDE / Desktop "Code" tab). Whether the marketplace loads in a Codex session is unverified by maintainers — the panel still runs there, just with generic personas.*
+> *VoltAgent specialists install through Claude Code's plugin system — the same Claude Code surfaces the panel itself runs on (CLI / IDE / Desktop "Code" tab / Agent SDK). Codex isn't a supported surface for the panel: it needs Claude Code's `Agent` tool to spawn reviewers in parallel — see [Surfaces & Requirements](#surfaces--requirements).*
 
 ## Surfaces & Requirements
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Same effect. Shell form (`claude plugin …`) from the terminal; REPL form (`/pl
 
 **Verify it loaded.** In a fresh Claude Code session, type `/roundtable:agent-review-panel` with no arguments. The skill should introduce itself and ask what to review. If you get `unknown command`, see [Troubleshooting](TROUBLESHOOTING.md#after-install-roundtableagent-review-panel-is-not-recognized). Migrating from an older install handle? See [MIGRATION.md](MIGRATION.md).
 
+**⚡ Recommended — add VoltAgent specialists.** Reviews get noticeably sharper when [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) are installed: the panel auto-upgrades each reviewer to a real domain specialist (e.g. Security Auditor → `voltagent-qa-sec:security-auditor`) instead of a generic persona. Not installed? It falls back gracefully — nothing breaks.
+
+```bash
+claude plugin marketplace add VoltAgent/awesome-claude-code-subagents
+claude plugin install voltagent-qa-sec@voltagent-subagents   # backs the core code-review personas
+```
+
+Add `voltagent-lang`, `voltagent-data-ai`, `voltagent-infra`, … as you need them (10 families, 130+ agents; the `/plugin …` REPL form works too — takes effect next session). Why it's worth it → [Sharper reviews with VoltAgent](#sharper-reviews-with-voltagent-specialists). *(Installs via Claude Code's plugin system; Codex support is unverified.)*
+
 **Use:**
 
 ```
@@ -118,6 +127,16 @@ You're reading the v3.3.0 rewrite that lands those findings. The full artifacts 
 - [`docs/reviews/2026-05-14-readme/review_panel_report.html`](docs/reviews/2026-05-14-readme/review_panel_report.html) — the interactive HTML dashboard
 - [`docs/reviews/2026-05-14-readme/review_panel_process.md`](docs/reviews/2026-05-14-readme/review_panel_process.md) — verbatim process log with all four reviewers' raw output
 
+## Sharper reviews with VoltAgent specialists
+
+By default every reviewer is a *generic* Claude agent wearing a persona prompt ("act as a Security Auditor"). That works — but if you install [VoltAgent's specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents), the panel **upgrades each persona to a matching domain specialist** whose expertise is built into its own system prompt: a real Security Auditor, Database Optimizer, or SRE instead of a generalist asked to role-play one.
+
+- **Automatic, zero-config.** During setup (Phase 1) the panel scans for installed `voltagent-*` agents and routes personas to them. No specialist installed for a given role? That reviewer falls back to a generic persona — nothing to configure, nothing breaks.
+- **130+ specialists across 10 families** — `qa-sec` (code review, security, performance, chaos), `lang` (20+ language experts), `data-ai`, `infra`, `core-dev`, and more. Content signals auto-add the right one: SQL → a database optimizer, Terraform → an IaC engineer, React → a frontend specialist. v3.4 added 30 such signal→specialist mappings, roughly doubling coverage.
+- **Install what you review.** `voltagent-qa-sec` backs the core code-review personas; add `voltagent-lang` / `voltagent-data-ai` / `voltagent-infra` for language-, ML-, or infra-heavy work. Commands are in [Quick Start](#quick-start).
+
+> *VoltAgent specialists install through Claude Code's plugin system (CLI / IDE / Desktop "Code" tab). Whether the marketplace loads in a Codex session is unverified by maintainers — the panel still runs there, just with generic personas.*
+
 ## Surfaces & Requirements
 
 This plugin needs the Claude Code `Agent` tool for parallel subagent spawning, local-filesystem access for output files, and a plugin loader.
@@ -138,7 +157,7 @@ This plugin needs the Claude Code `Agent` tool for parallel subagent spawning, l
 - **Claude Code v1.0+** on a supported surface, or the Claude Agent SDK
 - A Claude **Pro / Max** subscription or API access (Opus is the reviewer model)
 - **Node ≥18** (only needed if running `npm test` or developing locally)
-- **Optional:** [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) for stronger domain-specific reviews
+- **Recommended:** [VoltAgent specialist agents](https://github.com/VoltAgent/awesome-claude-code-subagents) — the panel auto-upgrades reviewers to domain specialists ([why it helps](#sharper-reviews-with-voltagent-specialists))
 
 Don't have Claude Code yet? Install it from [claude.ai/code](https://claude.ai/code), then come back to [Quick Start](#quick-start).
 
@@ -243,7 +262,7 @@ Phase 15 has three sequential sub-steps (15.1 → 15.2 → 15.3) so the HTML age
 
 **Advanced**
 
-- **VoltAgent integration** — maps personas to 130+ specialist agents across 10 families for deeper domain-specific reviews when installed
+- **VoltAgent integration** — auto-upgrades personas to 130+ domain specialists across 10 families when installed; content signals route each domain (SQL, Terraform, React, …) to its matching expert. See [Sharper reviews with VoltAgent](#sharper-reviews-with-voltagent-specialists)
 - **Multi-Run Union Protocol** — invoke `--runs N` or "run 3 times and merge" to execute the panel N times with rotated persona compositions. Phase 16 merges findings by location + bug class, scores stability as `[K/N RUNS]`, resolves judge divergence. Mitigates the ~30% single-run blind spot observed in early consistency analyses
 - **Codebase state check** — detects worktree/branch divergence to prevent false "missing code" findings
 - **Tiered knowledge mining** (L0 index / L1 summary / L2 full) — scans index lines first, only reads full content for relevant items
@@ -467,6 +486,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history and [ROADMAP.md](R
 
 | Version | Highlights |
 |---|---|
+| **v3.4** | VoltAgent catalog expansion — 30 new signal→specialist mappings (130+ agents / 10 families) + drift-detection automation (vendored catalog snapshot, CI gate) |
 | **v3.3** | Live-State Claim Discipline — cross-cutting rule set for findings asserting facts about *live* infrastructure or runtime state |
 | **v3.2** | Post-judge verification gate + Chart.js wrapper-div mandate — Phase 14.5 re-verifies judge-introduced P0/P1 against ground truth |
 | **v3.1** | Silent-phase-compression fix — file-based subagent state under `state/`, Phase 13.5 Pre-Judge Verification Gate |

--- a/docs/hero-flow-pixel-art-redesign-prompt.md
+++ b/docs/hero-flow-pixel-art-redesign-prompt.md
@@ -1,0 +1,129 @@
+# Hero diagram → 16-bit pixel-art redesign — handoff prompt
+
+This is a self-contained brief to hand to a design session ("claude design"). It redesigns the
+README hero diagram (`docs/hero-flow.svg`) as a **16-bit / SNES-era pixel-art** illustration.
+Everything the designer needs — corrected facts, layout, palette, acceptance criteria — is below.
+Copy from the `---` line down.
+
+---
+
+## Brief
+
+Redesign the **Agent Review Panel** hero diagram in **16-bit / SNES-era pixel art**. It is the first
+image in the repo's README (a GitHub-rendered `<img>`), so it must read instantly at ~880px wide
+and look crisp at any zoom. It replaces the current vector diagram at `docs/hero-flow.svg`.
+
+**What it depicts:** a multi-agent adversarial code-review *pipeline* — your code/plan goes in on the
+left, flows through review stages, and a final arbitrated report comes out on the right.
+
+## Style: 16-bit SNES pixel art (hard requirements)
+
+- **True pixel art** — every shape snaps to a pixel grid. Build "pixels" as equal-size `<rect>`s
+  (7px works well) on a fixed grid; reuse characters via `<g transform="translate(x,y)">`.
+- **NO anti-aliasing, NO gradients, NO blur/glow/drop-shadow filters.** (The current SVG leans on
+  `feGaussianBlur` glow and radial gradients — drop all of that. That's what makes it *vector*, not
+  pixel art.) Shade with **dithering** (checkerboard / Bayer pixel patterns), not smooth gradients.
+- **16-bit palette:** ~32–48 colors total. Richer than 8-bit (you may dither for depth and shading),
+  but still a tight, deliberate palette — no photographic blends.
+- **Background:** deep/dark, to match the repo's dark-themed README and make accent colors pop.
+  Use the brand charcoal `#0d1117` or a SNES-era deep indigo (e.g. `#16182e`). Panels/cards a step
+  lighter (`#1c2030` / `#21262d`).
+- **Reviewers as little specialist sprites** (8–12 px tall), each tinted by its semantic color.
+- **Legibility first.** This is a functional diagram, not just decoration — stage labels and the
+  output panel must be readable at README scale. Use a crisp pixel/monospace-style font for labels;
+  keep captions short.
+
+## Color semantics — preserve these exactly (they carry meaning)
+
+| Color | Meaning | Suggested hex |
+|---|---|---|
+| 🟢 Green | Verified / Agreed / pass | `#3fb950` |
+| 🔴 Red | Critical / blocking | `#f85149` |
+| 🟡 Yellow | Disputed / caution | `#d29922` |
+| 🔵 Blue | Primary flow / the Judge | `#388bfd` / `#58a6ff` |
+| 🟣 Purple | Blind / anti-bias step | `#bc8cff` |
+
+## Information architecture to preserve
+
+Left-to-right flow with a tall output panel on the right, plus a stage "breadcrumb" along the bottom.
+Keep this structure; restyle it as pixel art:
+
+```
+  ┌────────┐   ┌──────────┐  ┌──────────┐  ┌──────────┐         ┌──────────────┐
+  │  CODE  │→ │  GATHER   │→│  REVIEW   │→│  DEBATE   │ ─┐      │  REVIEW       │
+  │ / PLAN │   │ context & │  │ 4–6       │  │ adversarial│  │      │  REPORT       │
+  │ (input)│   │ setup     │  │ reviewers │  │ + finals  │  │      │  ───────────  │
+  └────────┘   └──────────┘  └──────────┘  └──────────┘  │      │  Exec summary │
+                                                          ▼      │  Consensus    │
+               ┌──────────┐  ┌──────────┐  ┌──────────┐         │  Action items │
+               │  VERIFY   │→│ ADJUDICATE│→ ( output ) ─────────▶│  Scope/limits │
+               │ audit +   │  │ Supreme   │                      │  legend       │
+               │ claim-check│  │ Judge (Opus)│                    └──────────────┘
+               └──────────┘  └──────────┘
+
+  Bottom breadcrumb:  GATHER → REVIEW → DEBATE → VERIFY → ADJUDICATE → REPORT
+```
+
+**Nodes (use these stage names — NOT phase numbers, see "Accuracy" below):**
+
+1. **Input** — "Your Code / Plan".
+2. **Gather** — context & setup: signal detection, persona selection, knowledge mining.
+3. **Review** — independent review: **4–6 reviewers in parallel, no cross-talk** (show 4–6 sprites).
+4. **Debate** — adversarial debate (1–3 rounds) + blind final scoring (anti-groupthink; a
+   blindfold/hidden-eye motif works for the "blind finals" beat).
+5. **Verify** — completeness audit + claim/severity verification (shield-and-check motif; VERIFIED /
+   CRITICAL chips).
+6. **Adjudicate** — **Supreme Judge** (Opus) arbitrates; scales-of-justice motif; emits epistemic
+   labels (DISPUTED / AGREED).
+7. **Output** — the tall **Review Report** panel: Executive Summary, Consensus, Action Items
+   (with VERIFIED/CRITICAL chips), Scope & Limitations, and a small color legend.
+
+Bottom breadcrumb pills, left→right: **Gather → Review → Debate → Verify → Adjudicate → Report**.
+
+## Accuracy — do NOT reintroduce stale facts
+
+The current diagram (and an older pixel attempt) are stale; the whole point of this redesign is to
+get them right:
+
+- ❌ **Do not print a phase count like "10-Phase Pipeline" or per-node phase numbers** ("Gather 1–2",
+  "Adjudicate 10–11"). The pipeline has grown (it's currently ~16 internal phases) and any baked-in
+  number rots. **Label by stage name only.** If you want a subtitle, use
+  *"Multi-Agent Adversarial Code Review Pipeline"* — no number.
+- ✅ **"4–6 reviewers in parallel" is correct** — keep it.
+- ✅ Reviewer archetypes to depict (pick ~6): Correctness, Security, Performance, Data/SQL,
+  Architecture, Risk, ML/Stats. (Exact set is flexible; 4–6 sprites total.)
+
+## Optional — nod to VoltAgent (nice-to-have, don't crowd the diagram)
+
+Reviewers can be backed by installed **VoltAgent specialist agents** (a Security Auditor becomes a
+real `voltagent-qa-sec:security-auditor`). If it fits cleanly, hint that reviewer sprites are
+"specialist-backed" — e.g. a tiny badge/pin on a sprite, or a one-line caption. Skip it if it adds
+clutter; legibility of the core flow wins.
+
+## Reference assets in this repo
+
+- **`docs/hero-flow.svg`** (current, on `main`) — the information architecture to preserve. Its
+  stale phase strings have already been fixed on the working branch; use it for *layout*, not style.
+- **`docs/pixel-flow.svg`** on branch **`feat/pixel-art-banner`** — an earlier pixel attempt with a
+  reusable **reviewer-sprite + orchestrator-sprite vocabulary** you can borrow. Caveats: it's a
+  *light/cream* theme (we want dark here) and its labels are badly stale ("Phase 1–2 / 3–4 / 5–6") —
+  reuse the sprites, not the theme or the labels.
+
+## Deliverable
+
+- **Format:** a **rect-grid pixel-art SVG** (preferred — version-controllable, sharp at any zoom,
+  matches repo convention). A raster PNG at 2× is acceptable as a fallback.
+- **Dimensions:** wide hero, roughly **2:1** (e.g. `960×480` or keep the current `900×520`). Tight
+  viewBox, ~10px padding, no wasted margin.
+- **Filename:** `docs/hero-flow-pixel.svg` (so it can sit beside the current one during review).
+- A small corner watermark "agent-review-panel" is fine (the current diagram has one).
+
+## Acceptance checklist
+
+- [ ] Reads clearly at ~880px wide on a GitHub README (light + dark GitHub themes).
+- [ ] True pixel art: no anti-aliasing, gradients, blur, or glow filters; shading via dithering.
+- [ ] 16-bit palette (~32–48 colors), dark background, semantic colors intact (green/red/yellow/blue/purple as above).
+- [ ] **No phase-count number and no per-node phase numbers** anywhere; stage-name labels only.
+- [ ] Left→right flow + tall output report panel + bottom stage breadcrumb all present.
+- [ ] "4–6 reviewers in parallel" depicted; 4–6 reviewer sprites.
+- [ ] Tight viewBox, ~2:1, no wasted space.

--- a/docs/hero-flow.svg
+++ b/docs/hero-flow.svg
@@ -47,7 +47,7 @@
 
   <!-- ═══ TITLE ROW ═══ -->
   <text x="450" y="30" text-anchor="middle" fill="#e6edf3" font-size="15" font-weight="700" letter-spacing="0.5">Agent Review Panel</text>
-  <text x="450" y="47" text-anchor="middle" fill="#8b949e" font-size="10.5" letter-spacing="0.3">Multi-Agent Adversarial Code Review — 10-Phase Pipeline</text>
+  <text x="450" y="47" text-anchor="middle" fill="#8b949e" font-size="10.5" letter-spacing="0.3">Multi-Agent Adversarial Code Review Pipeline</text>
 
   <!-- ══════════════════════════════════════════════════════════════
        LEFT: INPUT BLOCK
@@ -333,23 +333,23 @@
   <!-- Flow step pills at bottom -->
   <!-- Stage: Gather -->
   <rect x="30" y="472" width="88" height="18" rx="9" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="74" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="600">Gather (1–2)</text>
+  <text x="74" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="600">Gather</text>
   <line x1="118" y1="481" x2="128" y2="481" stroke="#8b949e" stroke-width="1" marker-end="url(#arrowGray)"/>
   <!-- Stage: Review -->
   <rect x="132" y="472" width="98" height="18" rx="9" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="181" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="600">Review (3–4)</text>
+  <text x="181" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="600">Review</text>
   <line x1="230" y1="481" x2="240" y2="481" stroke="#8b949e" stroke-width="1" marker-end="url(#arrowGray)"/>
   <!-- Stage: Debate -->
   <rect x="244" y="472" width="120" height="18" rx="9" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="304" y="484" text-anchor="middle" fill="#d29922" font-size="7.5" font-weight="600">Debate (5–7)</text>
+  <text x="304" y="484" text-anchor="middle" fill="#d29922" font-size="7.5" font-weight="600">Debate</text>
   <line x1="364" y1="481" x2="374" y2="481" stroke="#8b949e" stroke-width="1" marker-end="url(#arrowGray)"/>
   <!-- Stage: Verify -->
   <rect x="378" y="472" width="120" height="18" rx="9" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="438" y="484" text-anchor="middle" fill="#3fb950" font-size="7.5" font-weight="600">Verify (8–9)</text>
+  <text x="438" y="484" text-anchor="middle" fill="#3fb950" font-size="7.5" font-weight="600">Verify</text>
   <line x1="498" y1="481" x2="508" y2="481" stroke="#8b949e" stroke-width="1" marker-end="url(#arrowGray)"/>
   <!-- Stage: Adjudicate -->
   <rect x="512" y="472" width="130" height="18" rx="9" fill="#161b22" stroke="#388bfd" stroke-width="1.2"/>
-  <text x="577" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="700">Adjudicate (10–11)</text>
+  <text x="577" y="484" text-anchor="middle" fill="#58a6ff" font-size="7.5" font-weight="700">Adjudicate</text>
   <line x1="642" y1="481" x2="652" y2="481" stroke="#388bfd" stroke-width="1.2" marker-end="url(#arrowBlue)"/>
   <!-- Output pill -->
   <rect x="656" y="472" width="84" height="18" rx="9" fill="#1a2b1a" stroke="#3fb950" stroke-width="1.2"/>


### PR DESCRIPTION
## What & why

A README + hero-diagram review surfaced stale facts (concentrated in the hero image) and confirmed VoltAgent is buried. This PR fixes the staleness, surfaces VoltAgent with an install nudge, and adds a handoff brief for a pixel-art hero redesign.

### Staleness review findings
**Hero diagram (`docs/hero-flow.svg`) — the main offender (it's the first image in the README):**
- 🔴 Subtitle said **"10-Phase Pipeline"** — the skill now runs **16 top-level phases** + gates 13.5/14.5 + optional Phase 16.
- 🟠 Bottom breadcrumb numbered stages **"Verify (8–9)" / "Adjudicate (10–11)"** — wrong by several phases (Adjudicate is really 14–14.5), and the Merge stage was missing.

**Version-history table** topped out at **v3.3** though `package.json` is **v3.4.0** — and the missing v3.4 row *is* the VoltAgent catalog work.

**Verified current (not touched):** "4–6 reviewers" ✅, persona avatars ✅, "130+/10 families" ✅ (snapshot = 135/10), 406 tests ✅, cost table ✅.

### Changes
- **`docs/hero-flow.svg`** — interim de-rot: dropped the brittle phase numbers (subtitle → "…Code Review Pipeline"; breadcrumb pills → stage names only). Stable; will be superseded by the pixel-art redesign.
- **README — VoltAgent surfacing:** new **"Sharper reviews with VoltAgent specialists"** section (benefit-forward: specialist-backed personas, auto-upgrade, 130+/10 families, graceful fallback); an opt-in **install nudge in Quick Start**; strengthened the two buried mentions to cross-link it.
- **README — added the missing v3.4 version-history row.**
- **README — de-staled the "you're reading the … rewrite" line** (dropped the version number so it doesn't read as out-of-date on v3.4).
- **`docs/hero-flow-pixel-art-redesign-prompt.md`** (new) — self-contained brief to redesign the hero in **16-bit / SNES pixel art** with the corrected facts baked in (stage-name labels, no brittle phase count), semantic colors preserved.

### Pre-merge review (1 focused Opus review agent — not the full panel; ~35-line docs diff)
- **Verdict after fix: clean.** Initial pass was REQUEST-CHANGES on one **P1**: the VoltAgent section claimed *"the panel still runs there [Codex], just with generic personas"* — false per the README's own Surfaces section (the panel requires Claude Code's `Agent` tool; runs only on Claude Code surfaces + Agent SDK). **Fixed** in `44fe399`: Codex is now correctly stated as *not* a supported surface, linking to Surfaces & Requirements; the looser Quick Start "unverified" clause was aligned so the two Codex mentions don't contradict.
- **Independently verified clean:** all VoltAgent counts/family names (vs catalog JSON + SKILL.md + CHANGELOG), the install commands (no silent-fail marketplace-name footgun — `@voltagent-subagents` correctly uses the marketplace name), every added anchor link, SVG well-formed XML + label fit, the v3.4 row, and the pixel-art brief's facts/colors.
- Two cosmetic **P3s left as noted** (not blocking): breadcrumb pill widths now slightly oversized for the shorter labels (renders fine, text centered; full chain reflow not worth it on a soon-to-be-replaced asset); and non-rendered HTML comments in the SVG still mention old phase numbers.

### Verification
- `npm test` → **406/406**; `bash scripts/release-check.sh` → **12/12 green** (baseline + after every commit).
- VoltAgent install commands confirmed against the live marketplace registry: `voltagent-subagents` ← `VoltAgent/awesome-claude-code-subagents`.

### Notes / out of scope
- The Sample-output report block (lines ~92–122) is a **verbatim historical quote** of the 2026-05-14 panel run — left untouched (changing it would falsify the record). The demo GIF (line 86) is intentionally pinned to the `v3.3.0` tag it was captured at (HTTP 200, tag exists).
- An earlier pixel hero exists on `feat/pixel-art-banner` (`docs/pixel-flow.svg`) but is **also stale** (labels read "Phase 1–6") and light-themed; the redesign brief references its sprite vocabulary but starts fresh for the dark 16-bit direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)