### PR TITLE
fix: anchor release-check version compares + wire release-check into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Release-check (doc-drift gate)
+        run: bash scripts/release-check.sh

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -122,6 +122,16 @@ fi
 
 # --- 5. Version consistency across files -------------------------------------
 
+# Anchored version match (panel finding 2026-07-16): the previous bare
+# `grep -q "$CANON_VERSION"` treated dots as regex wildcards and matched
+# substrings, so 13.8.0, 3.8.0-rc1, and 3x8x0 all false-PASSED against 3.8.0.
+# Dots are escaped and the version must not extend into a longer version-ish
+# token on either side.
+version_match() {
+  local esc="${CANON_VERSION//./\\.}"
+  grep -qE "(^|[^0-9.])${esc}([^0-9A-Za-z.-]|\$)"
+}
+
 check_version_in() {
   local file="$1"
   local pattern="$2"
@@ -131,7 +141,7 @@ check_version_in() {
   if [ -z "$found" ]; then
     return
   fi
-  if echo "$found" | grep -q "$CANON_VERSION"; then
+  if echo "$found" | version_match; then
     pass "$label matches canonical version $CANON_VERSION"
   else
     fail "$label does NOT match canonical version $CANON_VERSION:"
@@ -146,7 +156,7 @@ check_version_in "skills/agent-review-panel/SKILL.md" '^# Agent Review Panel v' 
 # SKILL.md HTML footer instruction (v2.16.4+ requires full semver match)
 FOOTER_LINE=$(grep 'HTML footer should read "Agent Review Panel v' skills/agent-review-panel/SKILL.md || true)
 if [ -n "$FOOTER_LINE" ]; then
-  if echo "$FOOTER_LINE" | grep -q "$CANON_VERSION"; then
+  if echo "$FOOTER_LINE" | version_match; then
     pass "SKILL.md HTML footer instruction matches canonical version"
   else
     fail "SKILL.md HTML footer instruction does NOT match canonical version $CANON_VERSION:"


### PR DESCRIPTION
## Summary

Fixes the two gating findings from the v3.8.0 verification panel run (the panel reviewed `scripts/release-check.sh` itself — report verdict: APPROVE CONDITIONAL on exactly these two):

1. **Unanchored version compares (P1)** — `grep -q "$CANON_VERSION"` treats dots as regex wildcards and matches substrings: `13.8.0`, `3.8.0-rc1`, and `3x8x0` all false-PASSED against canon `3.8.0` (reproduced by the panel 4 ways + a negative control). New `version_match()` helper escapes dots and anchors both sides so the version can't extend into a longer version-ish token. Verified: all four false-PASS reproductions now fail; package.json / eval-suite / SKILL.md H1 / footer / marketplace surfaces all still pass.
2. **CI wiring gap (P2, mandatory)** — release-check ran only as a manual ritual, the exact failure mode its own header documents (v2.16.2–v2.16.5 shipped four releases with doc drift). It now runs as a step in `test.yml` on every push/PR to main — this very PR is the first live exercise of that step.

No version bump — infra/script fix, no skill change.

## Test plan

- [x] Anchored matcher unit-tested against all panel reproductions (3 legit forms MATCH, 4 false-PASS forms no-match)
- [x] `bash scripts/release-check.sh` fully green locally
- [x] 494/494 `npm test`
- [x] CI on this PR runs the new release-check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)